### PR TITLE
scons py2/py3 compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -35,6 +35,7 @@ import sys
 if sys.version_info[0] == 2:
     print('Building with scons from python2')
 else:
+    raw_input = input
     print('Building with scons from python3')
 
 if 'SCONS_CONFIG_DIR' in os.environ:


### PR DESCRIPTION
Mapping raw_input to input in python3 for the case when scons is built with python3