### PR TITLE
link to system version of libuuid and libgfortran

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,15 @@ jobs:
             mkdir config build install
             . /opt/conda/bin/activate root
             conda install --yes cython gdal h5py libgdal pytest numpy fftw scipy basemap scons opencv hdf4 hdf5 netcdf4 libgcc libstdcxx-ng cmake
-            yum install -y uuid-devel x11-devel motif-devel jq
+            yum install -y uuid-devel x11-devel motif-devel jq gcc-gfortran
             ln -s /opt/conda/bin/cython /opt/conda/bin/cython3
             cd /opt/conda/lib
             unlink libuuid.so
             unlink libuuid.so.1
             ln -s /lib64/libuuid.so.1.3.0 libuuid.so
             ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1
-            yum install -y gcc-gfortran
+            cd /lib64
+            test -f libgfortran.so || ln -sv libgfortran.so.*.* libgfortran.so
 
       - run:
           name: Build SConfigISCE and setup dirs
@@ -52,7 +53,6 @@ jobs:
               echo "MOTIFINCPATH = /usr/include" >> SConfigISCE
               echo "X11INCPATH = /usr/include" >> SConfigISCE
               echo "RPATH = /opt/conda/lib /usr/lib64 /usr/lib" >> SConfigISCE
-              echo "LINKFLAGS = -L/lib64 -lgfortran" >> SConfigISCE
               cat SConfigISCE
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,6 @@ jobs:
             ln -s /lib64/libuuid.so.1.3.0 libuuid.so
             ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1
             yum install -y gcc-gfortran
-            cd /opt/conda/lib
-            unlink libgfortran.so
-            unlink libgfortran.so.4
-            ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so
-            ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4
 
       - run:
           name: Build SConfigISCE and setup dirs
@@ -57,6 +52,7 @@ jobs:
               echo "MOTIFINCPATH = /usr/include" >> SConfigISCE
               echo "X11INCPATH = /usr/include" >> SConfigISCE
               echo "RPATH = /opt/conda/lib /usr/lib64 /usr/lib" >> SConfigISCE
+              echo "LINKFLAGS = -L/lib64 -lgfortran" >> SConfigISCE
               cat SConfigISCE
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           command: |
             set -ex
             pwd
+            mkdir config build install
             . /opt/conda/bin/activate root
             conda install --yes cython gdal h5py libgdal pytest numpy fftw scipy basemap scons opencv hdf4 hdf5 netcdf4 libgcc libstdcxx-ng cmake
             yum install -y uuid-devel x11-devel motif-devel jq
@@ -36,7 +37,6 @@ jobs:
             unlink libgfortran.so.4
             ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so
             ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4
-            mkdir config build install
 
       - run:
           name: Build SConfigISCE and setup dirs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,17 @@ jobs:
             conda install --yes cython gdal h5py libgdal pytest numpy fftw scipy basemap scons opencv hdf4 hdf5 netcdf4 libgcc libstdcxx-ng cmake
             yum install -y uuid-devel x11-devel motif-devel jq
             ln -s /opt/conda/bin/cython /opt/conda/bin/cython3
+            cd /opt/conda/lib
+            unlink libuuid.so
+            unlink libuuid.so.1
+            ln -s /lib64/libuuid.so.1.3.0 libuuid.so
+            ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1
+            yum install -y gcc-gfortran
+            cd /opt/conda/lib
+            unlink libgfortran.so
+            unlink libgfortran.so.4
+            ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so
+            ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4
             mkdir config build install
 
       - run:
@@ -46,7 +57,6 @@ jobs:
               echo "MOTIFINCPATH = /usr/include" >> SConfigISCE
               echo "X11INCPATH = /usr/include" >> SConfigISCE
               echo "RPATH = /opt/conda/lib /usr/lib64 /usr/lib" >> SConfigISCE
-              echo "LINKFLAGS = -luuid" >> SConfigISCE
               cat SConfigISCE
 
       - run:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,23 @@ RUN set -ex \
  && yum install -y uuid-devel x11-devel motif-devel jq \
  && ln -sf /opt/conda/bin/cython /opt/conda/bin/cython3
 
+# link system libuuid
+RUN set -ex \
+ && cd /opt/conda/lib \
+ && unlink libuuid.so \
+ && unlink libuuid.so.1 \
+ && ln -s /lib64/libuuid.so.1.3.0 libuuid.so \
+ && ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1
+
+# install libgfortran.so.3
+RUN set -ex \
+ && yum install -y gcc-gfortran \
+ && cd /opt/conda/lib \
+ && unlink libgfortran.so \
+ && unlink libgfortran.so.4 \
+ && ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so \
+ && ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4
+
 # copy repo
 COPY . /root/isce2
 
@@ -91,6 +108,16 @@ RUN set -ex \
       netcdf4 \
  && sudo yum update -y \
  && sudo yum install -y uuid-devel x11-devel motif-devel \
+ && cd /opt/conda/lib \
+ && sudo unlink libuuid.so \
+ && sudo unlink libuuid.so.1 \
+ && sudo ln -s /lib64/libuuid.so.1.3.0 libuuid.so \
+ && sudo ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1 \
+ && sudo yum install -y gcc-gfortran \
+ && sudo unlink libgfortran.so \
+ && sudo unlink libgfortran.so.4 \
+ && sudo ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so \
+ && sudo ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4 \
  && sudo yum install -y /tmp/isce-2.0-1.x86_64.rpm \
  && sudo yum clean all \
  && sudo rm -rf /var/cache/yum \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,14 +50,11 @@ RUN set -ex \
  && ln -s /lib64/libuuid.so.1.3.0 libuuid.so \
  && ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1
 
-# install libgfortran.so.3
+# install libgfortran.so.3 and create missing link
 RUN set -ex \
  && yum install -y gcc-gfortran \
- && cd /opt/conda/lib \
- && unlink libgfortran.so \
- && unlink libgfortran.so.4 \
- && ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so \
- && ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4
+ && cd /lib64 \
+ && ( test -f libgfortran.so || ln -sv libgfortran.so.*.* libgfortran.so )
 
 # copy repo
 COPY . /root/isce2
@@ -107,17 +104,14 @@ RUN set -ex \
       hdf5 \
       netcdf4 \
  && sudo yum update -y \
- && sudo yum install -y uuid-devel x11-devel motif-devel \
+ && sudo yum install -y uuid-devel x11-devel motif-devel gcc-gfortran \
  && cd /opt/conda/lib \
  && sudo unlink libuuid.so \
  && sudo unlink libuuid.so.1 \
  && sudo ln -s /lib64/libuuid.so.1.3.0 libuuid.so \
  && sudo ln -s /lib64/libuuid.so.1.3.0 libuuid.so.1 \
- && sudo yum install -y gcc-gfortran \
- && sudo unlink libgfortran.so \
- && sudo unlink libgfortran.so.4 \
- && sudo ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so \
- && sudo ln -s /lib64/libgfortran.so.3.0.0 libgfortran.so.4 \
+ && cd /lib64 \
+ && ( test -f libgfortran.so || sudo ln -sv libgfortran.so.*.* libgfortran.so ) \
  && sudo yum install -y /tmp/isce-2.0-1.x86_64.rpm \
  && sudo yum clean all \
  && sudo rm -rf /var/cache/yum \

--- a/docker/SConfigISCE
+++ b/docker/SConfigISCE
@@ -36,9 +36,6 @@ X11INCPATH = /usr/include       # path to location of the X11 directory
 # list of paths to search for shared libraries when running programs
 RPATH = /opt/conda/lib /usr/lib64 /usr/lib
 
-# additional linker flags
-LINKFLAGS = -luuid
-
 #Explicitly enable cuda if needed
 ENABLE_CUDA = True
 #CUDA_TOOLKIT_PATH = $YOUR_CUDA_INSTALLATION  #/usr/local/cuda


### PR DESCRIPTION
Fixes #31. Also creates link to libgfortran.so.3 (system installed) instead of libgfortran.so.4 (conda installed). 
Was able to follow instructions here (https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/) to display `mdx` X11 window from docker container to display an ARIA product:

<img width="1403" alt="Screen Shot 2019-04-17 at 11 14 01 AM" src="https://user-images.githubusercontent.com/387300/56312712-a6a3e380-6105-11e9-9c1c-0e26e6bd17b4.png">
