### PR TITLE
fix bug while calculating corrLooks for snaphu(_mcf)

### DIFF
--- a/components/isceobj/Unwrap/snaphu.py
+++ b/components/isceobj/Unwrap/snaphu.py
@@ -54,7 +54,7 @@ class snaphu(Component):
         self.azimuthLooks = obj.insar.topo.numberAzimuthLooks
 
         azres = obj.insar.masterFrame.platform.antennaLength/2.0
-        azfact = obj.insar.topo.numberAzimuthLooks *azres / obj.insar.topo.azimuthSpacing
+        azfact = azres / obj.insar.topo.azimuthSpacing
 
         rBW = obj.insar.masterFrame.instrument.pulseLength * obj.insar.masterFrame.instrument.chirpSlope
         rgres = abs(SPEED_OF_LIGHT / (2.0 * rBW))

--- a/components/isceobj/Unwrap/snaphu_mcf.py
+++ b/components/isceobj/Unwrap/snaphu_mcf.py
@@ -54,7 +54,7 @@ class snaphu_mcf(Component):
         self.azimuthLooks = obj.insar.topo.numberAzimuthLooks
 
         azres = obj.insar.masterFrame.platform.antennaLength/2.0
-        azfact = obj.insar.topo.numberAzimuthLooks *azres / obj.insar.topo.azimuthSpacing
+        azfact = azres / obj.insar.topo.azimuthSpacing
 
         rBW = obj.insar.masterFrame.instrument.pulseLength * obj.insar.masterFrame.instrument.chirpSlope
         rgres = abs(SPEED_OF_LIGHT / (2.0 * rBW))


### PR DESCRIPTION
Currently, the number of looks in azimuth direction is used twice instead of once while calculating the `corrLooks` value.

Below is the relevant document of `NCORRLOOKS` in SNPAHU:
https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/snaphu.conf.full