### PR TITLE
examples/input_files: remove .slc / .raw suffix for OUTPUT value

### DIFF
--- a/examples/input_files/master_ALOS.xml
+++ b/examples/input_files/master_ALOS.xml
@@ -1,12 +1,12 @@
 <component>
     <property name="IMAGEFILE">
-        <value>data/IMG-HH-ALPSRP207310710-H1.0__A</value>
+        <value>data/20091215/IMG-HH-ALPSRP207310710-H1.0__A</value>
     </property>
     <property name="LEADERFILE">
-        <value>data/LED-ALPSRP207310710-H1.0__A</value>
+        <value>data/20091215/LED-ALPSRP207310710-H1.0__A</value>
     </property>
     <property name="OUTPUT">
-        <value>091215.raw</value>
+        <value>20091215</value>
     </property>
 </component>
 

--- a/examples/input_files/master_ALOS2.xml
+++ b/examples/input_files/master_ALOS2.xml
@@ -1,12 +1,12 @@
 <component name="master">
     <property name="IMAGEFILE">
-        <value>data/IMG-HH-ALOS2015010600-140902-UBSR1.1__A</value>
+        <value>data/20140902/IMG-HH-ALOS2015010600-140902-UBSR1.1__A</value>
     </property>
     <property name="LEADERFILE">
-        <value>data/LED-ALOS2015010600-140902-UBSR1.1__A</value>
+        <value>data/20140902/LED-ALOS2015010600-140902-UBSR1.1__A</value>
     </property>
     <property name="OUTPUT">
-        <value>20140902.slc</value>
+        <value>20140902</value>
     </property>
 </component>
 

--- a/examples/input_files/master_COSMO_SKYMED.xml
+++ b/examples/input_files/master_COSMO_SKYMED.xml
@@ -1,9 +1,9 @@
 <component>
     <property name="HDF5">
-        <value>CSKS4_RAW_B_HI_08_HH_RA_FF_20110311162513_20110311162521.h5</value>
+        <value>data/CSKS4_RAW_B_HI_08_HH_RA_FF_20110311162513_20110311162521.h5</value>
     </property>
     <property name="OUTPUT">
-        <value>20110311.raw</value>
+        <value>20110311</value>
     </property>
 </component>
 

--- a/examples/input_files/master_COSMO_SKYMED_SLC.xml
+++ b/examples/input_files/master_COSMO_SKYMED_SLC.xml
@@ -1,9 +1,9 @@
 <component>
     <property name="HDF5">
-        <value>CSKS4_SCSB_B_HI_08_HH_RA_FF_20110311162513_20110311162521.h5</value>
+        <value>data/CSKS4_SCSB_B_HI_08_HH_RA_FF_20110311162513_20110311162521.h5</value>
     </property>
     <property name="OUTPUT">
-        <value>20110311.slc</value>
+        <value>20110311</value>
     </property>
 </component>
 

--- a/examples/input_files/master_SENTINEL1.xml
+++ b/examples/input_files/master_SENTINEL1.xml
@@ -2,12 +2,12 @@
 <component>
   <property name="safe">
     <value>data/S1A_S1_SLC__1SSV_20170122T234204_20170122T234233_014951_01867B_A254.zip</value>
-</property>
+  </property>
   <property name="orbit directory">
       <value>/home/s1/orbits/poeorb</value>
   </property>
   <property name="OUTPUT">
-    <value>20170122.slc</value>
+    <value>20170122</value>
   </property>
 </component>
 <!-- This is for Strip Map Sentinel SLC data only -->

--- a/examples/input_files/master_TERRASARX.xml
+++ b/examples/input_files/master_TERRASARX.xml
@@ -2,8 +2,8 @@
 <component>
   <property name="XML">
         path/TSX1_SAR__SSC______SM_S_SRA_20091205T042212_20091205T042220.xml
-    </property>
-  <property name="OUTPUT">20091205.raw</property>
+  </property>
+  <property name="OUTPUT">20091205</property>
 </component>
 <!--
 Shown above is the bare minimum input XML file for TERRASARX sensor.


### PR DESCRIPTION
Update the OUTPUT value in example input files: use "20091205" instead of "20091205.raw" or "20091205.slc", to be consistent with the Notebook/stripmapApp example. Otherwise, stripmapApp.py throw an error during the process.

I updated the xml files for the sensors mentioned in StripmapApp notebook only, as I am not sure about the format for the rest sensors.