### PR TITLE
gdal2isce_xml: bug fixed for print() when sch is NoneType

### DIFF
--- a/applications/gdal2isce_xml.py
+++ b/applications/gdal2isce_xml.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     elif sch == 'BAND':
         img.scheme = 'BSQ'
     else:
-        print('Unrecognized interleaving scheme, ' + sch)
+        print('Unrecognized interleaving scheme, {}'.format(sch))
         print('Assuming default, BIP')
         img.scheme = 'BIP'
 


### PR DESCRIPTION
This PR fixes a bug in the print() in applications/gdal2isce_xml.py when the input vrt file does not have "INTERLEAVE" and sch is assigned with None.