### PR TITLE
 Sentinel1 TOPS: Fix swath extraction when redundant bursts encountered across scene

### DIFF
--- a/components/isceobj/Sensor/TOPS/Sentinel1.py
+++ b/components/isceobj/Sensor/TOPS/Sentinel1.py
@@ -493,15 +493,9 @@ class Sentinel1(Component):
             offset = np.int(np.rint((aslice.product.bursts[0].burstStartUTC - t0).total_seconds() / burstStartInterval.total_seconds()))
 
             for kk in range(aslice.product.numberOfBursts):
-                #####Overwrite previous copy if one exists
+                #####Skip appending if burst also exists from previous scene
                 if (offset+kk) < len(self.product.bursts):
-                    self.product.bursts[offset+kk] = aslice.product.bursts[kk]
-
-                    ####Keep track of tiff src files
-                    if len(self.tiff):
-                        self._tiffSrc[offset+kk] = aslice.tiff[0]
-
-                    self._elevationAngleVsTau[offset+kk] = aslice._elevationAngleVsTau[kk]
+                    continue
 
                 elif (offset+kk) == len(self.product.bursts):
                     self.product.bursts.append(aslice.product.bursts[kk])


### PR DESCRIPTION
Resolving issue from: http://earthdef.caltech.edu/boards/4/topics/3249?r=3253#message-3253 based on advice by @piyushrpt 

There were issues with extracting the IW2 subswath over 2 spatially connected SLCs with redundant busts. 

E.g. case:

![image](https://user-images.githubusercontent.com/6346909/76585044-53563300-6518-11ea-8007-2eb3db9532ef.png)

* S1A_IW_SLC__1SDV_20180812T223318_20180812T223346_023219_028600_7C06.zip
* S1A_IW_SLC__1SDV_20180812T223343_20180812T223412_023219_028600_05C8.zip
* Relative Orbit: 47, bbox: [ -6.6008 -5.9093 106.4627 107.1788], Date: 20180812
* Red burst - burst which is present in both 7C06 and 05C8.

[Test logs before fix](https://gist.github.com/shitong01/fbfeb684d8cee054f5b0c54aa6847057)


[Test logs after fix](https://gist.github.com/shitong01/377ab7a08a700a7f4f7698a70df048e9)



