### PR TITLE
disable GPUampcor (not used) to allow CUDA >=10.0

### DIFF
--- a/components/zerodop/SConscript
+++ b/components/zerodop/SConscript
@@ -37,6 +37,6 @@ if envzerodop['CYTHON3'] and envzerodop['GPU_ACC_ENABLED']:
     SConscript('GPUtopozero/SConscript')
     SConscript('GPUgeo2rdr/SConscript')
     SConscript('GPUresampslc/SConscript')
-    SConscript('GPUampcor/SConscript')
+#SConscript('GPUampcor/SConscript')
 #SConscript('unw2hgt/SConscript')
 #SConscript('bistaticunw2hgt/SConscript')


### PR DESCRIPTION
GPUampcor requires device cublas libraries which are no longer supported by CUDA 10. Since no one is using this module, it's better we disable it. 