### PR TITLE
cuda: remove arch specific flag; add /lib64 to LIBPATH for libcuda.so…

### DIFF
--- a/components/zerodop/GPUampcor/cuda/SConscript
+++ b/components/zerodop/GPUampcor/cuda/SConscript
@@ -2,19 +2,19 @@
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Copyright 2010 California Institute of Technology. ALL RIGHTS RESERVED.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # United States Government Sponsorship acknowledged. This software is subject to
 # U.S. export control laws and regulations and has been classified as 'EAR99 NLR'
 # (No [Export] License Required except when exporting to an embargoed country,
@@ -49,7 +49,7 @@ if envGPUampcor['GPU_ACC_ENABLED']:
         build_base += "-ccbin " + envGPUampcor['NVCC_CCBIN'] + " "
     else:
         print('Assuming default system compiler for nvcc.')
-    build_base += "-arch=sm_35 -shared -Xcompiler -fPIC -O3 "
+    build_base += "-shared -Xcompiler -fPIC -O3 "
     build_cmd = build_base + "-dc -m64 -o $TARGET -c $SOURCE"
     built_path = os.path.join(build, 'gpu-ampcor.o')
     linked_path = os.path.join(build, 'gpu-ampcor-linked.o')

--- a/components/zerodop/GPUtopozero/cuda/compilation
+++ b/components/zerodop/GPUtopozero/cuda/compilation
@@ -1,2 +1,2 @@
-nvcc -arch=sm_35 -Xcompiler -fPIC -o gpu-topo.o -c Topo.cu
+nvcc -Xcompiler -fPIC -o gpu-topo.o -c Topo.cu
 cp -f gpu-topo.o ..

--- a/scons_tools/cuda.py
+++ b/scons_tools/cuda.py
@@ -52,7 +52,7 @@ def generate(env):
     # default flags for the NVCC compiler
     env['STATICNVCCFLAGS'] = ''
     env['SHAREDNVCCFLAGS'] = ''
-    env['ENABLESHAREDNVCCFLAG'] = '-arch=sm_35 -shared -Xcompiler -fPIC'
+    env['ENABLESHAREDNVCCFLAG'] = '-shared -Xcompiler -fPIC'
 
     # default NVCC commands
     env['STATICNVCCCMD'] = '$NVCC -o $TARGET -c $NVCCFLAGS $STATICNVCCFLAGS $SOURCES'
@@ -153,7 +153,7 @@ def generate(env):
     #env.Append(LIBPATH=[cudaSDKPath + '/lib', cudaSDKPath + '/common/lib' + cudaSDKSubLibDir, cudaToolkitPath + '/lib'])
 
     env.Append(CUDACPPPATH=[cudaToolkitPath + '/include'])
-    env.Append(CUDALIBPATH=[cudaToolkitPath + '/lib', cudaToolkitPath + '/lib64'])
+    env.Append(CUDALIBPATH=[cudaToolkitPath + '/lib', cudaToolkitPath + '/lib64', '/lib64'])
     env.Append(CUDALIBS=['cudart'])
 
 def exists(env):


### PR DESCRIPTION
… for most Linux systems

Some fixed for using CUDA modules:
1. remove -arch=sm_35 which is specific to K40/K80. If no arch is specified, nvcc produces code compatible with sM-30 devices and above. This allows a compatibility with a wider range of GPUs. If a machine specific code is desired, e.g., P100 with sm_60, I recommend to add NVCCFLAGS to SConfigISCE. 
2. libcuda.so comes with nvidia graphic driver and usually is in a system folder such as /lib64.  I added it to cuda.py extension for scons. Otherwise, we could add it CUDALIBPATH in SConfigISCE as well. 
