### PR TITLE
use circleci workflows for test, docker build, and deploy to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
-version: 2
+version: 2.1
 jobs:
-  build:
+  test:
     docker:
         - image: hysds/pge-base:latest
           user: root
@@ -79,5 +79,113 @@ jobs:
               topsApp.py --help --steps
               stripmapApp.py --help --steps
               python3 -c "import isce"
-              
+  build:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+            pip install \
+              docker-compose awscli
+      - run:
+          name: Build
+          command: |
+            mkdir images
+            echo 'export TAG="$CIRCLE_SHA1"' >> images/env.sh
+            source images/env.sh
+            docker build --rm --force-rm -t isce/isce2:$TAG -f docker/Dockerfile .
+            cd images
+            docker save isce/isce2:$TAG > isce2.tar
+      - persist_to_workspace:
+          root: images
+          paths:
+            - "*"
+  build-periodically:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+            pip install \
+              docker-compose awscli
+      - run:
+          name: Build
+          command: |
+            mkdir images
+            echo 'export TAG=$(date -u +%Y%m%d)' >> images/env.sh
+            source images/env.sh
+            docker build --rm --force-rm -t isce/isce2:$TAG -f docker/Dockerfile .
+            cd images
+            docker save isce/isce2:$TAG > isce2.tar
+      - persist_to_workspace:
+          root: images
+          paths:
+            - "*"
+  deploy:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              curl file
+      - attach_workspace:
+          at: images
+      - run:
+          name: Deploy
+          command: |
+            cd images
+            source env.sh
+            docker load -i isce2.tar
+            docker tag isce/isce2:$TAG isce/isce2:latest
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push isce/isce2:$TAG
+            docker push isce/isce2:latest
 
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+  build-deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 7 * * 0"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-periodically:
+          filters:
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build-periodically
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             pip install \
               docker-compose awscli
       - run:
-          name: Build
+          name: Build docker image
           command: |
             mkdir images
             SHA1=$(echo $CIRCLE_SHA1 | cut -c1-7)
@@ -120,7 +120,7 @@ jobs:
             pip install \
               docker-compose awscli
       - run:
-          name: Build
+          name: Build docker image
           command: |
             mkdir images
             echo 'export TAG=$(date -u +%Y%m%d)' >> images/env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           command: |
             mkdir images
             SHA1=$(echo $CIRCLE_SHA1 | cut -c1-7)
-            echo 'export TAG="$SHA1"' >> images/env.sh
+            echo "export TAG=$SHA1" >> images/env.sh
             source images/env.sh
             docker build --rm --force-rm -t isce/isce2:$TAG -f docker/Dockerfile .
             cd images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,8 @@ jobs:
           name: Build
           command: |
             mkdir images
-            echo 'export TAG="$CIRCLE_SHA1"' >> images/env.sh
+            SHA1=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            echo 'export TAG="$SHA1"' >> images/env.sh
             source images/env.sh
             docker build --rm --force-rm -t isce/isce2:$TAG -f docker/Dockerfile .
             cd images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
     docker:
       - image: docker:stable-git
     steps:
+      - setup_remote_docker
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             - "*"
   deploy:
     docker:
-      - image: alpine:latest
+      - image: docker:stable-git
     steps:
       - run:
           name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ISCE2
 
+[![CircleCI](https://circleci.com/gh/isce-framework/isce2.svg?style=svg)](https://circleci.com/gh/isce-framework/isce2)
+
 This is the Interferometric synthetic aperture radar Scientific Computing
 Environment (ISCE).  Its initial development was funded by NASA's Earth Science
 Technology Office (ESTO) under the Advanced Information Systems Technology


### PR DESCRIPTION
We may need to iterate configuring the proper settings in the circleci dashboard.

- renamed "build" job to "test" and created "test" workflow
  - will run on all pull requests and merges into master
- "build" job now builds isce docker container
- "deploy" job will deploy docker image to dockerhub at isce/isce2 (https://cloud.docker.com/u/isce/repository/list)
  - need to configure DOCKER_PASS and DOCKER_USER in "Build Settings" -> "Envrionment Variables" on circleci
- created "build-deploy" workflow to run "build" job then "deploy" job on merge of PR to master
- created "build-periodically" workflow to run "build-periodically" job then "deploy" job once a week