### PR TITLE
Remove use of malloc.h

### DIFF
--- a/components/stdproc/alosreformat/ALOS_lib/src/cfft1d_fftpack.c
+++ b/components/stdproc/alosreformat/ALOS_lib/src/cfft1d_fftpack.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <complex.h>
-#include <malloc.h>
 /************************************************************************
 * cfft1d is a subroutine used to call and initialize perflib Fortran FFT *
 * routines.                                                             *


### PR DESCRIPTION
This header is deprecated and Linux-specific.
The standard include for malloc should be stdlib.h.