### PR TITLE
Orbit.minTime property is not callable

### DIFF
--- a/components/isceobj/Orbit/Orbit.py
+++ b/components/isceobj/Orbit/Orbit.py
@@ -1061,7 +1061,7 @@ class Orbit(Component):
         ###This wont break the old interface but could cause 
         ###issues at midnight crossing
         if reference is None:
-            reference = self.minTime()
+            reference = self.minTime
 
         refEpoch = reference.replace(hour=0, minute=0, second=0, microsecond=0)
 


### PR DESCRIPTION
While testing [autoRIFT](https://github.com/leiyangleon/autoRIFT), and ISCE contrib module, I ran into a `TypeError: 'datetimeType' object is not callable` exception from ISCE.

`Oribt.minTime` is defined as a property here:

https://github.com/isce-framework/isce2/blob/629f09755ba6e4ab8e1bc82468b231317fa326aa/components/isceobj/Orbit/Orbit.py#L298-L304

and was accessed like a method (called) later (which then meant that the `datetimeType` class instance that was stored in `minTime` was what was called; fortunately, it's also not callable). 

This PR fixes the `minTime` access to return the expected `datetimeType` class instance. 

Here's a minimal reproducer of the issue:

```python
>>> class C():
...     def __init__(self, p):
...         self._p = p
...         
...     @property
...     def p(self):
...         return self._p
...     
...     @p.setter
...     def p(self, p):
...         self._p = p
...     
>>> c = C(0)
>>> c.p
0
>>> c.p()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: 'int' object is not callable
```
When a property is access like a method, it tries to call the stored object.