### PR TITLE
Remove internal usage of ISCE_HOME env variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
               set -ex
               pwd
               . /opt/conda/bin/activate root
-              export ISCE_HOME=/root/project/install/isce
+              ISCE_HOME=/root/project/install/isce
               export PATH="$ISCE_HOME/bin:$ISCE_HOME/applications:/opt/conda/bin:$PATH"
               export PYTHONPATH="/root/project/install:$PYTHONPATH"
               export LD_LIBRARY_PATH="/opt/conda/lib:$LD_LIBRARY_PATH"

--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,12 @@ version = release_history # compatibility alias
 __version__ = release_version
 
 import sys, os
-isce_path = os.path.split(os.path.abspath(__file__))[0]
+isce_path = os.path.dirname(os.path.abspath(__file__))
+
+import logging
+from logging.config import fileConfig as _fc
+_fc(os.path.join(isce_path, 'defaults', 'logging', 'logging.conf'))
+
 sys.path.insert(1,isce_path)
 sys.path.insert(1,os.path.join(isce_path,'applications'))
 sys.path.insert(1,os.path.join(isce_path,'components'))

--- a/applications/CalculatePegPoint.py
+++ b/applications/CalculatePegPoint.py
@@ -31,12 +31,8 @@
 
 
 
-import os
 import math
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from iscesys.Compatibility import Compatibility
 Compatibility.checkPythonVersion()
 from isceobj.Location.Peg import Peg

--- a/applications/calculateBaseline.py
+++ b/applications/calculateBaseline.py
@@ -30,11 +30,7 @@
 
 
 
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from iscesys.Compatibility import Compatibility
 Compatibility.checkPythonVersion()
 from iscesys.Component.FactoryInit import FactoryInit

--- a/applications/createGeneric.py
+++ b/applications/createGeneric.py
@@ -30,11 +30,7 @@
 
 
 
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 import isceobj
 from iscesys.Component.FactoryInit import FactoryInit
 

--- a/applications/extractHDROrbit.py
+++ b/applications/extractHDROrbit.py
@@ -30,12 +30,8 @@
 
 
 
-import os
 import datetime
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from iscesys.Compatibility import Compatibility
 Compatibility.checkPythonVersion()
 from iscesys.Component.FactoryInit import FactoryInit

--- a/applications/focus.py
+++ b/applications/focus.py
@@ -30,12 +30,8 @@
 
 
 
-import os
 import math
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 import isceobj
 from iscesys.Component.FactoryInit import FactoryInit
 from iscesys.DateTimeUtil.DateTimeUtil import DateTimeUtil as DTU

--- a/applications/insarApp.py
+++ b/applications/insarApp.py
@@ -34,8 +34,7 @@ from __future__ import print_function
 import time
 import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -45,11 +44,6 @@ from iscesys.Compatibility import Compatibility
 from iscesys.Component.Configurable import SELF
 import isceobj.InsarProc as InsarProc
 from isceobj.Scene.Frame import FrameMixin
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.insar')
 

--- a/applications/isceApp.py
+++ b/applications/isceApp.py
@@ -1437,7 +1437,6 @@ class IsceApp(Application, FrameMixin):
             sys.exit("Could not find the output directory: %s" % self.outputDir)
         os.chdir(self.outputDir) ##change working directory to given output directory
 
-        ##read configfile only here so that log path is in output directory
         logger = logging.getLogger('isce.isceProc')
         logger.info(self.intromsg)
         self._isce.dataDirectory = self.outputDir

--- a/applications/isceApp.py
+++ b/applications/isceApp.py
@@ -41,8 +41,7 @@ import datetime
 import os
 import sys
 import math
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -1439,10 +1438,6 @@ class IsceApp(Application, FrameMixin):
         os.chdir(self.outputDir) ##change working directory to given output directory
 
         ##read configfile only here so that log path is in output directory
-        logging.config.fileConfig(
-            os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-                'logging.conf')
-        )
         logger = logging.getLogger('isce.isceProc')
         logger.info(self.intromsg)
         self._isce.dataDirectory = self.outputDir

--- a/applications/make_raw.py
+++ b/applications/make_raw.py
@@ -27,16 +27,8 @@
 # Author: Walter Szeliga
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
-
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
-
 import isce
+from isce import logging
 from iscesys.Compatibility import Compatibility
 from iscesys.Component.Component import Component, Port
 from isceobj.Planet.Ellipsoid import Ellipsoid

--- a/applications/rtcApp.py
+++ b/applications/rtcApp.py
@@ -30,10 +30,8 @@
 
 
 import time
-import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -43,11 +41,6 @@ from iscesys.Compatibility import Compatibility
 from iscesys.Component.Configurable import SELF
 from isceobj import RtcProc
 from isceobj.Util.decorators import use_api
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.grdsar')
 

--- a/applications/scansarApp.py
+++ b/applications/scansarApp.py
@@ -27,13 +27,9 @@
 # Authors: Giangi Sacco, Eric Gurrola
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
 import time
-import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -42,11 +38,6 @@ from iscesys.Component.Application import Application
 from iscesys.Compatibility import Compatibility
 from iscesys.Component.Configurable import SELF
 from isceobj import ScansarProc
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.insar')
 

--- a/applications/stripmapApp.py
+++ b/applications/stripmapApp.py
@@ -35,10 +35,8 @@
 
 from __future__ import print_function
 import time
-import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -49,11 +47,6 @@ from iscesys.Component.Configurable import SELF
 import isceobj.StripmapProc as StripmapProc
 from isceobj.Scene.Frame import FrameMixin
 from isceobj.Util.decorators import use_api
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.insar')
 

--- a/applications/topsApp.py
+++ b/applications/topsApp.py
@@ -34,10 +34,8 @@
 
 
 import time
-import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -46,11 +44,6 @@ from iscesys.Component.Application import Application
 from iscesys.Compatibility import Compatibility
 from iscesys.Component.Configurable import SELF
 from isceobj import TopsProc
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.insar')
 

--- a/applications/topsOffsetApp.py
+++ b/applications/topsOffsetApp.py
@@ -30,10 +30,8 @@
 
 
 import time
-import os
 import sys
-import logging
-import logging.config
+from isce import logging
 
 import isce
 import isceobj
@@ -41,11 +39,6 @@ from isceobj import TopsProc
 from isce.applications.topsApp import TopsInSAR
 from iscesys.Component.Application import Application
 from isceobj.Util.decorators import use_api
-
-logging.config.fileConfig(
-    os.path.join(os.environ['ISCE_HOME'], 'defaults', 'logging',
-        'logging.conf')
-)
 
 logger = logging.getLogger('isce.insar')
 

--- a/applications/viewMetadata.py
+++ b/applications/viewMetadata.py
@@ -27,14 +27,7 @@
 # Author: Walter Szeliga
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
-
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from iscesys.Compatibility import Compatibility
 Compatibility.checkPythonVersion()
 from iscesys.Component.FactoryInit import FactoryInit

--- a/components/isceobj/Location/Offset.py
+++ b/components/isceobj/Location/Offset.py
@@ -29,11 +29,7 @@
 
 
 import math
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 
 from isceobj.Util.decorators import type_check, force, pickled, logged
 import numpy as np

--- a/components/isceobj/Scene/test/testTrack.py
+++ b/components/isceobj/Scene/test/testTrack.py
@@ -27,14 +27,7 @@
 # Author: Walter Szeliga
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
-
-import os
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from isceobj.Sensor.ERS import ERS
 from isceobj.Scene.Track import Track
 logger = logging.getLogger("testTrack")

--- a/components/isceobj/Util/geo/__init__.py
+++ b/components/isceobj/Util/geo/__init__.py
@@ -45,10 +45,6 @@ ellipsoid        oblate ellipsoid of revolution (e.g, WGS84) with all the
   See mainpage.txt for a complete dump of geo's philosophy-- otherwise,
   use the docstrings.
 """
-import os
-isce_path  = os.getenv("ISCE_HOME")
 
 ## \namespace geo  Vector- and Affine-spaces, on Earth
 __all__ = ['euclid', 'coordinates', 'ellipsoid', 'charts', 'affine', 'motion']
-
-

--- a/components/iscesys/Component/Configurable.py
+++ b/components/iscesys/Component/Configurable.py
@@ -32,10 +32,7 @@ from __future__ import print_function
 import os
 import sys
 import operator
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 from iscesys.DictUtils.DictUtils import DictUtils as DU
 from iscesys.Compatibility import Compatibility
 Compatibility.checkPythonVersion()

--- a/components/iscesys/DataRetriever/DataRetriever.py
+++ b/components/iscesys/DataRetriever/DataRetriever.py
@@ -37,8 +37,7 @@ import isce
 import zipfile
 import os
 import sys
-import logging
-import logging.config
+from isce import logging
 from iscesys.Component.Component import Component
 import shutil
 from urllib import request
@@ -325,8 +324,4 @@ class DataRetriever(Component):
         # logger not defined until baseclass is called
 
         if not self.logger:
-            logging.config.fileConfig(
-                os.path.join(os.environ['ISCE_HOME'], 'defaults',
-                'logging', 'logging.conf')
-            )
             self.logger = logging.getLogger('isce.iscesys.DataRetriever')

--- a/components/stdproc/orbit/orbitLib/CalcSchHeightVel.py
+++ b/components/stdproc/orbit/orbitLib/CalcSchHeightVel.py
@@ -29,19 +29,14 @@
 
 
 
-import os
 import logging
 import math
-import logging.config
 
 from iscesys.Compatibility import Compatibility
 
 from isceobj.Planet import Planet
 from isceobj import Constants as CN
 from iscesys.Component.Component import Component, Port
-
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
 
 RANGE_SAMPLING_RATE = Component.Parameter('rangeSamplingRate',
                                           public_name='range sampling rate',

--- a/contrib/demUtils/demstitcher/DemStitcher.py
+++ b/contrib/demUtils/demstitcher/DemStitcher.py
@@ -43,8 +43,7 @@ import os
 import sys
 import math
 import urllib.request, urllib.parse, urllib.error
-import logging
-import logging.config
+from isce import logging
 from iscesys.Component.Component import Component
 
 import xml.etree.ElementTree as ET
@@ -1013,10 +1012,6 @@ class DemStitcher(Component):
         # logger not defined until baseclass is called
 
         if not self.logger:
-            logging.config.fileConfig(
-                os.path.join(os.environ['ISCE_HOME'], 'defaults',
-                'logging', 'logging.conf')
-            )
             self.logger = logging.getLogger('isce.contrib.demUtils.DemStitcher')
 
     url = property(getUrl,setUrl)

--- a/contrib/demUtils/demstitcher/DemStitcherV3.py
+++ b/contrib/demUtils/demstitcher/DemStitcherV3.py
@@ -39,8 +39,7 @@ from ctypes import cdll
 import os
 import sys
 import urllib.request, urllib.error, urllib.parse
-import logging
-import logging.config
+from isce import logging
 from iscesys.Component.Component import Component
 from contrib.demUtils.DemStitcher import DemStitcher as DS
 #Parameters definitions
@@ -291,7 +290,4 @@ class DemStitcher(DS):
         #it's /srtm/version2_1/SRTM(1,3)
         self._remove = ['.jpg','.xml']
         if not self.logger:
-            logging.config.fileConfig(
-            os.environ['ISCE_HOME'] + '/library/applications/logging.conf'
-            )
             self.logger = logging.getLogger('isce.contrib.demUtils.DemStitcherV3')

--- a/contrib/demUtils/swbdstitcher/SWBDStitcher.py
+++ b/contrib/demUtils/swbdstitcher/SWBDStitcher.py
@@ -39,9 +39,8 @@ from ctypes import cdll
 import numpy as np
 import os
 import sys
-import logging
+from isce import logging
 import math
-import logging.config
 import urllib.request, urllib.parse, urllib.error
 from iscesys.Component.Component import Component
 from contrib.demUtils.DemStitcher import DemStitcher
@@ -315,9 +314,6 @@ class SWBDStitcher(DemStitcher):
         #it's /srtm/version2_1/SRTM(1,3)
         self._remove = ['.jpg','.xml']
         if not self.logger:
-            logging.config.fileConfig(
-            os.environ['ISCE_HOME'] + '/library/applications/logging.conf'
-            )
             self.logger = logging.getLogger('isce.contrib.demUtils.SWBDStitcher')
 
         self.parameter_list = self.parameter_list + super(DemStitcher,self).parameter_list

--- a/contrib/demUtils/watermask/WaterMask.py
+++ b/contrib/demUtils/watermask/WaterMask.py
@@ -35,8 +35,7 @@ import sys
 import math
 from html.parser import HTMLParser
 import urllib.request, urllib.parse, urllib.error
-import logging
-import logging.config
+from isce import logging
 from iscesys.Component.Component import Component
 import zipfile
 import os
@@ -979,10 +978,6 @@ class MaskStitcher(Component):
         # logger not defined until baseclass is called
 
         if not self.logger:
-            logging.config.fileConfig(
-                os.path.join(os.environ['ISCE_HOME'], 'defaults',
-                'logging', 'logging.conf')
-            )
             self.logger = logging.getLogger('isce.contrib.demUtils.MaskStitcher')
 
     utl = property(getUrl,setUrl)

--- a/contrib/issi/applications/ISSI.py
+++ b/contrib/issi/applications/ISSI.py
@@ -32,10 +32,7 @@
 
 import os
 import math
-import logging
-import logging.config
-logging.config.fileConfig(os.path.join(os.environ['ISCE_HOME'], 'defaults',
-    'logging', 'logging.conf'))
+from isce import logging
 
 import isce
 from iscesys.Component.FactoryInit import FactoryInit


### PR DESCRIPTION
ISCE_HOME was only used to get the location of the default logging config.
Lots of scripts were using boilerplate to set up this config, so I added
an `isce.logging` helper module which is the same as builtin python logging
but already has the configuration defaults set up for isce.

ISCE_HOME setup is retained in the toplevel `__init__.py`
but can now be removed without affecting functionality.