### PR TITLE
Bugfixes for gcc/gfortran 9

### DIFF
--- a/components/mroipac/looks/bindings/looksmodule.cpp
+++ b/components/mroipac/looks/bindings/looksmodule.cpp
@@ -250,7 +250,7 @@ int takeLookscpx(DataAccessor *IAIn, DataAccessor* IAout, int ld, int la)
 
             for(int j = 0; j < nfull; j++)
             {
-                bdbl[j] += ain[j];
+                bdbl[j] += complex<double>(ain[j].real(), ain[j].imag());
             }
 
         }

--- a/contrib/mdx/src/SConscript
+++ b/contrib/mdx/src/SConscript
@@ -35,7 +35,7 @@ import os
 Import('envmdx')
 envmdx.Append( CCFLAGS=['-DSUN','-DIO64','-I'+envmdx['MOTIFINCPATH'],'-I'+envmdx['X11INCPATH']] )
 envmdx.PrependUnique( LIBPATH=[envmdx['MOTIFLIBPATH'],envmdx['X11LIBPATH']] )
-envmdx.Append( FORTRANFLAGS=['-DSUN','-DIO64','-DGFORTRAN'] )
+envmdx.Append( FORTRANFLAGS=['-DSUN','-DIO64'] )
 
 listFiles = ['graphx_mdx.c','rdf_reader_subs.f','mdx_subs.F']
 build = envmdx['PRJ_LIB_DIR']

--- a/contrib/mdx/src/mdx_main.F
+++ b/contrib/mdx/src/mdx_main.F
@@ -74,12 +74,6 @@ c*****************************************************************
           integer i_arg
           integer i_inarg
 
-          integer iargc
-#ifdef GFORTRAN
-c          external iargc
-#else
-           external iargc
-#endif
           integer rdflen
           external rdflen
 
@@ -110,7 +104,7 @@ c          external iargc
           equivalence(b_data,r_data)
 
           a_cmd = '-V'
-          i_inarg = iargc()
+          i_inarg = command_argument_count()
           if (i_inarg .eq. 0) then
             write(6,*) '  '
             write(6,'(1x,a,a18,a)'     ) '   <<  mdx    Version  ',version_mdx(),        '  >>   '


### PR DESCRIPTION
I was having trouble compiling using macports gfortran-mp-9 due to
being unable to link to symbol iargc. I think [1] implies this is a
gfortran 77 extension, so maybe it isn't available in the mac library?
It looks like there is a replacement [2] which is standard fortran as
of '03, and using this function fixes this bug for me.

[1] https://gcc.gnu.org/onlinedocs/gfortran/IARGC.html
[2] https://gcc.gnu.org/onlinedocs/gfortran/COMMAND_005fARGUMENT_005fCOUNT.html

Fixes #57 