### PR TITLE
stripmapStack: expose --filter_strength and --dual2single options

### DIFF
--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -5,7 +5,7 @@
 import os, imp, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import numpy as np
 import shelve
 import isce
@@ -575,7 +575,7 @@ class run(object):
              configObj.igram = configObj.outDir+'.int'
              configObj.filtIgram = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.int'
              configObj.coherence = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.cor'
-             configObj.filtStrength = filtStrength
+             #configObj.filtStrength = filtStrength
              configObj.filterCoherence('[Function-2]')
 
              configObj.igram = configObj.filtIgram

--- a/contrib/stack/stripmapStack/prepRawALOS.py
+++ b/contrib/stack/stripmapStack/prepRawALOS.py
@@ -192,7 +192,7 @@ def main(iargs=None):
         
 
     # now generate the unpacking script for all the date dirs
-    dateDirs = glob.glob(os.path.join(inps.inputDir,'2*'))
+    dateDirs = sorted(glob.glob(os.path.join(inps.inputDir,'2*')))
     if inps.outputDir is not None:
         f = open(run_unPack,'w')
         for dataDir in dateDirs:

--- a/contrib/stack/stripmapStack/prepRawALOS.py
+++ b/contrib/stack/stripmapStack/prepRawALOS.py
@@ -27,6 +27,8 @@ def createParser():
             help='output directory where data needs to be unpacked into isce format (for script generation).')
     parser.add_argument('-t', '--text_cmd', dest='text_cmd', type=str, default='source ~/.bash_profile;',
             help='text command to be added to the beginning of each line of the run files. Default: source ~/.bash_profile;')
+    parser.add_argument('--dual2single','--fbd2fbs', dest='fbd2fbs', action='store_true',
+            help='resample the FBD acquisitions to FBS. Recommended for "interferogram" workflow without ionosphere.')
     return parser
 
 
@@ -202,8 +204,14 @@ def main(iargs=None):
                     os.makedirs(slcDir)     
                 cmd = 'unpackFrame_ALOS_raw.py -i ' + os.path.abspath(dataDir) + ' -o ' + slcDir      
                 IMG_files = glob.glob(os.path.join(AlosFiles[0],'IMG*'))
-                if len(IMG_files)==1:
-                    cmd = cmd + ' -f  fbs2fbd ' 
+                if inps.fbd2fbs:
+                    #recommended for regular interferometry to use all FBS bandwidth
+                    if len(IMG_files) == 2:
+                        cmd += ' -f fbd2fbs '
+                else:
+                    #used for ionosphere workflow for simplicity
+                    if len(IMG_files) == 1:
+                        cmd = cmd + ' -f  fbs2fbd ' 
                 if len(AlosFiles) > 1:
                     cmd = cmd + ' -m' 
                 print (cmd)

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -56,6 +56,11 @@ def createParser():
             help='sub-band band width')
     parser.add_argument('-u', '--unw_method', dest='unwMethod', type=str, default='snaphu'
        , help='unwrapping method (icu, snaphu, or snaphu2stage)')
+
+    parser.add_argument('-f','--filter_strength', dest='filtStrength', type=str, default=filtStrength,
+            help='strength of Goldstein filter applied to the wrapped phase before spatial coherence estimation.'
+                 ' Default: {}'.format(filtStrength))
+
     parser.add_argument('--filter_sigma_x', dest='filterSigmaX', type=str, default='100'
        , help='filter sigma for gaussian filtering the dispersive and nonDispersive phase')
 

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -238,6 +238,16 @@ def interferogramStack(inps, acquisitionDates, stackMasterDate, slaveDates, pair
 
 def interferogramIonoStack(inps, acquisitionDates, stackMasterDate, slaveDates, pairs):
 
+    # raise exception for ALOS-1 if --fbd2fbs was used
+    run_unpack_file = os.path.join(inps.workDir, 'run_unPackALOS')
+    if os.path.isfile(run_unpack_file):
+        with open(run_unpack_file, 'r') as f:
+            lines = f.readlines()
+        if any('fbd2fbs' in line for line in lines):
+            msg = 'ALOS-1 FBD mode data exists with fbd2fbs enabled, which is not applicable for ionosphere workflow'
+            msg += '\nsolution: restart from prepRawALOS.py WITHOUT --dual2single/--fbd2fbs option.'
+            raise ValueError(msg)
+
     # an interferogram stack with ionosphere correction.
     # coregistration is with geometry + const offset + rubbersheeting
 


### PR DESCRIPTION
This PR exposes two options in stripmapStack: 

1. --dual2single/--fbd2fbs option for ALOS-1 data in prepRawALOS.py to better support the regular interferometry without ionospheric correction.
2. -f / --filter_strength option for stackStripMap.py.

Both options are initiated with default value the same as previously hardwired, so all previous setting should not be affected.