### PR TITLE
Simplify python version info

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -216,43 +216,12 @@ else:
 ### End of GPU branch-specific modifications
 
 
-file = '__init__.py'
-if not os.path.exists(file):
-    fout = open(file,"w")
-    fout.write("#!/usr/bin/env python3")
-    fout.close()
-
-env.Install(inst,file)
-try:
-    from subprocess import check_output
-    svn_revision = check_output('svnversion').strip() or 'Unknown'
-    if sys.version_info[0] == 3:
-        svn_revision = svn_revision.decode('utf-8')
-except ImportError:
-    try:
-        import popen2
-        stdout, stdin, stderr = popen2.popen3('svnversion')
-        svn_revision = stdout.read().strip()
-        if stderr.read():
-            raise Exception
-    except Exception:
-        svn_revision = 'Unknown'
-except OSError:
-    svn_revision = 'Unknown'
+env.Install(inst, '__init__.py')
+env.Install(inst, 'release_history.py')
 
 if not os.path.exists(inst):
     os.makedirs(inst)
 
-fvers = open(os.path.join(inst,'version.py'),'w')
-
-from release_history import release_version, release_svn_revision, release_date
-fvers_lines = ["release_version = '"+release_version+"'\n",
-               "release_svn_revision = '"+release_svn_revision+"'\n",
-               "release_date = '"+release_date+"'\n",
-               "svn_revision = '"+svn_revision+"'\n\n"]
-
-fvers.write(''.join(fvers_lines))
-fvers.close()
 v = 0
 if isrerun == 'no':
     cmd = 'scons -Q install --isrerun=yes'

--- a/__init__.py
+++ b/__init__.py
@@ -25,13 +25,9 @@
 # Author: Giangi Sacco
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
-
-from __future__ import print_function
-
-from .version import release_version, release_svn_revision, release_date
-from .version import svn_revision
+from .release_history import release_version, release_svn_revision, release_date
+svn_revision = release_svn_revision
+version = release_history # compatibility alias
 
 __version__ = release_version
 


### PR DESCRIPTION
SCons does some preprocessing during build to create version.py, but all that info is already in release_history.py. It's simpler to just use release_history.py directly, and it makes things easier for alternative build systems (hint hint)