### PR TITLE
Fix Burst Loading in Estimate Range and Azimuth Misreg

### DIFF
--- a/contrib/stack/topsStack/estimateAzimuthMisreg.py
+++ b/contrib/stack/topsStack/estimateAzimuthMisreg.py
@@ -63,6 +63,7 @@ def main(iargs=None):
 
         minBurst = int(os.path.basename(freqFiles[0]).split('.')[0][-2:])
         maxBurst = int(os.path.basename(freqFiles[-1]).split('.')[0][-2:])
+        maxBurst = maxBurst + 1
 
     #maxBurst = maxBurst - 1
 
@@ -79,9 +80,9 @@ def main(iargs=None):
   #  val = []
         lineCount = 0
         for ii in range(minBurst, maxBurst):
-          intname = os.path.join(esddir, 'overlap_%02d.%dalks_%drlks.int'%(ii+1, alks,rlks))
-          freqname = os.path.join(esddir, 'freq_%02d.%dalks_%drlks.bin'%(ii+1,alks,rlks))
-          corname = os.path.join(esddir, 'overlap_%02d.%dalks_%drlks.cor'%(ii+1, alks, rlks))
+          intname = os.path.join(esddir, 'overlap_%02d.%dalks_%drlks.int'%(ii, alks,rlks))
+          freqname = os.path.join(esddir, 'freq_%02d.%dalks_%drlks.bin'%(ii,alks,rlks))
+          corname = os.path.join(esddir, 'overlap_%02d.%dalks_%drlks.cor'%(ii, alks, rlks))
 
 
           img = isceobj.createImage()

--- a/contrib/stack/topsStack/estimateRangeMisreg.py
+++ b/contrib/stack/topsStack/estimateRangeMisreg.py
@@ -178,7 +178,8 @@ def main(iargs=None):
 
         minBurst = max(minSlave, minMaster)
         maxBurst = min(maxSlave, maxMaster)
-        maxBurst = maxBurst - 1 ###For overlaps
+        #maxBurst = maxBurst - 1 ###For overlaps
+        maxBurst = maxBurst + 1
 
         for pair in [(masterTop,slaveTop), (masterBottom,slaveBottom)]:
             for ii in range(minBurst,maxBurst):


### PR DESCRIPTION
Within the for loops that iterate over range(minBurst, maxBurst), the maximum burst number files are not loaded because range() is end exclusive. In cases where only one burst in a swath is used, the scripts fail to produce misregistration estimates. This can be fixed for both scripts by adding `maxBurst = maxBurst +1`, and removing `maxBurst = maxBurst - 1` in estimateRangeMisreg.py