### PR TITLE
Fix for importlib has no attribute util

### DIFF
--- a/configuration/buildHelper.py
+++ b/configuration/buildHelper.py
@@ -98,9 +98,9 @@ def main(factoryFile,package,buildDir):
 #    import isce
     import filecmp
     try:
-        import importlib
+        from importlib import util
         factoryFile = os.path.abspath(factoryFile)
-        mod = importlib.util.spec_from_file_location('.', factoryFile)
+        mod = util.spec_from_file_location('.', factoryFile)
         factModule = mod.loader.load_module()
         factoriesInfo = factModule.getFactoriesInfo()
         nameList = []

--- a/contrib/stack/stripmapStack/stripmapWrapper.py
+++ b/contrib/stack/stripmapStack/stripmapWrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os, sys
-import importlib
+from importlib import util as importlibutil
 import argparse
 import configparser
 
@@ -95,7 +95,7 @@ class ConfigParser:
 
     # If any of the following calls raises an exception,
     # there's a problem we can't handle -- let the caller handle it.
-    spec = importlib.util.find_spec(name)
+    spec = importlibutil.find_spec(name)
 
     try:
       return spec.loader.load_module()

--- a/contrib/stack/topsStack/SentinelWrapper.py
+++ b/contrib/stack/topsStack/SentinelWrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os, sys
-import importlib
+from importlib import util as importlibutil
 import argparse
 import configparser
 
@@ -158,7 +158,7 @@ class ConfigParser:
 
     # If any of the following calls raises an exception,
     # there's a problem we can't handle -- let the caller handle it.
-    spec = importlib.util.find_spec(name)
+    spec = importlibutil.find_spec(name)
 
     try:
       return spec.loader.load_module()


### PR DESCRIPTION
Some installations of python 3.6/3.7 (cause to be determined) do not export util in importlib/\_\_init\_\_.py . This might cause installation / tests to fail. Encountered this on some flavors of 3.7 on conda. 

Stack processor wrappers need to be tested. Helper has been tested. 