### PR TITLE
dem.py: use abspath filename in xml after correction

### DIFF
--- a/applications/dem.py
+++ b/applications/dem.py
@@ -34,6 +34,8 @@ import sys
 import os
 import argparse
 from contrib.demUtils import createDemStitcher
+
+
 def main():
     #if not argument provided force the --help flag
     if(len(sys.argv) == 1):
@@ -132,8 +134,12 @@ def main():
                 print('Could not create a stitched DEM. Some tiles are missing')
             else:
                 if(args.correct):
-                    ds.correct()
                     #ds.correct(args.output,args.source,width,min(lat[0],lat[1]),min(lon[0],lon[1]))
+                    demImg = ds.correct()
+                    # replace filename with full path including dir in which file is located
+                    demImg.filename = os.path.abspath(os.path.join(args.dir, demImg.filename))
+                    demImg.setAccessMode('READ')
+                    demImg.renderHdr()
         else:
             print('Error. The --bbox (or -b) option must be specified when --action stitch is used')
             raise ValueError

--- a/applications/fixImageXml.py
+++ b/applications/fixImageXml.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
+
+import os
+import argparse
 import isce
 import isceobj
-import argparse
-import os
+from isceobj.Util.ImageUtil import ImageLib as IML
+
 
 def cmdLineParse():
     '''
@@ -13,19 +16,14 @@ def cmdLineParse():
     parser = argparse.ArgumentParser(description='Fixes pathnames in ISCE image XML files. Can be used to do more things in the future.')
     parser.add_argument('-i', '--input', type=str, required=True, dest='infile',
             help = 'Input image for which the XML file needs to be fixed.')
-    parser.add_argument('-f', '--full', action='store_true', default=False, dest='full',
+
+    fname = parser.add_mutually_exclusive_group(required=True)
+    fname.add_argument('-f', '--full', action='store_false',
             help = 'Replace filename with full path including dir in which file is located')
-    parser.add_argument('-b', '--base', action='store_true', default=False, dest='base',
+    fname.add_argument('-b', '--base', action='store_true',
             help = 'Replace filename with basename to use in current directory')
 
     inps = parser.parse_args()
-
-    if (inps.full and inps.base):
-        raise Exception('User requested to use both full path and basename')
-
-    if (not inps.full) and (not inps.base):
-        raise Exception('User did not request any change')
-
     return inps
 
 
@@ -33,8 +31,6 @@ if __name__ == '__main__':
     '''
     Main driver.
     '''
-    from imageMath import IML
-
     inps = cmdLineParse()
 
     if inps.infile.endswith('.xml'):
@@ -42,15 +38,15 @@ if __name__ == '__main__':
 
     dirname  = os.path.dirname(inps.infile)
 
-    img, dataname, metaName = IML.loadImage(inps.infile)
+    img = IML.loadImage(inps.infile)[0]
 
     if inps.full:
         fname = os.path.abspath( os.path.join(dirname, os.path.basename(inps.infile)))
-    elif inps.base:
-        fname = os.path.basename( os.path.basename(inps.infile))
     else:
-        raise Exception('Unknown state in {0}'.format(os.path.basename(__file__)))
+        fname = os.path.basename( os.path.basename(inps.infile))
 
     img.filename = fname
     img.setAccessMode('READ')
     img.renderHdr()
+
+

--- a/contrib/stack/stripmapStack/README.md
+++ b/contrib/stack/stripmapStack/README.md
@@ -29,7 +29,6 @@ d) fix the path of the file in the xml file of the DEM by using fixImageXml.py.
 mkdir DEM; cd DEM
 dem.py -a stitch -b -37 -31 -72 -69 -r -s 1 -c
 rm demLat*.dem demLat*.dem.xml demLat*.dem.vrt
-fixImageXml.py -f -i demLat*.dem.wgs84
 cd ..
 ```
 

--- a/contrib/stack/topsStack/README.md
+++ b/contrib/stack/topsStack/README.md
@@ -57,7 +57,6 @@ Download of DEM (need to use wgs84 version) using the ISCE DEM download script.
 mkdir DEM; cd DEM
 dem.py -a stitch -b 18 20 -100 -97 -r -s 1 –c
 rm demLat*.dem demLat*.dem.xml demLat*.dem.vrt
-fixImageXml.py -f -i demLat*.dem.wgs84             #Updating DEM’s wgs84 xml to include full path to the DEM
 cd ..
 ```
 


### PR DESCRIPTION
This PR includes the following changes:

+ dem.py: replace filename in xml file with abspath after geoid to ellipsoid correction, so that fixImageXml.py call can be skipped.

+ update README.md files in contrib/stack/*Stack, as fixImageXml.py is not needed anymore

+ fixImageXml: use native argparse mutually exclusive group for --full/--base options to replace checking with own code