### PR TITLE
Add covariance file output for denseoffsets

### DIFF
--- a/components/isceobj/StripmapProc/runDenseOffsets.py
+++ b/components/isceobj/StripmapProc/runDenseOffsets.py
@@ -65,7 +65,7 @@ def estimateOffsetField(master, slave, denseOffsetFileName,
     
     objOffset.offsetImageName = denseOffsetFileName + '.bil'
     objOffset.snrImageName = denseOffsetFileName +'_snr.bil'
-
+    objOffset.covImageName = denseOffsetFileName +'_cov.bil'
 
     objOffset.denseampcor(sar, sim)
 

--- a/components/isceobj/TopsProc/TopsProc.py
+++ b/components/isceobj/TopsProc/TopsProc.py
@@ -320,6 +320,14 @@ OFFSET_SNR_FILE = Component.Parameter(
         mandatory=False,
         doc='Filename for gross dense offsets SNR. Used in runDenseOffsets.')
 
+OFFSET_COV_FILE = Component.Parameter(
+        'covfile',
+        public_name='Offset covariance filename',
+        default='dense_offsets_cov.bil',
+        type=str,
+        mandatory=False,
+        doc='Filename for gross dense offsets covariance. Used in runDenseOffsets.')
+
 FILT_OFFSET_OUTPUT_FILE = Component.Parameter(
     'filt_offsetfile',
     public_name='Filtered offset filename',
@@ -333,6 +341,7 @@ OFFSET_GEOCODE_LIST = Component.Parameter('off_geocode_list',
         public_name='offset geocode list',
         default = [OFFSET_OUTPUT_FILE,
                    OFFSET_SNR_FILE,
+                   OFFSET_COV_FILE,
                    FILT_OFFSET_OUTPUT_FILE],
         container = list,
         type=str,
@@ -385,6 +394,7 @@ class TopsProc(Component):
                       OFFSET_WIDTH,
                       OFFSET_OUTPUT_FILE,
                       OFFSET_SNR_FILE,
+                      OFFSET_COV_FILE,
                       FILT_OFFSET_OUTPUT_FILE,
                       OFFSET_GEOCODE_LIST)
 

--- a/components/isceobj/TopsProc/runDenseOffsets.py
+++ b/components/isceobj/TopsProc/runDenseOffsets.py
@@ -118,9 +118,11 @@ def runDenseOffsetsCPU(self):
 
     objOffset.offsetImageName = os.path.join(self._insar.mergedDirname, self._insar.offsetfile)
     objOffset.snrImageName = os.path.join(self._insar.mergedDirname, self._insar.snrfile)
+    objOffset.covImageName = os.path.join(self._insar.mergedDirname, self._insar.covfile)
 
     print('Output dense offsets file name: %s' % (objOffset.offsetImageName))
     print('Output SNR file name: %s' % (objOffset.snrImageName))
+    print('Output covariance file name: %s' % (objOffset.covImageName))
     print('\n======================================')
     print('Running dense ampcor...')
     print('======================================\n')

--- a/components/mroipac/ampcor/DenseAmpcor.py
+++ b/components/mroipac/ampcor/DenseAmpcor.py
@@ -436,9 +436,6 @@ class DenseAmpcor(Component):
         self.locationDownOffset *= self.scaling_factor
         self.locationAcrossOffset *= self.scaling_factor
         self.snr *= self.scaling_factor
-        self.cov1 *= self.scaling_factor
-        self.cov2 *= self.scaling_factor
-        self.cov3 *= self.scaling_factor
 
         self.write_slantrange_images()
 

--- a/components/mroipac/ampcor/DenseAmpcor.py
+++ b/components/mroipac/ampcor/DenseAmpcor.py
@@ -435,7 +435,6 @@ class DenseAmpcor(Component):
         #### Scale images (default is 1.0 to keep as pixel)
         self.locationDownOffset *= self.scaling_factor
         self.locationAcrossOffset *= self.scaling_factor
-        self.snr *= self.scaling_factor
 
         self.write_slantrange_images()
 


### PR DESCRIPTION
This PR add the covariance output file for denseoffsets (Stripmap and TOPS processing). This simply writes to a file the already calculated covariance values by Ampcor. The generated covariance file includes 3 bands (x, y and xy covariance).