### PR TITLE
stack/saveKml: bug fixed for deprecated aspect normal in matplotlib

### DIFF
--- a/contrib/stack/stripmapStack/saveKml.py
+++ b/contrib/stack/stripmapStack/saveKml.py
@@ -151,8 +151,8 @@ def display(file,inps):
        cmap = reverse_colourmap(cmap) 
     cmap.set_bad(alpha=0.0)
  #   cmap.set_under('k', alpha=0)
-    try:     ax.imshow(data, aspect = 'normal', vmax = inps.max, vmin = inps.min, cmap = cmap)
-    except:  ax.imshow(data, aspect = 'normal', cmap = cmap)
+    try:     ax.imshow(data, aspect = 'auto', vmax = inps.max, vmin = inps.min, cmap = cmap)
+    except:  ax.imshow(data, aspect = 'auto', cmap = cmap)
 
     ax.set_xlim([0,width])
     ax.set_ylim([length,0])

--- a/contrib/stack/topsStack/saveKml.py
+++ b/contrib/stack/topsStack/saveKml.py
@@ -151,8 +151,8 @@ def display(file,inps):
        cmap = reverse_colourmap(cmap) 
     cmap.set_bad(alpha=0.0)
  #   cmap.set_under('k', alpha=0)
-    try:     ax.imshow(data, aspect = 'normal', vmax = inps.max, vmin = inps.min, cmap = cmap)
-    except:  ax.imshow(data, aspect = 'normal', cmap = cmap)
+    try:     ax.imshow(data, aspect = 'auto', vmax = inps.max, vmin = inps.min, cmap = cmap)
+    except:  ax.imshow(data, aspect = 'auto', cmap = cmap)
 
     ax.set_xlim([0,width])
     ax.set_ylim([length,0])


### PR DESCRIPTION
This PR replace the deprecated aspect "normal" value since matplotlib 2.1 with the new "auto" value,

Here is the reference:
https://matplotlib.org/2.2.3/api/api_changes.html#axes-set-aspect-normal