### PR TITLE
stripmapStack/unwrap: uncomment corrLooks for snaphu

### DIFF
--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -197,6 +197,8 @@ class config(object):
         self.f.write('nomcf : ' + self.noMCF + '\n')
         self.f.write('master : ' + self.master + '\n')
         self.f.write('defomax : ' + self.defoMax + '\n')
+        self.f.write('alks : ' + self.alks + '\n')
+        self.f.write('rlks : ' + self.rlks + '\n')
         self.f.write('method : ' + self.unwMethod + '\n')
         self.f.write('##########################'+'\n')
 

--- a/contrib/stack/stripmapStack/unwrap.py
+++ b/contrib/stack/stripmapStack/unwrap.py
@@ -113,9 +113,19 @@ def extractInfoFromPickle(pckfile, inps):
     data['earthRadius'] = elp.local_radius_of_curvature(llh.lat, hdg)
     
     #azspacing  = burst.azimuthTimeInterval * sv.getScalarVelocity()
-    azres = 20.0 
+    #azres = 20.0 
+    azspacing = sv.getScalarVelocity() / burst.PRF
+    azres = burst.platform.antennaLength / 2.0
+    azfact = azres / azspacing
+
+    burst.getInstrument()
+    rgBandwidth = burst.instrument.pulseLength * burst.instrument.chirpSlope
+    rgres = abs(SPEED_OF_LIGHT / (2.0 * rgBandwidth))
+    rgspacing = burst.instrument.rangePixelSize
+    rgfact = rgres / rgspacing
 
     #data['corrlooks'] = inps.rglooks * inps.azlooks * azspacing / azres
+    data['corrlooks'] = inps.rglooks * inps.azlooks / (azfact * rgfact)
     data['rglooks'] = inps.rglooks
     data['azlooks'] = inps.azlooks
 
@@ -149,7 +159,7 @@ def runUnwrap(infile, outfile, corfile, config, costMode = None,initMethod = Non
     altitude   = config['altitude']
     rangeLooks = config['rglooks']
     azimuthLooks = config['azlooks']
-    #corrLooks = config['corrlooks']
+    corrLooks = config['corrlooks']
     maxComponents = 20
 
     snp = Snaphu()
@@ -163,7 +173,7 @@ def runUnwrap(infile, outfile, corfile, config, costMode = None,initMethod = Non
     snp.setAltitude(altitude)
     snp.setCorrfile(corfile)
     snp.setInitMethod(initMethod)
-   # snp.setCorrLooks(corrLooks)
+    snp.setCorrLooks(corrLooks)
     snp.setMaxComponents(maxComponents)
     snp.setDefoMaxCycles(defomax)
     snp.setRangeLooks(rangeLooks)

--- a/contrib/stack/stripmapStack/unwrap.py
+++ b/contrib/stack/stripmapStack/unwrap.py
@@ -258,33 +258,34 @@ def runUnwrapIcu(infile, outfile):
     unwImage.finalizeImage()
     unwImage.renderHdr()
 
-def runUnwrap2Stage(unwrappedIntFilename,connectedComponentsFilename,unwrapped2StageFilename, unwrapper_2stage_name=None, solver_2stage=None):                                                                                            
+def runUnwrap2Stage(unwrappedIntFilename,connectedComponentsFilename,unwrapped2StageFilename,
+                    unwrapper_2stage_name=None, solver_2stage=None):
   
-      if unwrapper_2stage_name is None:
-          unwrapper_2stage_name = 'REDARC0'
-  
-      if solver_2stage is None:
-          # If unwrapper_2state_name is MCF then solver is ignored
-          # and relaxIV MCF solver is used by default
-          solver_2stage = 'pulp'
-  
-      print('Unwrap 2 Stage Settings:')
-      print('Name: %s'%unwrapper_2stage_name)
-      print('Solver: %s'%solver_2stage)
-  
-      inpFile = unwrappedIntFilename
-      ccFile  = connectedComponentsFilename
-      outFile = unwrapped2StageFilename
-  
-      # Hand over to 2Stage unwrap
-      unw = UnwrapComponents()
-      unw.setInpFile(inpFile)
-      unw.setConnCompFile(ccFile)
-      unw.setOutFile(outFile)
-      unw.setSolver(solver_2stage)
-      unw.setRedArcs(unwrapper_2stage_name)
-      unw.unwrapComponents()
-      return
+    if unwrapper_2stage_name is None:
+        unwrapper_2stage_name = 'REDARC0'
+
+    if solver_2stage is None:
+        # If unwrapper_2state_name is MCF then solver is ignored
+        # and relaxIV MCF solver is used by default
+        solver_2stage = 'pulp'
+
+    print('Unwrap 2 Stage Settings:')
+    print('Name: %s'%unwrapper_2stage_name)
+    print('Solver: %s'%solver_2stage)
+
+    inpFile = unwrappedIntFilename
+    ccFile  = connectedComponentsFilename
+    outFile = unwrapped2StageFilename
+
+    # Hand over to 2Stage unwrap
+    unw = UnwrapComponents()
+    unw.setInpFile(inpFile)
+    unw.setConnCompFile(ccFile)
+    unw.setOutFile(outFile)
+    unw.setSolver(solver_2stage)
+    unw.setRedArcs(unwrapper_2stage_name)
+    unw.unwrapComponents()
+    return
 
 
 def main(iargs=None):
@@ -303,24 +304,26 @@ def main(iargs=None):
 
     if inps.method != 'icu':
     
-       masterShelveDir = os.path.join(interferogramDir , 'masterShelve')
-       if not os.path.exists(masterShelveDir):
-          os.makedirs(masterShelveDir)
+        masterShelveDir = os.path.join(interferogramDir , 'masterShelve')
+        if not os.path.exists(masterShelveDir):
+            os.makedirs(masterShelveDir)
 
-       inps.master = os.path.dirname(inps.master)
-       cpCmd='cp ' + os.path.join(inps.master, 'data*') +' '+masterShelveDir
-       os.system(cpCmd)
-       pckfile = os.path.join(masterShelveDir,'data')
-       print(pckfile)
-       metadata = extractInfoFromPickle(pckfile, inps)
+        inps.master = os.path.dirname(inps.master)
+        cpCmd='cp ' + os.path.join(inps.master, 'data*') +' '+masterShelveDir
+        os.system(cpCmd)
+        pckfile = os.path.join(masterShelveDir,'data')
+        print(pckfile)
+        metadata = extractInfoFromPickle(pckfile, inps)
+
     ########
     print ('unwrapping method : ' , inps.method)
     if inps.method == 'snaphu':
-       if inps.nomcf: 
-           fncall =  runUnwrap
-       else:
-           fncall = runUnwrapMcf
-       fncall(inps.intfile, inps.unwprefix + '_snaphu.unw', inps.cohfile, metadata, defomax=inps.defomax)
+        if inps.nomcf: 
+            fncall =  runUnwrap
+        else:
+            fncall = runUnwrapMcf
+        fncall(inps.intfile, inps.unwprefix + '_snaphu.unw', inps.cohfile, metadata, defomax=inps.defomax)
+
     elif inps.method == 'snaphu2stage':
         if inps.nomcf: 
             fncall =  runUnwrap
@@ -329,11 +332,12 @@ def main(iargs=None):
         fncall(inps.intfile, inps.unwprefix + '_snaphu.unw', inps.cohfile, metadata, defomax=inps.defomax)
 
         # adding in the two-stage
-        runUnwrap2Stage(inps.unwprefix + '_snaphu.unw', inps.unwprefix + '_snaphu.unw.conncomp',inps.unwprefix + '_snaphu2stage.unw')
-
+        runUnwrap2Stage(inps.unwprefix + '_snaphu.unw',
+                        inps.unwprefix + '_snaphu.unw.conncomp',
+                        inps.unwprefix + '_snaphu2stage.unw')
 
     elif inps.method == 'icu':
-       runUnwrapIcu(inps.intfile, inps.unwprefix + '_icu.unw')
+        runUnwrapIcu(inps.intfile, inps.unwprefix + '_icu.unw')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR enables the usage of `corrLooks` value while calling snpahu or snaphu_mcf unwrapping in stripmapStack. Changes include:

1.  write `alks : ` and `rlks : ` in the `config_igram_*` file in `unwrap()` in `Stack.py`
2. calculate the corrlooks value in `extractInfoFromPickle()`
3. uncomment `snp.setCorrLooks()` in `runUnwrap()`
4. adjust indentations in `main()` and `runUnwrap2Stage()`