### PR TITLE
Enable building with clang

### DIFF
--- a/components/iscesys/ImageApi/InterleavedAccessor/src/GDALAccessor.cpp
+++ b/components/iscesys/ImageApi/InterleavedAccessor/src/GDALAccessor.cpp
@@ -98,7 +98,7 @@ GDALAccessor::getStream (char * dataLine, int & numEl)
     int ypos0 = LastPosition / LineWidth;
     int xpos0 = LastPosition % LineWidth;
     LastPosition += numEl;
-    int ypos1 = (LastPosition - 1) / LineWidth;
+    int ypos1 = (LastPosition - std::streampos(1)) / LineWidth;
     if (LastPosition * SizeV >= FileSize)
     {
 	numEl -= LastPosition % LineWidth;

--- a/components/mroipac/looks/bindings/cpxlooksmodule.cpp
+++ b/components/mroipac/looks/bindings/cpxlooksmodule.cpp
@@ -145,7 +145,7 @@ PyObject * cpxlooks_C(PyObject* self, PyObject* args)
             }
             for(int j = 0; j < na; ++j)
             {
-                b[j] = b[j] + a[j]*pow(pha,j+1)*pow(phd,lineToGet);
+                b[j] = b[j] + a[j]*pow(pha,j+1.0f)*pow(phd,lineToGet*1.0f);
             }
         }
         if(eofReached)


### PR DESCRIPTION
This PR allows building with clang on os-x. 

* Most libraries on macports / conda on OSX seem to be shipping with libc++ instead of libstdc++ . Making things work with gcc is getting harder unless you build all libraries yourself. 

* Will allow for development of conda packages for os-x. Dont have access to GPU on a mac to test those sections of the code base. 

* Still needs gfortran (and hence some gcc > 5) for building the fortran parts. 

* Tested and works with topsApp.py/stripmapApp.py/mdx.py

* To get this to work modify your SConfigISCE as follows:

```bash

PRJ_SCONS_BUILD = /Users/jovian/tools/ISCE3_latest/build
PRJ_SCONS_INSTALL = /Users/jovian/tools/ISCE3_latest/install/isce
LIBPATH =  /opt/local/lib /opt/local/lib/gcc7
CPPPATH =  /opt/local/include /opt/local/include/libomp /opt/local/include/python3.7m
FORTRANPATH =  /opt/local/include
FORTRAN = gfortran
CC = clang
CXX = clang++
STDCPPLIB = c++
MOTIFLIBPATH = /opt/local/lib              # path to libXm.dylib
X11LIBPATH = /opt/local/lib                # path to libXt.dylib
MOTIFINCPATH = /opt/local/include          # path to location of the Xm directory with various include files (.h)
X11INCPATH = /opt/local/include            # path to location of the X11 directory with various include files
```