### PR TITLE
OMP threads cap fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -141,12 +141,13 @@ else:
 gdal_version = os.popen('gdal-config --version').read()
 print('GDAL version: {0}'.format(gdal_version))
 try:
+    gdal_majorversion = int(gdal_version.split('.')[0])
     gdal_subversion = int(gdal_version.split('.')[1])
 except:
     raise Exception('gdal-config not found. GDAL does not appear to be installed ... cannot proceed. If you have installed gdal, ensure that you have path to gdal-config in your environment')
 
 env['GDALISCXX11'] = None
-if gdal_subversion >= 3:
+if (gdal_majorversion > 2) or (gdal_subversion >= 3):
     env['GDALISCXX11'] = 'True' 
 
 

--- a/components/stdproc/stdproc/resamp_slc/src/resamp_slc.f90
+++ b/components/stdproc/stdproc/resamp_slc/src/resamp_slc.f90
@@ -21,7 +21,7 @@
       integer i, j, k
       integer int_az_off
       integer i_na
-      integer ith, thnum
+      integer ith, thnum, ithorig
         
       integer ii, jj
       integer chipi, chipj
@@ -82,6 +82,7 @@
       !$OMP END MASTER
       !$OMP END PARALLEL
 
+      ithorig = ith
       ith = min(ith,8)
       print *, 'Number of threads: ', ith
       call omp_set_num_threads(ith)
@@ -283,6 +284,8 @@
           deallocate(rout)
       endif
 
+      !Reset number of threads
+      call omp_set_num_threads(ithorig)
       end
       
 


### PR DESCRIPTION
Fix for OMP threads cap reported on the user forums. 
The reason behind the cap needs to be explored. 
For now, the cap is in place but the number of threads get reset to the original number reported by the system so that other calls in the same process are not affected. 