### PR TITLE
stripmapStack/MaskAndFitler: more plotting options

### DIFF
--- a/contrib/stack/stripmapStack/createWaterMask.py
+++ b/contrib/stack/stripmapStack/createWaterMask.py
@@ -32,10 +32,16 @@ def createParser():
                              'and (0,360) or (-180,180) for longitudes.')
     parser.add_argument('-d','--dem_file', dest='demName', type=str, default=None,
                       help='DEM file in geo coordinates, i.e. demLat*.dem.wgs84.')
+
     parser.add_argument('-l', '--lat_file', dest='latName', type=str, default=None, 
                       help='pixel by pixel lat file in radar coordinate')
     parser.add_argument('-L', '--lon_file', dest='lonName', type=str, default=None, 
                       help='pixel by pixel lat file in radar coordinate')
+
+    parser.add_argument('--fill', dest='fillValue', type=int, default=-1, choices={-1,0},
+                      help='fill value for pixels with missing data. Default: -1.\n'
+                           '-1 for water body\n'
+                           ' 0 for land')
     parser.add_argument('-o', '--output', dest='outfile', type=str,
                       help='output filename of water mask in radar coordinates')
     return parser
@@ -73,7 +79,7 @@ def dem2bbox(dem_file):
     return bbox
 
 
-def download_waterMask(bbox, dem_file):
+def download_waterMask(bbox, dem_file, fill_value=-1):
     out_dir = os.getcwd()
     # update out_dir and/or bbox if dem_file is input
     if dem_file:
@@ -86,8 +92,7 @@ def download_waterMask(bbox, dem_file):
     #inps.waterBodyGeo = sw.defaultName(inps.bbox)
     sw.outputFile = os.path.join(out_dir, sw.defaultName(bbox))
     sw._noFilling = False
-    sw._fillingValue = -1.0    #fill pixels without DEM data with value of -1, same as water body
-    #sw._fillingValue = 0.0
+    sw._fillingValue = fill_value
     sw.stitch(bbox[0:2], bbox[2:])
     return sw.outputFile
 
@@ -106,7 +111,7 @@ def geo2radar(geo_file, rdr_file, lat_file, lon_file):
 def main(iargs=None):
 
     inps = cmdLineParse(iargs)
-    geo_file = download_waterMask(inps.bbox, inps.demName)    
+    geo_file = download_waterMask(inps.bbox, inps.demName, inps.fillValue)
     if inps.latName and inps.lonName:
         geo2radar(geo_file, inps.outfile, inps.latName, inps.lonName)
     return

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -401,7 +401,8 @@ def runMultilook(in_dir, out_dir, alks, rlks):
     return out_dir
 
 
-def runMultilookGdal(in_dir, out_dir, alks, rlks):
+def runMultilookGdal(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr',
+                     fbase_list=['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']):
     print('generate multilooked geometry files with alks={} and rlks={}'.format(alks, rlks))
     import gdal
 
@@ -411,10 +412,9 @@ def runMultilookGdal(in_dir, out_dir, alks, rlks):
         print('create directory: {}'.format(out_dir))
 
     # multilook files one by one
-    for fbase in ['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']:
-        fname = '{}.rdr'.format(fbase)
-        in_file = os.path.join(in_dir, fname)
-        out_file = os.path.join(out_dir, fname)
+    for fbase in fbase_list:
+        in_file = os.path.join(in_dir, '{}{}'.format(fbase, in_ext))
+        out_file = os.path.join(out_dir, '{}{}'.format(fbase, out_ext))
 
         if os.path.isfile(in_file):
             ds = gdal.Open(in_file, gdal.GA_ReadOnly)
@@ -434,8 +434,9 @@ def runMultilookGdal(in_dir, out_dir, alks, rlks):
             # copy the full resolution xml/vrt file from ./merged/geom_master to ./geom_master
             # to facilitate the number of looks extraction
             # the file path inside .xml file is not, but should, updated
-            shutil.copy(in_file+'.xml', out_file+'.full.xml')
-            shutil.copy(in_file+'.vrt', out_file+'.full.vrt')
+            if in_file != out_file+'.full':
+                shutil.copy(in_file+'.xml', out_file+'.full.xml')
+                shutil.copy(in_file+'.vrt', out_file+'.full.vrt')
 
     return out_dir
 


### PR DESCRIPTION
This PR adds more plotting capabilities in `stripmapStack/MaskAndFilter.py`, including:

+ plot SNR and the evolution of offset after each step to better check the changes by masking, filling and filtering operations.

+ plot both azimuth and range offset in one figure and move the plotting to the end after file writing

+ add `-v, --v-snr, --figsize and --save` options to customize the plot

+ update file path in the XML file so that the script can work even if the files are moved.

It also includes two minors changes in createWaterMask.py and topo.py:

+ createWaterMask: add `--fill` option to be able to change the fill value for the missing waterbody data, because sometimes it's land sometimes it's water.

+ topo: add in_ext/out_ext/fbase_list argument to `runMultilookGdal()` for more flexibility and fix a bug for .full.xml file copying when input/output are in the same directory