### PR TITLE
Hide rubbersheeting scipy/astropy imports

### DIFF
--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -9,7 +9,6 @@ from isceobj.Constants import SPEED_OF_LIGHT
 import numpy as np
 import gdal
 
-from scipy import ndimage
 try:
     import cv2
 except ImportError:
@@ -296,6 +295,8 @@ def fill(data, invalid=None):
     Output:
         Return a filled array.
     """
+    from scipy import ndimage
+
     if invalid is None: invalid = np.isnan(data)
 
     ind = ndimage.distance_transform_edt(invalid,

--- a/components/isceobj/StripmapProc/runRubbersheet.py
+++ b/components/isceobj/StripmapProc/runRubbersheet.py
@@ -6,7 +6,6 @@
 import isce
 import isceobj
 from osgeo import gdal
-from scipy import ndimage
 import numpy as np
 import os
 
@@ -24,6 +23,9 @@ def fill(data, invalid=None):
     Output:
         Return a filled array.
     """
+
+    from scipy import ndimage
+
     if invalid is None: invalid = np.isnan(data)
 
     ind = ndimage.distance_transform_edt(invalid,
@@ -34,6 +36,8 @@ def fill(data, invalid=None):
 
 def mask_filter(denseOffsetFile, snrFile, band, snrThreshold, filterSize, outName):
     #masking and Filtering
+
+    from scipy import ndimage
 
     ##Read in the offset file
     ds = gdal.Open(denseOffsetFile + '.vrt', gdal.GA_ReadOnly)

--- a/components/isceobj/StripmapProc/runRubbersheetAzimuth.py
+++ b/components/isceobj/StripmapProc/runRubbersheetAzimuth.py
@@ -9,14 +9,14 @@
 import isce
 import isceobj
 from osgeo import gdal
-from scipy import ndimage
-from astropy.convolution import convolve
 import numpy as np
 import os
 
 def mask_filterNoSNR(denseOffsetFile,filterSize,outName):
     # Masking the offsets with a data-based approach
-    
+
+    from scipy import ndimage
+
     # Open the offsets
     ds = gdal.Open(denseOffsetFile+'.vrt',gdal.GA_ReadOnly)
     off_az = ds.GetRasterBand(1).ReadAsArray()
@@ -79,6 +79,9 @@ def mask_filterNoSNR(denseOffsetFile,filterSize,outName):
 
 
 def off_masking(off,filterSize,thre=2):
+
+    from scipy import ndimage
+
     # Define the mask to fill the offsets
     vram = ndimage.median_filter(off.real, filterSize)
     vazm = ndimage.median_filter(off.imag, filterSize)
@@ -111,6 +114,8 @@ def fill(data, invalid=None):
 
 def mask_filter(denseOffsetFile, snrFile, band, snrThreshold, filterSize, outName):
     #masking and Filtering
+
+    from scipy import ndimage
 
     ##Read in the offset file
     ds = gdal.Open(denseOffsetFile + '.vrt', gdal.GA_ReadOnly)
@@ -154,7 +159,9 @@ def mask_filter(denseOffsetFile, snrFile, band, snrThreshold, filterSize, outNam
     return None
 
 def fill_with_smoothed(off,filterSize):
-    
+
+    from astropy.convolution import convolve
+
     off_2filt=np.copy(off)
     kernel = np.ones((filterSize,filterSize),np.float32)/(filterSize*filterSize)
     loop = 0

--- a/components/isceobj/StripmapProc/runRubbersheetRange.py
+++ b/components/isceobj/StripmapProc/runRubbersheetRange.py
@@ -9,15 +9,14 @@
 import isce
 import isceobj
 from osgeo import gdal
-from scipy import ndimage
 import numpy as np
 import os
-from astropy.convolution import convolve
-
 
 def mask_filterNoSNR(denseOffsetFile,filterSize,outName):
     # Masking the offsets with a data-based approach
-    
+
+    from scipy import ndimage
+
     # Open the offsets
     ds = gdal.Open(denseOffsetFile+'.vrt',gdal.GA_ReadOnly)
     off_az = ds.GetRasterBand(1).ReadAsArray()
@@ -78,6 +77,9 @@ def mask_filterNoSNR(denseOffsetFile,filterSize,outName):
     return 
 
 def off_masking(off,filterSize,thre=2):
+
+    from scipy import ndimage
+
     vram = ndimage.median_filter(off.real, filterSize)
     vazm = ndimage.median_filter(off.imag, filterSize)
 
@@ -100,6 +102,8 @@ def fill(data, invalid=None):
     Output:
         Return a filled array.
     """
+    from scipy import ndimage
+
     if invalid is None: invalid = np.isnan(data)
 
     ind = ndimage.distance_transform_edt(invalid,
@@ -108,7 +112,9 @@ def fill(data, invalid=None):
     return data[tuple(ind)]
 
 def fill_with_smoothed(off,filterSize):
-    
+
+    from astropy.convolution import convolve
+
     off_2filt=np.copy(off)
     kernel = np.ones((filterSize,filterSize),np.float32)/(filterSize*filterSize)
     loop = 0
@@ -130,6 +136,8 @@ def fill_with_smoothed(off,filterSize):
     
 def mask_filter(denseOffsetFile, snrFile, band, snrThreshold, filterSize, outName):
     #masking and Filtering
+
+    from scipy import ndimage
 
     ##Read in the offset file
     ds = gdal.Open(denseOffsetFile + '.vrt', gdal.GA_ReadOnly)
@@ -235,6 +243,8 @@ def resampleOffset(maskedFiltOffset, geometryOffset, outName):
     return None
 
 def runRubbersheetRange(self):
+
+    from scipy import ndimage
 
     if not self.doRubbersheetingRange:
         print('Rubber sheeting in azimuth not requested ... skipping')

--- a/components/isceobj/TopsProc/runIon.py
+++ b/components/isceobj/TopsProc/runIon.py
@@ -9,9 +9,6 @@ import shutil
 import datetime
 import numpy as np
 import numpy.matlib
-import scipy.signal as ss
-from scipy import interpolate
-from scipy.interpolate import interp1d
 
 import isceobj
 import logging
@@ -638,6 +635,7 @@ def cal_coherence(inf, win=5, edge=0):
 
           4: keep all samples
     '''
+    import scipy.signal as ss
 
     if win % 2 != 1:
         raise Exception('window size must be odd!')
@@ -1682,6 +1680,9 @@ def computeDopplerOffset(burst, firstline, lastline, firstcolumn, lastcolumn, nr
 
     output: first lines > 0, last lines < 0
     '''
+    from scipy import interpolate
+    from scipy.interpolate import interp1d
+
     Vs = np.linalg.norm(burst.orbit.interpolateOrbit(burst.sensingMid, method='hermite').getVelocity())
     Ks =   2 * Vs * burst.azimuthSteeringRate / burst.radarWavelength 
 
@@ -1830,6 +1831,7 @@ def adaptive_gaussian(ionos, wgt, size_max, size_min):
     size_max: maximum window size
     size_min: minimum window size
     '''
+    import scipy.signal as ss
 
     length = (ionos.shape)[0]
     width = (ionos.shape)[1]
@@ -1892,6 +1894,8 @@ def filt_gaussian(self, ionParam):
     currently not implemented.
     a less accurate method is to use ionsphere without any projection
     '''
+    from scipy import interpolate
+    from scipy.interpolate import interp1d
 
     #################################################
     #SET PARAMETERS HERE
@@ -2659,5 +2663,3 @@ def runIon(self):
     #esd_noion(self, ionParam)
 
     return
-
-    

--- a/components/isceobj/TopsProc/runOffsetFilter.py
+++ b/components/isceobj/TopsProc/runOffsetFilter.py
@@ -3,7 +3,6 @@
 # Copyright 2016
 #
 
-from scipy.ndimage.filters import median_filter
 import numpy as np
 import isce
 import isceobj
@@ -19,6 +18,8 @@ def runOffsetFilter(self):
 
     if not self.doDenseOffsets:
         return
+
+    from scipy.ndimage.filters import median_filter
 
     offsetfile = os.path.join(self._insar.mergedDirname, self._insar.offsetfile) 
     snrfile = os.path.join(self._insar.mergedDirname, self._insar.snrfile)

--- a/components/isceobj/TopsProc/runPrepESD.py
+++ b/components/isceobj/TopsProc/runPrepESD.py
@@ -8,7 +8,6 @@ import numpy as np
 import os
 import isceobj
 import logging
-import scipy.signal as SS
 from isceobj.Util.ImageUtil import ImageLib as IML
 import datetime
 import pprint
@@ -177,6 +176,7 @@ def createCoherence(intfile, win=5):
     '''
     Compute coherence using scipy convolve 2D.
     '''
+    import scipy.signal as SS
 
     corfile = os.path.splitext(intfile)[0] + '.cor'
     filt = np.ones((win,win))/ (1.0*win*win)


### PR DESCRIPTION
Recent rubbersheeting changes added scipy and astropy imports which
are not otherwise needed. Due to isce2's eager import behavior this
causes errors when using unrelated functionality. We can fix this
by tucking these imports away inside their function definitions.

To reproduce:
`python3 -c "import isce; from stripmapApp import Insar"`
(without scipy/astropy installed)