### PR TITLE
build and deploy docker by release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,32 @@ jobs:
           root: images
           paths:
             - "*"
+  build-release:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+            pip install \
+              docker-compose awscli
+      - run:
+          name: Build docker image
+          command: |
+            mkdir images
+            echo "export TAG=$CIRCLE_TAG" >> images/env.sh
+            source images/env.sh
+            docker build --rm --force-rm -t isce/isce2:$TAG -f docker/Dockerfile .
+            cd images
+            docker save isce/isce2:$TAG > isce2.tar
+      - persist_to_workspace:
+          root: images
+          paths:
+            - "*"
   build-periodically:
     docker:
       - image: docker:stable-git
@@ -172,6 +198,22 @@ workflows:
           filters:
             branches:
               only: master
+  build-deploy-release:
+    jobs:
+      - build-release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
   weekly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ workflows:
               ignore: /.*/
       - deploy:
           requires:
-            - build
+            - build-release
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
Deployed docker image should be able to be pulled via e.g. `docker pull isce2:v2.3.2`.
Doing a `docker pull isce2:latest` still pulls the deployed docker image from the
most recent of these three circleci jobs: PR merge, weekly build, or release.