### PR TITLE
Use exist_ok argument to makedirs when appropriate

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -216,11 +216,10 @@ else:
 ### End of GPU branch-specific modifications
 
 
+os.makedirs(inst, exist_ok=True)
 env.Install(inst, '__init__.py')
 env.Install(inst, 'release_history.py')
 
-if not os.path.exists(inst):
-    os.makedirs(inst)
 
 v = 0
 if isrerun == 'no':

--- a/components/isceobj/Alos2Proc/Alos2ProcPublic.py
+++ b/components/isceobj/Alos2Proc/Alos2ProcPublic.py
@@ -985,10 +985,8 @@ def resampleBursts(masterSwath, slaveSwath,
     import numpy.matlib
     from contrib.alos2proc.alos2proc import resamp
 
-    if not os.path.exists(slaveBurstResampledDir):
-        os.makedirs(slaveBurstResampledDir)
-    if not os.path.exists(interferogramDir):
-        os.makedirs(interferogramDir)
+    os.makedirs(slaveBurstResampledDirm, exist_ok=True)
+    os.makedirs(interferogramDirm, exist_ok=True)
 
     #get burst file names
     masterBurstSlc = [masterBurstPrefix+'_%02d.slc'%(i+1) for i in range(masterSwath.numberOfBursts)]

--- a/components/isceobj/Alos2Proc/Alos2ProcPublic.py
+++ b/components/isceobj/Alos2Proc/Alos2ProcPublic.py
@@ -985,8 +985,8 @@ def resampleBursts(masterSwath, slaveSwath,
     import numpy.matlib
     from contrib.alos2proc.alos2proc import resamp
 
-    os.makedirs(slaveBurstResampledDirm, exist_ok=True)
-    os.makedirs(interferogramDirm, exist_ok=True)
+    os.makedirs(slaveBurstResampledDir, exist_ok=True)
+    os.makedirs(interferogramDir, exist_ok=True)
 
     #get burst file names
     masterBurstSlc = [masterBurstPrefix+'_%02d.slc'%(i+1) for i in range(masterSwath.numberOfBursts)]

--- a/components/isceobj/Alos2Proc/runCoherence.py
+++ b/components/isceobj/Alos2Proc/runCoherence.py
@@ -22,8 +22,7 @@ def runCoherence(self):
     #slaveTrack = self._insar.loadTrack(master=False)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
     numberRangeLooks = self._insar.numberRangeLooks1 * self._insar.numberRangeLooks2

--- a/components/isceobj/Alos2Proc/runDenseOffset.py
+++ b/components/isceobj/Alos2Proc/runDenseOffset.py
@@ -24,8 +24,7 @@ def runDenseOffset(self):
     self.updateParamemetersFromUser()
 
     denseOffsetDir = 'dense_offset'
-    if not os.path.exists(denseOffsetDir):
-        os.makedirs(denseOffsetDir)
+    os.makedirs(denseOffsetDir, exist_ok=True)
     os.chdir(denseOffsetDir)
 
     #masterTrack = self._insar.loadProduct(self._insar.masterTrackParameter)

--- a/components/isceobj/Alos2Proc/runDiffInterferogram.py
+++ b/components/isceobj/Alos2Proc/runDiffInterferogram.py
@@ -21,8 +21,7 @@ def runDiffInterferogram(self):
     masterTrack = self._insar.loadTrack(master=True)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runDownloadDem.py
+++ b/components/isceobj/Alos2Proc/runDownloadDem.py
@@ -31,8 +31,7 @@ def runDownloadDem(self):
     #get 1 arcsecond dem for coregistration
     if self.dem == None:
         demDir = 'dem_1_arcsec'
-        if not os.path.exists(demDir):
-            os.makedirs(demDir)
+        os.makedirs(demDir, exist_ok=True)
         os.chdir(demDir)
 
         downloadUrl = 'http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/2000.02.11'
@@ -52,8 +51,7 @@ def runDownloadDem(self):
     #get 3 arcsecond dem for geocoding
     if self.demGeo == None:
         demGeoDir = 'dem_3_arcsec'
-        if not os.path.exists(demGeoDir):
-            os.makedirs(demGeoDir)
+        os.makedirs(demGeoDir, exist_ok=True)
         os.chdir(demGeoDir)
 
         downloadUrl = 'http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL3.003/2000.02.11'
@@ -73,8 +71,7 @@ def runDownloadDem(self):
     #get water body for masking interferogram
     if self.wbd == None:
         wbdDir = 'wbd_1_arcsec'
-        if not os.path.exists(wbdDir):
-            os.makedirs(wbdDir)
+        os.makedirs(wbdDir, exist_ok=True)
         os.chdir(wbdDir)
 
         #cmd = 'wbd.py {}'.format(bboxStr)

--- a/components/isceobj/Alos2Proc/runFilt.py
+++ b/components/isceobj/Alos2Proc/runFilt.py
@@ -28,8 +28,7 @@ def runFilt(self):
     #slaveTrack = self._insar.loadTrack(master=False)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runFiltOffset.py
+++ b/components/isceobj/Alos2Proc/runFiltOffset.py
@@ -25,8 +25,7 @@ def runFiltOffset(self):
     self.updateParamemetersFromUser()
 
     denseOffsetDir = 'dense_offset'
-    if not os.path.exists(denseOffsetDir):
-        os.makedirs(denseOffsetDir)
+    os.makedirs(denseOffsetDir, exist_ok=True)
     os.chdir(denseOffsetDir)
 
     #masterTrack = self._insar.loadProduct(self._insar.masterTrackParameter)

--- a/components/isceobj/Alos2Proc/runFrameMosaic.py
+++ b/components/isceobj/Alos2Proc/runFrameMosaic.py
@@ -24,8 +24,7 @@ def runFrameMosaic(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     mosaicDir = 'insar'
-    if not os.path.exists(mosaicDir):
-        os.makedirs(mosaicDir)
+    os.makedirs(mosaicDir, exist_ok=True)
     os.chdir(mosaicDir)
 
     numberOfFrames = len(masterTrack.frames)
@@ -334,8 +333,7 @@ def frameMosaic(track, inputFiles, outputfile, rangeOffsets, azimuthOffsets, num
             if DEBUG:
                 #create a dir and work in this dir
                 diffDir = 'frame_mosaic'
-                if not os.path.exists(diffDir):
-                    os.makedirs(diffDir)
+                os.makedirs(diffDir, exist_ok=True)
                 os.chdir(diffDir)
 
                 #dump phase difference

--- a/components/isceobj/Alos2Proc/runFrameOffset.py
+++ b/components/isceobj/Alos2Proc/runFrameOffset.py
@@ -20,8 +20,7 @@ def runFrameOffset(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     mosaicDir = 'insar'
-    if not os.path.exists(mosaicDir):
-        os.makedirs(mosaicDir)
+    os.makedirs(mosaicDir, exist_ok=True)
     os.chdir(mosaicDir)
 
     if len(masterTrack.frames) > 1:

--- a/components/isceobj/Alos2Proc/runGeo2Rdr.py
+++ b/components/isceobj/Alos2Proc/runGeo2Rdr.py
@@ -19,8 +19,7 @@ def runGeo2Rdr(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runGeocode.py
+++ b/components/isceobj/Alos2Proc/runGeocode.py
@@ -24,8 +24,7 @@ def runGeocode(self):
     demFile = os.path.abspath(self._insar.demGeo)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
     #compute bounding box for geocoding

--- a/components/isceobj/Alos2Proc/runGeocodeOffset.py
+++ b/components/isceobj/Alos2Proc/runGeocodeOffset.py
@@ -35,7 +35,7 @@ def runGeocodeOffset(self):
     demFile = os.path.abspath(self._insar.demGeo)
 
     denseOffsetDir = 'dense_offset'
-    os.makedirs(denseOffsetDirm, exist_ok=True)
+    os.makedirs(denseOffsetDir, exist_ok=True)
     os.chdir(denseOffsetDir)
 
     masterTrack = self._insar.loadProduct(self._insar.masterTrackParameter)

--- a/components/isceobj/Alos2Proc/runGeocodeOffset.py
+++ b/components/isceobj/Alos2Proc/runGeocodeOffset.py
@@ -35,8 +35,7 @@ def runGeocodeOffset(self):
     demFile = os.path.abspath(self._insar.demGeo)
 
     denseOffsetDir = 'dense_offset'
-    if not os.path.exists(denseOffsetDir):
-        os.makedirs(denseOffsetDir)
+    os.makedirs(denseOffsetDirm, exist_ok=True)
     os.chdir(denseOffsetDir)
 
     masterTrack = self._insar.loadProduct(self._insar.masterTrackParameter)

--- a/components/isceobj/Alos2Proc/runIonFilt.py
+++ b/components/isceobj/Alos2Proc/runIonFilt.py
@@ -31,8 +31,7 @@ def runIonFilt(self):
     subbandPrefix = ['lower', 'upper']
 
     ionCalDir = os.path.join(ionDir['ion'], ionDir['ionCal'])
-    if not os.path.exists(ionCalDir):
-        os.makedirs(ionCalDir)
+    os.makedirs(ionCalDir, exist_ok=True)
     os.chdir(ionCalDir)
 
 

--- a/components/isceobj/Alos2Proc/runIonSubband.py
+++ b/components/isceobj/Alos2Proc/runIonSubband.py
@@ -58,8 +58,7 @@ def runIonSubband(self):
     ############################################################
     #create and enter 'ion' directory
     #after finishing each step, we are in this directory
-    if not os.path.exists(ionDir['ion']):
-        os.makedirs(ionDir['ion'])
+    os.makedirs(ionDir['ion'], exist_ok=True)
     os.chdir(ionDir['ion'])
 
     #create insar processing directories
@@ -70,12 +69,10 @@ def runIonSubband(self):
             for j, swathNumber in enumerate(range(self._insar.startingSwath, self._insar.endingSwath + 1)):
                 swathDir = 's{}'.format(swathNumber)
                 fullDir = os.path.join(subbandDir, frameDir, swathDir)
-                if not os.path.exists(fullDir):
-                    os.makedirs(fullDir)
+                os.makedirs(fullDir, exist_ok=True)
 
     #create ionospheric phase directory
-    if not os.path.exists(ionDir['ionCal']):
-        os.makedirs(ionDir['ionCal'])
+    os.makedirs(ionDir['ionCal'], exist_ok=True)
 
 
     ############################################################
@@ -223,8 +220,7 @@ def runIonSubband(self):
             os.chdir(frameDir)
 
             mosaicDir = ionDir['swathMosaic']
-            if not os.path.exists(mosaicDir):
-                os.makedirs(mosaicDir)
+            os.makedirs(mosaicDir, exist_ok=True)
             os.chdir(mosaicDir)
 
             if not (
@@ -316,8 +312,7 @@ def runIonSubband(self):
         os.chdir(ionDir['subband'][k])
 
         mosaicDir = ionDir['insar']
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         numberOfFrames = len(masterTrack.frames)
@@ -406,8 +401,7 @@ def runIonSubband(self):
         os.chdir(ionDir['subband'][k])
 
         insarDir = ionDir['insar']
-        if not os.path.exists(insarDir):
-            os.makedirs(insarDir)
+        os.makedirs(insarDir, exist_ok=True)
         os.chdir(insarDir)
 
         rangePixelSize = self._insar.numberRangeLooks1 * masterTrack.rangePixelSize

--- a/components/isceobj/Alos2Proc/runIonUwrap.py
+++ b/components/isceobj/Alos2Proc/runIonUwrap.py
@@ -31,8 +31,7 @@ def runIonUwrap(self):
     subbandPrefix = ['lower', 'upper']
 
     ionCalDir = os.path.join(ionDir['ion'], ionDir['ionCal'])
-    if not os.path.exists(ionCalDir):
-        os.makedirs(ionCalDir)
+    os.makedirs(ionCalDir, exist_ok=True)
     os.chdir(ionCalDir)
 
 

--- a/components/isceobj/Alos2Proc/runLook.py
+++ b/components/isceobj/Alos2Proc/runLook.py
@@ -25,8 +25,7 @@ def runLook(self):
     wbdFile = os.path.abspath(self._insar.wbd)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runPreprocessor.py
+++ b/components/isceobj/Alos2Proc/runPreprocessor.py
@@ -270,8 +270,7 @@ def runPreprocessor(self):
     for i, (masterFrame, slaveFrame) in enumerate(zip(self._insar.masterFrames, self._insar.slaveFrames)):
         #frame number starts with 1
         frameDir = 'f{}_{}'.format(i+1, masterFrame)
-        if not os.path.exists(frameDir):
-            os.makedirs(frameDir)
+        os.makedirs(frameDir, exist_ok=True)
         os.chdir(frameDir)
 
         #attach a frame to master and slave
@@ -287,8 +286,7 @@ def runPreprocessor(self):
             print('processing frame {} swath {}'.format(masterFrame, j))
 
             swathDir = 's{}'.format(j)
-            if not os.path.exists(swathDir):
-                os.makedirs(swathDir)
+            os.makedirs(swathDir, exist_ok=True)
             os.chdir(swathDir)
 
             #attach a swath to master and slave

--- a/components/isceobj/Alos2Proc/runRdr2Geo.py
+++ b/components/isceobj/Alos2Proc/runRdr2Geo.py
@@ -22,8 +22,7 @@ def runRdr2Geo(self):
     wbdFile = os.path.abspath(self._insar.wbd)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runRdrDemOffset.py
+++ b/components/isceobj/Alos2Proc/runRdrDemOffset.py
@@ -27,13 +27,11 @@ def runRdrDemOffset(self):
     demFile = os.path.abspath(self._insar.dem)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
     rdrDemDir = 'rdr_dem_offset'
-    if not os.path.exists(rdrDemDir):
-        os.makedirs(rdrDemDir)
+    os.makedirs(rdrDemDir, exist_ok=True)
     os.chdir(rdrDemDir)
 
     ##################################################################################################

--- a/components/isceobj/Alos2Proc/runRectRangeOffset.py
+++ b/components/isceobj/Alos2Proc/runRectRangeOffset.py
@@ -22,8 +22,7 @@ def runRectRangeOffset(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2Proc/runSlcMatch.py
+++ b/components/isceobj/Alos2Proc/runSlcMatch.py
@@ -37,8 +37,7 @@ def runSlcMatch(self):
     wbdFile = os.path.abspath(self._insar.wbd)
 
     denseOffsetDir = 'dense_offset'
-    if not os.path.exists(denseOffsetDir):
-        os.makedirs(denseOffsetDir)
+    os.makedirs(denseOffsetDir, exist_ok=True)
     os.chdir(denseOffsetDir)
 
     masterTrack = self._insar.loadProduct(self._insar.masterTrackParameter)

--- a/components/isceobj/Alos2Proc/runSlcMosaic.py
+++ b/components/isceobj/Alos2Proc/runSlcMosaic.py
@@ -30,8 +30,7 @@ def runSlcMosaic(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     denseOffsetDir = 'dense_offset'
-    if not os.path.exists(denseOffsetDir):
-        os.makedirs(denseOffsetDir)
+    os.makedirs(denseOffsetDir, exist_ok=True)
     os.chdir(denseOffsetDir)
 
 

--- a/components/isceobj/Alos2Proc/runSwathMosaic.py
+++ b/components/isceobj/Alos2Proc/runSwathMosaic.py
@@ -28,8 +28,7 @@ def runSwathMosaic(self):
         os.chdir(frameDir)
 
         mosaicDir = 'mosaic'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         if not (

--- a/components/isceobj/Alos2Proc/runSwathOffset.py
+++ b/components/isceobj/Alos2Proc/runSwathOffset.py
@@ -29,8 +29,7 @@ def runSwathOffset(self):
         os.chdir(frameDir)
 
         mosaicDir = 'mosaic'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         if not (

--- a/components/isceobj/Alos2Proc/runUnwrapSnaphu.py
+++ b/components/isceobj/Alos2Proc/runUnwrapSnaphu.py
@@ -26,8 +26,7 @@ def runUnwrapSnaphu(self):
     #slaveTrack = self._insar.loadTrack(master=False)
 
     insarDir = 'insar'
-    if not os.path.exists(insarDir):
-        os.makedirs(insarDir)
+    os.makedirs(insarDir, exist_ok=True)
     os.chdir(insarDir)
 
 

--- a/components/isceobj/Alos2burstProc/runCoregSd.py
+++ b/components/isceobj/Alos2burstProc/runCoregSd.py
@@ -44,8 +44,7 @@ def runCoregSd(self):
             # spectral diversity or mai
             ##################################################
             sdDir = 'spectral_diversity'
-            if not os.path.exists(sdDir):
-                os.makedirs(sdDir)
+            os.makedirs(sdDir, exist_ok=True)
             os.chdir(sdDir)
 
             interferogramDir = 'burst_interf_2_coreg_cc'

--- a/components/isceobj/Alos2burstProc/runExtractBurst.py
+++ b/components/isceobj/Alos2burstProc/runExtractBurst.py
@@ -66,8 +66,7 @@ def runExtractBurst(self):
                 #########################################################################################
 
                 #extract burst
-                if not os.path.exists(extractDir):
-                    os.makedirs(extractDir)
+                os.makedirs(extractDir, exist_ok=True)
                 os.chdir(extractDir)
                 if os.path.isfile(os.path.join('../', fullApertureSlc)):
                     os.rename(os.path.join('../', fullApertureSlc), fullApertureSlc)

--- a/components/isceobj/Alos2burstProc/runFiltSd.py
+++ b/components/isceobj/Alos2burstProc/runFiltSd.py
@@ -29,8 +29,7 @@ def runFiltSd(self):
     #slaveTrack = self._insar.loadTrack(master=False)
 
     sdDir = 'sd'
-    if not os.path.exists(sdDir):
-        os.makedirs(sdDir)
+    os.makedirs(sdDir, exist_ok=True)
     os.chdir(sdDir)
 
     sd = isceobj.createImage()

--- a/components/isceobj/Alos2burstProc/runFrameMosaic.py
+++ b/components/isceobj/Alos2burstProc/runFrameMosaic.py
@@ -23,8 +23,7 @@ def runFrameMosaic(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     mosaicDir = 'insar'
-    if not os.path.exists(mosaicDir):
-        os.makedirs(mosaicDir)
+    os.makedirs(mosaicDir, exist_ok=True)
     os.chdir(mosaicDir)
 
     numberOfFrames = len(masterTrack.frames)
@@ -125,8 +124,7 @@ def runFrameMosaic(self):
 
     #mosaic spectral diversity inteferograms
     mosaicDir = 'sd'
-    if not os.path.exists(mosaicDir):
-        os.makedirs(mosaicDir)
+    os.makedirs(mosaicDir, exist_ok=True)
     os.chdir(mosaicDir)
 
     numberOfFrames = len(masterTrack.frames)

--- a/components/isceobj/Alos2burstProc/runFrameOffset.py
+++ b/components/isceobj/Alos2burstProc/runFrameOffset.py
@@ -21,8 +21,7 @@ def runFrameOffset(self):
     slaveTrack = self._insar.loadTrack(master=False)
 
     mosaicDir = 'insar'
-    if not os.path.exists(mosaicDir):
-        os.makedirs(mosaicDir)
+    os.makedirs(mosaicDir, exist_ok=True)
     os.chdir(mosaicDir)
 
     if len(masterTrack.frames) > 1:

--- a/components/isceobj/Alos2burstProc/runGeocodeSd.py
+++ b/components/isceobj/Alos2burstProc/runGeocodeSd.py
@@ -25,8 +25,7 @@ def runGeocodeSd(self):
     demFile = os.path.abspath(self._insar.demGeo)
 
     sdDir = 'sd'
-    if not os.path.exists(sdDir):
-        os.makedirs(sdDir)
+    os.makedirs(sdDir, exist_ok=True)
     os.chdir(sdDir)
 
     if self.geocodeListSd == None:

--- a/components/isceobj/Alos2burstProc/runIonSubband.py
+++ b/components/isceobj/Alos2burstProc/runIonSubband.py
@@ -59,8 +59,7 @@ def runIonSubband(self):
     ############################################################
     #create and enter 'ion' directory
     #after finishing each step, we are in this directory
-    if not os.path.exists(ionDir['ion']):
-        os.makedirs(ionDir['ion'])
+    os.makedirs(ionDir['ion'], exist_ok=True)
     os.chdir(ionDir['ion'])
 
     #create insar processing directories
@@ -71,12 +70,10 @@ def runIonSubband(self):
             for j, swathNumber in enumerate(range(self._insar.startingSwath, self._insar.endingSwath + 1)):
                 swathDir = 's{}'.format(swathNumber)
                 fullDir = os.path.join(subbandDir, frameDir, swathDir)
-                if not os.path.exists(fullDir):
-                    os.makedirs(fullDir)
+                os.makedirs(fullDir, exist_ok=True)
 
     #create ionospheric phase directory
-    if not os.path.exists(ionDir['ionCal']):
-        os.makedirs(ionDir['ionCal'])
+    os.makedirs(ionDir['ionCal'])
 
 
     ############################################################
@@ -100,10 +97,8 @@ def runIonSubband(self):
                 slcDir = os.path.join('../', frameDir, swathDir, burstPrefix)
                 slcLowerDir = os.path.join(ionDir['subband'][0], frameDir, swathDir, burstPrefix)
                 slcUpperDir = os.path.join(ionDir['subband'][1], frameDir, swathDir, burstPrefix)
-                if not os.path.exists(slcLowerDir):
-                    os.makedirs(slcLowerDir)
-                if not os.path.exists(slcUpperDir):
-                    os.makedirs(slcUpperDir)
+                os.makedirs(slcLowerDir, exist_ok=True)
+                os.makedirs(slcUpperDir, exist_ok=True)
                 for k in range(swath.numberOfBursts):
                     print('processing burst: %02d'%(k+1))
                     slc = os.path.join(slcDir, burstPrefix+'_%02d.slc'%(k+1))
@@ -208,8 +203,7 @@ def runIonSubband(self):
             os.chdir(frameDir)
 
             mosaicDir = 'mosaic'
-            if not os.path.exists(mosaicDir):
-                os.makedirs(mosaicDir)
+            os.makedirs(mosaicDir, exist_ok=True)
             os.chdir(mosaicDir)
 
             if self._insar.endingSwath-self._insar.startingSwath+1 == 1:
@@ -289,8 +283,7 @@ def runIonSubband(self):
         os.chdir(ionDir['subband'][k])
 
         mosaicDir = 'insar'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         numberOfFrames = len(masterTrack.frames)
@@ -374,8 +367,7 @@ def runIonSubband(self):
         os.chdir(ionDir['subband'][k])
 
         insarDir = ionDir['insar']
-        if not os.path.exists(insarDir):
-            os.makedirs(insarDir)
+        os.makedirs(insarDir, exist_ok=True)
         os.chdir(insarDir)
 
         rangePixelSize = self._insar.numberRangeLooks1 * masterTrack.rangePixelSize

--- a/components/isceobj/Alos2burstProc/runLookSd.py
+++ b/components/isceobj/Alos2burstProc/runLookSd.py
@@ -24,8 +24,7 @@ def runLookSd(self):
     wbdFile = os.path.abspath(self._insar.wbd)
 
     sdDir = 'sd'
-    if not os.path.exists(sdDir):
-        os.makedirs(sdDir)
+    os.makedirs(sdDir, exist_ok=True)
     os.chdir(sdDir)
 
     sd = isceobj.createImage()

--- a/components/isceobj/Alos2burstProc/runPreprocessor.py
+++ b/components/isceobj/Alos2burstProc/runPreprocessor.py
@@ -193,8 +193,7 @@ def runPreprocessor(self):
     for i, (masterFrame, slaveFrame) in enumerate(zip(self._insar.masterFrames, self._insar.slaveFrames)):
         #frame number starts with 1
         frameDir = 'f{}_{}'.format(i+1, masterFrame)
-        if not os.path.exists(frameDir):
-            os.makedirs(frameDir)
+        os.makedirs(frameDir, exist_ok=True)
         os.chdir(frameDir)
 
         #attach a frame to master and slave
@@ -210,8 +209,7 @@ def runPreprocessor(self):
             print('processing frame {} swath {}'.format(masterFrame, j))
 
             swathDir = 's{}'.format(j)
-            if not os.path.exists(swathDir):
-                os.makedirs(swathDir)
+            os.makedirs(swathDir, exist_ok=True)
             os.chdir(swathDir)
 
             #attach a swath to master and slave

--- a/components/isceobj/Alos2burstProc/runSwathMosaic.py
+++ b/components/isceobj/Alos2burstProc/runSwathMosaic.py
@@ -28,8 +28,7 @@ def runSwathMosaic(self):
         os.chdir(frameDir)
 
         mosaicDir = 'mosaic'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         if self._insar.endingSwath-self._insar.startingSwath+1 == 1:
@@ -159,8 +158,7 @@ def runSwathMosaic(self):
         os.chdir(frameDir)
 
         mosaicDir = 'mosaic'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         if self._insar.endingSwath-self._insar.startingSwath+1 == 1:

--- a/components/isceobj/Alos2burstProc/runSwathOffset.py
+++ b/components/isceobj/Alos2burstProc/runSwathOffset.py
@@ -27,8 +27,7 @@ def runSwathOffset(self):
         os.chdir(frameDir)
 
         mosaicDir = 'mosaic'
-        if not os.path.exists(mosaicDir):
-            os.makedirs(mosaicDir)
+        os.makedirs(mosaicDir, exist_ok=True)
         os.chdir(mosaicDir)
 
         if self._insar.endingSwath-self._insar.startingSwath+1 == 1:

--- a/components/isceobj/Alos2burstProc/runUnwrapSnaphuSd.py
+++ b/components/isceobj/Alos2burstProc/runUnwrapSnaphuSd.py
@@ -28,8 +28,7 @@ def runUnwrapSnaphuSd(self):
     #slaveTrack = self._insar.loadTrack(master=False)
 
     sdDir = 'sd'
-    if not os.path.exists(sdDir):
-        os.makedirs(sdDir)
+    os.makedirs(sdDir, exist_ok=True)
     os.chdir(sdDir)
 
 

--- a/components/isceobj/Catalog/Catalog.py
+++ b/components/isceobj/Catalog/Catalog.py
@@ -172,12 +172,7 @@ class Catalog(OrderedDict):
         return the normal value."""
         if self._isLargeList(v):
             # Make the catalog directory if it doesn't already exist
-            try:
-                os.makedirs('catalog')
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    print("Couldn't create directory, 'catalog'! Please check your permissions.")
-                    raise
+            os.makedirs('catalog', exist_ok=True)
             fileName = 'catalog/%s.%s.%03i' % ('.'.join(nodePath), key, Catalog.bigArrayNum)
             Catalog.bigArrayNum += 1
             f = open(fileName, 'w')

--- a/components/isceobj/RtcProc/runPreprocessor.py
+++ b/components/isceobj/RtcProc/runPreprocessor.py
@@ -25,9 +25,7 @@ def runPreprocessor(self):
 
     self.master.configure()
 
-
-    if not os.path.isdir(self.master.output):
-        os.makedirs(self.master.output)
+    os.makedirs(self.master.output, exist_ok=True)
 
 
     slantRangeExtracted = False

--- a/components/isceobj/RtcProc/runTopo.py
+++ b/components/isceobj/RtcProc/runTopo.py
@@ -46,8 +46,7 @@ def runTopo(self, method='legendre'):
     demImg.load(demname + '.xml')
 
 
-    if not os.path.isdir(self._grd.geometryFolder):
-        os.makedirs(self._grd.geometryFolder)
+    os.makedirs(self._grd.geometryFolder, exist_ok=True)
 
 
     #####Run Topo

--- a/components/isceobj/Sensor/TOPS/Sentinel1.py
+++ b/components/isceobj/Sensor/TOPS/Sentinel1.py
@@ -954,14 +954,7 @@ class Sentinel1(Component):
         if length is None:
             length = self.product.bursts[0].numberOfLines
 
-
-        if os.path.isdir(self.output):
-            print('Output directory exists. Overwriting ...')
-#            os.rmdir(self.output)
-        else:
-            print('Creating directory {0} '.format(self.output))
-            os.makedirs(self.output)
-
+        os.makedirs(self.output, exist_ok=True)
 
         prevTiff = None
         for index, burst in enumerate(self.product.bursts):

--- a/components/isceobj/StripmapProc/runCrop.py
+++ b/components/isceobj/StripmapProc/runCrop.py
@@ -190,12 +190,7 @@ def cropFrame(frame, limits, outname, israw=False):
     inname = frame.image.filename
     suffix = os.path.splitext(inname)[1]
     outdirname = os.path.dirname(outname)
-
-    if os.path.isdir(outdirname):
-        print('Output directory already exists. Will be overwritten ....')
-    else:
-        os.makedirs(outdirname)
-        print('Creating {0} directory.'.format(outdirname))
+    os.makedirs(outdirname, exist_ok=True)
 
     indata = IML.mmapFromISCE(inname, logging)
     indata.bands[0][ymin:ymax,xmin*factor:xmax*factor].tofile(outname)

--- a/components/isceobj/StripmapProc/runDenseOffsets.py
+++ b/components/isceobj/StripmapProc/runDenseOffsets.py
@@ -90,10 +90,7 @@ def runDenseOffsets(self):
     slaveSlc = os.path.join(self.insar.coregDirname, self._insar.refinedCoregFilename )
 
     dirname = self.insar.denseOffsetsDirname
-    if os.path.isdir(dirname):
-        logger.info('dense offsets directory {0} already exists.'.format(dirname))
-    else:
-        os.makedirs(dirname)
+    os.makedirs(dirname, exist_ok=True)
 
     denseOffsetFilename = os.path.join(dirname , self.insar.denseOffsetFilename)
 

--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -416,10 +416,7 @@ def runDispersive(self):
         highBandIgram += '.unw'
 
     outputDir = self.insar.ionosphereDirname
-    if os.path.isdir(outputDir):
-        logger.info('Ionosphere directory {0} already exists.'.format(outputDir))
-    else:
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
 
     outDispersive = os.path.join(outputDir, self.insar.dispersiveFilename)
     sigmaDispersive = outDispersive + ".sig"

--- a/components/isceobj/StripmapProc/runGeo2rdr.py
+++ b/components/isceobj/StripmapProc/runGeo2rdr.py
@@ -52,10 +52,7 @@ def runGeo2rdr(self):
     info = self._insar.loadProduct( self._insar.slaveSlcCropProduct)
 
     offsetsDir = self.insar.offsetsDirname 
-    if os.path.isdir(offsetsDir):
-        logger.info('Geometry directory {0} already exists.'.format(offsetsDir))
-    else:
-        os.makedirs(offsetsDir)
+    os.makedirs(offsetsDir, exist_ok=True)
 
     grdr = createGeo2rdr()
     grdr.configure()

--- a/components/isceobj/StripmapProc/runInterferogram.py
+++ b/components/isceobj/StripmapProc/runInterferogram.py
@@ -223,10 +223,7 @@ def subBandIgram(self, masterSlc, slaveSlc, subBandDir,radarWavelength):
 
     ifgDir = os.path.join(self.insar.ifgDirname, subBandDir)
 
-    if os.path.isdir(ifgDir):
-        logger.info('Interferogram directory {0} already exists.'.format(ifgDir))
-    else:
-        os.makedirs(ifgDir)
+    os.makedirs(ifgDir, exist_ok=True)
 
     interferogramName = os.path.join(ifgDir , self.insar.ifgFilename)
 

--- a/components/isceobj/StripmapProc/runPreprocessor.py
+++ b/components/isceobj/StripmapProc/runPreprocessor.py
@@ -64,8 +64,7 @@ def runPreprocessor(self):
     if israwdata:
         print('Master data is in RAW format. Adding _raw to output name.')
         sensor.output = os.path.join(dirname + '_raw', os.path.basename(dirname)+'.raw')
-        if not os.path.isdir( os.path.dirname(sensor.output)):
-            os.makedirs( os.path.dirname(sensor.output))
+        os.makedirs(os.path.dirname(sensor.output), exist_ok=True)
         #sensor._resampleFlag = 'single2dual'
         master = make_raw(sensor, masterdop)
 
@@ -85,9 +84,8 @@ def runPreprocessor(self):
         iszerodop = isZeroDopplerSLC(self.masterSensorName) 
         sensor.output =  os.path.join(dirname + '_slc', os.path.basename(dirname)+'.slc')
 
-        if not os.path.isdir( os.path.dirname(sensor.output)):
-            os.makedirs( os.path.dirname(sensor.output))
-        
+        os.makedirs(os.path.dirname(sensor.output), exist_ok=True)
+
         master = make_raw(sensor, masterdop)
         
         if self._insar.masterSlcProduct is None:
@@ -121,8 +119,7 @@ def runPreprocessor(self):
         print('Slave data is in RAW format. Adding _raw to output name.')
         sensor.output = os.path.join(dirname + '_raw', os.path.basename(dirname)+'.raw')
 
-        if not os.path.isdir( os.path.dirname(sensor.output)):
-            os.makedirs( os.path.dirname(sensor.output))
+        os.makedirs(os.path.dirname(sensor.output), exist_ok=True)
 
         slave = make_raw(sensor, slavedop)
 
@@ -142,8 +139,7 @@ def runPreprocessor(self):
         iszerodop = isZeroDopplerSLC(self.slaveSensorName)
         sensor.output =  os.path.join(dirname + '_slc', os.path.basename(dirname)+'.slc')
 
-        if not os.path.isdir( os.path.dirname(sensor.output)):
-            os.makedirs( os.path.dirname(sensor.output))
+        os.makedirs( os.path.dirname(sensor.output), exist_ok=True)
 
         slave = make_raw(sensor, slavedop)
         

--- a/components/isceobj/StripmapProc/runROI.py
+++ b/components/isceobj/StripmapProc/runROI.py
@@ -235,11 +235,7 @@ def runFormSLC(self):
         outdir = os.path.join(self.master.output + '_slc')
         outname = os.path.join( outdir, os.path.basename(self.master.output) + '.slc')
         xmlname = outdir + '.xml'
-        if not os.path.isdir(outdir):
-            print('Creating directory: {0}'.format(outdir))
-            os.makedirs(outdir)
-        else:
-            print('SLC directory {0} already exists'.format(outdir))
+        os.makedirs(outdir, exist_ok=True)
 
         slcFrame = focus(frame, outname)
 
@@ -260,11 +256,7 @@ def runFormSLC(self):
         outdir = os.path.join(self.slave.output + '_slc')
         outname = os.path.join( outdir, os.path.basename(self.slave.output) + '.slc')
         xmlname = outdir + '.xml'
-        if not os.path.isdir(outdir):
-            print('Creating directory: {0}'.format(outdir))
-            os.makedirs(outdir)
-        else:
-            print('SLC directory {0} already exists'.format(outdir))
+        os.makedirs(outdir, exist_ok=True)
 
         slcFrame = focus(frame, outname)
 

--- a/components/isceobj/StripmapProc/runRefineSlaveTiming.py
+++ b/components/isceobj/StripmapProc/runRefineSlaveTiming.py
@@ -144,11 +144,7 @@ def runRefineSlaveTiming(self):
     print ('*************************************')
 
     misregDir = self.insar.misregDirname
-
-    if os.path.isdir(misregDir):
-        logger.info('mis-registration directory {0} already exists.'.format(misregDir))
-    else:
-        os.makedirs(misregDir)
+    os.makedirs(misregDir, exist_ok=True)
  
     outShelveFile = os.path.join(misregDir, self.insar.misregFilename)
     odb = shelve.open(outShelveFile)

--- a/components/isceobj/StripmapProc/runResampleSlc.py
+++ b/components/isceobj/StripmapProc/runResampleSlc.py
@@ -117,10 +117,7 @@ def runResampleSlc(self, kind='coarse'):
     # preparing the output directory for coregistered slave slc
     coregDir = self.insar.coregDirname
 
-    if os.path.isdir(coregDir):
-        logger.info('Geometry directory {0} already exists.'.format(coregDir))
-    else:
-        os.makedirs(coregDir)
+    os.makedirs(coregDir, exist_ok=True)
 
     # output file name of the coregistered slave slc
     img = slaveFrame.getImage()

--- a/components/isceobj/StripmapProc/runResampleSubbandSlc.py
+++ b/components/isceobj/StripmapProc/runResampleSubbandSlc.py
@@ -83,10 +83,7 @@ def resampleSlc(self,masterFrame, slaveFrame, imageSlc2, radarWavelength, coregD
     # preparing the output directory for coregistered slave slc
     #coregDir = self.insar.coregDirname
 
-    if os.path.isdir(coregDir):
-        logger.info('Geometry directory {0} already exists.'.format(coregDir))
-    else:
-        os.makedirs(coregDir)
+    os.makedirs(coregDir, exist_ok=True)
 
     # output file name of the coregistered slave slc
     img = slaveFrame.getImage() 

--- a/components/isceobj/StripmapProc/runSplitSpectrum.py
+++ b/components/isceobj/StripmapProc/runSplitSpectrum.py
@@ -142,15 +142,8 @@ def runSplitSpectrum(self):
     lowBandDir = os.path.join(self.insar.splitSpectrumDirname, self.insar.lowBandSlcDirname)
     highBandDir = os.path.join(self.insar.splitSpectrumDirname, self.insar.highBandSlcDirname)
 
-    if os.path.isdir(lowBandDir):
-        logger.info('low-band slc directory {0} already exists.'.format(lowBandDir))
-    else:
-        os.makedirs(lowBandDir)
-
-    if os.path.isdir(highBandDir):
-        logger.info('high-band slc directory {0} already exists.'.format(highBandDir))
-    else:
-        os.makedirs(highBandDir)
+    os.makedirs(lowBandDir, exist_ok=True)
+    os.makedirs(highBandDir, exist_ok=True)
 
     masterLowBandSlc = os.path.join(lowBandDir, os.path.basename(masterSlc)) 
     masterHighBandSlc = os.path.join(highBandDir, os.path.basename(masterSlc)) 

--- a/components/isceobj/StripmapProc/runTopo.py
+++ b/components/isceobj/StripmapProc/runTopo.py
@@ -51,10 +51,7 @@ def runTopo(self):
     #IU.copyAttributes(demImage, objDem)
     geometryDir = self.insar.geometryDirname
 
-    if os.path.isdir(geometryDir):
-        logger.info('Geometry directory {0} already exists.'.format(geometryDir))
-    else:
-        os.makedirs(geometryDir)
+    os.makedirs(geometryDir, exist_ok=True)
 
 
     demFilename = self.verifyDEM()

--- a/components/isceobj/TopsProc/runBurstIfg.py
+++ b/components/isceobj/TopsProc/runBurstIfg.py
@@ -168,8 +168,7 @@ def runBurstIfg(self):
             continue
     
         ifgdir = os.path.join(self._insar.fineIfgDirname, 'IW{0}'.format(swath))
-        if not os.path.exists(ifgdir):
-            os.makedirs(ifgdir)
+        os.makedirs(ifgdir, exist_ok=True)
 
         ####Load relevant products
         master = self._insar.loadProduct( os.path.join(self._insar.masterSlcProduct, 'IW{0}.xml'.format(swath)))

--- a/components/isceobj/TopsProc/runCoarseOffsets.py
+++ b/components/isceobj/TopsProc/runCoarseOffsets.py
@@ -99,8 +99,7 @@ def runCoarseOffsets(self):
         ###Offsets output directory
         outdir = os.path.join(self._insar.coarseOffsetsDirname, self._insar.overlapsSubDirname, 'IW{0}'.format(swath))
 
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
 
         ###Burst indices w.r.t master

--- a/components/isceobj/TopsProc/runCoarseResamp.py
+++ b/components/isceobj/TopsProc/runCoarseResamp.py
@@ -103,8 +103,7 @@ def runCoarseResamp(self):
 
         ###Output directory for coregistered SLCs
         outdir = os.path.join(self._insar.coarseCoregDirname, self._insar.overlapsSubDirname, 'IW{0}'.format(swath))
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
     
         ###Directory with offsets

--- a/components/isceobj/TopsProc/runFineOffsets.py
+++ b/components/isceobj/TopsProc/runFineOffsets.py
@@ -200,8 +200,7 @@ def runFineOffsets(self):
         ###Offsets output directory
         outdir = os.path.join(self._insar.fineOffsetsDirname, 'IW{0}'.format(swath))
 
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
 
         ###Burst indices w.r.t master

--- a/components/isceobj/TopsProc/runFineResamp.py
+++ b/components/isceobj/TopsProc/runFineResamp.py
@@ -207,8 +207,7 @@ def runFineResamp(self):
 
         ###Output directory for coregistered SLCs
         outdir = os.path.join(self._insar.fineCoregDirname, 'IW{0}'.format(swath))
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
     
         ###Directory with offsets

--- a/components/isceobj/TopsProc/runIon.py
+++ b/components/isceobj/TopsProc/runIon.py
@@ -413,11 +413,9 @@ def subband(self, ionParam):
 
         #create dirs
         lowerDir = os.path.join(ionParam.ionDirname, ionParam.lowerDirname, ionParam.fineIfgDirname, 'IW{0}'.format(swath))
-        if not os.path.isdir(lowerDir):
-            os.makedirs(lowerDir)
         upperDir = os.path.join(ionParam.ionDirname, ionParam.upperDirname, ionParam.fineIfgDirname, 'IW{0}'.format(swath))
-        if not os.path.isdir(upperDir):
-            os.makedirs(upperDir)
+        os.makedirs(lowerDir, exist_ok=True)
+        os.makedirs(upperDir, exist_ok=True)
 
         ##############################################################
         #for resampling
@@ -732,8 +730,7 @@ def merge(self, ionParam):
             frames.append(ifg)
             burstList.append([os.path.join(burstDirname, 'IW{0}'.format(swath),  'burst_%02d.int'%(x+1)) for x in range(minBurst, maxBurst)])
 
-        if not os.path.isdir(mergeDirname):
-            os.makedirs(mergeDirname)
+        os.makedirs(mergeDirname, exist_ok=True)
 
         suffix = '.full'
         if (ionParam.numberRangeLooks0 == 1) and (ionParam.numberAzimuthLooks0 == 1):
@@ -940,8 +937,7 @@ def multilook_unw(self, ionParam, mergedDirname):
         procdir = os.path.join(ionParam.ionDirname, dirx, mergedDirname)
         #create a directory for original files
         oridir = os.path.join(procdir, oridir0)
-        if not os.path.isdir(oridir):
-            os.makedirs(oridir)
+        os.makedirs(oridir, exist_ok=True)
         #move files, renameFile uses os.rename, which overwrites if file already exists in oridir. This can support re-run
         filename0 = os.path.join(procdir, self._insar.mergedIfgname)
         filename  = os.path.join(oridir, self._insar.mergedIfgname)
@@ -1293,8 +1289,7 @@ def ionosphere(self, ionParam):
 
     #dump ionosphere
     outDir = os.path.join(ionParam.ionDirname, ionParam.ioncalDirname)
-    if not os.path.isdir(outDir):
-        os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
     outFilename = os.path.join(outDir, ionParam.ionRawNoProj)
     ion = np.zeros((length*2, width), dtype=np.float32)
     ion[0:length*2:2, :] = amp
@@ -1434,8 +1429,7 @@ def ionSwathBySwath(self, ionParam):
         for dirx in dirs:
             outputFilename = self._insar.mergedIfgname
             outputDirname = os.path.join(ionParam.ionDirname, dirx, ionParam.mergedDirname + '_IW{0}'.format(swath))
-            if not os.path.isdir(outputDirname):
-                os.makedirs(outputDirname)
+            os.makedirs(outputDirname, exist_ok=True)
             suffix = '.full'
             if (numberRangeLooks0 == 1) and (numberAzimuthLooks0 == 1):
                 suffix=''
@@ -1561,8 +1555,7 @@ def ionSwathBySwath(self, ionParam):
 
         #dump result
         outDir = os.path.join(ionParam.ionDirname, ionParam.ioncalDirname + '_IW{0}'.format(swath))
-        if not os.path.isdir(outDir):
-            os.makedirs(outDir)
+        os.makedirs(outDir, exist_ok=True)
         outFilename = os.path.join(outDir, ionParam.ionRawNoProj)
         ion = np.zeros((length*2, width), dtype=np.float32)
         ion[0:length*2:2, :] = amp
@@ -1635,8 +1628,7 @@ def ionSwathBySwath(self, ionParam):
 
     #dump ionosphere
     outDir = os.path.join(ionParam.ionDirname, ionParam.ioncalDirname)
-    if not os.path.isdir(outDir):
-        os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
     outFilename = os.path.join(outDir, ionParam.ionRawNoProj)
     ion = np.zeros((length*2, width), dtype=np.float32)
     ion[0:length*2:2, :] = ampMerged
@@ -2197,8 +2189,7 @@ def ion2grd(self, ionParam):
         nburst = len(frames[i].bursts)
         ###output directory for burst ionosphere
         outdir = os.path.join(ionParam.ionDirname, ionParam.ionBurstDirname, 'IW{0}'.format(swathList2[i]))
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
         for j in range(nburst):
             #according to runBurstIfg.py, this is originally from self._insar.masterSlcProduct, 'IW{0}.xml'
@@ -2565,8 +2556,7 @@ def esd_noion(self, ionParam):
 
 
         sdir = os.path.join(ionParam.ionDirname, esddir, 'IW{0}'.format(swath))
-        if not os.path.exists(sdir):
-            os.makedirs(sdir)
+        os.makedirs(sdir, exist_ok=True)
 
         #use mis-registration estimated from esd to compute phase error
         for ii in range(minBurst, maxBurst):

--- a/components/isceobj/TopsProc/runMergeBursts.py
+++ b/components/isceobj/TopsProc/runMergeBursts.py
@@ -719,8 +719,7 @@ def runMergeBursts(self, adjust=1):
     # STEP 2. MERGE BURSTS
     #########################################
     mergedir = self._insar.mergedDirname
-    if not os.path.isdir(mergedir):
-        os.makedirs(mergedir)
+    os.makedirs(mergedir, exist_ok=True)
     if (self.numberRangeLooks == 1) and (self.numberAzimuthLooks==1):
         suffix = ''
     else:

--- a/components/isceobj/TopsProc/runMergeSLCs.py
+++ b/components/isceobj/TopsProc/runMergeSLCs.py
@@ -28,8 +28,7 @@ def runMergeSLCs(self):
     mSlcList = [os.path.join(self._insar.masterSlcProduct, 'burst_%02d.slc'%(x+1)) for x in range(minBurst, maxBurst)]
     sSlcList = [os.path.join(self._insar.fineCoregDirname, 'burst_%02d.slc'%(x+1)) for x in range(minBurst, maxBurst)]
     mergedir = self._insar.mergedDirname
-    if not os.path.isdir(mergedir):
-        os.makedirs(mergedir)
+    os.makedirs(mergedir, exist_ok=True)
 
     suffix = '.full'
     if (self.numberRangeLooks == 1) and (self.numberAzimuthLooks==1):

--- a/components/isceobj/TopsProc/runOverlapIfg.py
+++ b/components/isceobj/TopsProc/runOverlapIfg.py
@@ -128,8 +128,7 @@ def runOverlapIfg(self):
         nBurst = maxBurst - minBurst
 
         ifgdir = os.path.join( self._insar.coarseIfgDirname, self._insar.overlapsSubDirname, 'IW{0}'.format(swath))
-        if not os.path.exists(ifgdir):
-            os.makedirs(ifgdir)
+        os.makedirs(ifgdir, exist_ok=True)
 
         ####All indexing is w.r.t stack master for overlaps
         maxBurst = maxBurst - 1

--- a/components/isceobj/TopsProc/runPrepESD.py
+++ b/components/isceobj/TopsProc/runPrepESD.py
@@ -245,8 +245,7 @@ def runPrepESD(self):
 
         ####Create ESD output directory
         esddir = self._insar.esdDirname
-        if not os.path.isdir(esddir):
-            os.makedirs(esddir)
+        os.makedirs(esddir, exist_ok=True)
 
         ####Overlap offsets directory
         offdir = os.path.join( self._insar.coarseOffsetsDirname, self._insar.overlapsSubDirname, 'IW{0}'.format(swath))

--- a/components/isceobj/TopsProc/runSubsetOverlaps.py
+++ b/components/isceobj/TopsProc/runSubsetOverlaps.py
@@ -105,18 +105,8 @@ def runSubsetOverlaps(self):
         outdir = os.path.join(self._insar.geometryDirname, self._insar.overlapsSubDirname, 'IW{0}'.format(swath))
         submasterdir = os.path.join(self._insar.masterSlcProduct, self._insar.overlapsSubDirname, 'IW{0}'.format(swath)) 
 
-
-        if os.path.isdir(outdir):
-            logger.info('Overlap directory {0} already exists'.format(outdir))
-        else:
-            os.makedirs(outdir)
-
-
-        if os.path.isdir(submasterdir):
-            logger.info('Submaster Overlap directory {0} already exists'.format(submasterdir))
-        else:
-            os.makedirs(submasterdir)
-
+        os.makedirs(outdir, exist_ok=True)
+        os.makedirs(submasterdir, exist_ok=True)
 
         ###Azimuth time interval
         dt = mFrame.bursts[0].azimuthTimeInterval        

--- a/components/isceobj/TopsProc/runTopo.py
+++ b/components/isceobj/TopsProc/runTopo.py
@@ -47,15 +47,9 @@ def runTopoCPU(self):
         if numCommon > 0:
             catalog.addItem('Number of common bursts IW-{0}'.format(swath), self._insar.numberOfCommonBursts[swath-1], 'topo')
 
-    
             ###Check if geometry directory already exists.
             dirname = os.path.join(self._insar.geometryDirname, 'IW{0}'.format(swath))
-
-            if os.path.isdir(dirname):
-                logger.info('Geometry directory {0} already exists.'.format(dirname))
-            else:
-                os.makedirs(dirname)
-
+            os.makedirs(dirname, exist_ok=True)
 
             ###For each burst
             for index in range(numCommon):
@@ -201,11 +195,8 @@ def runTopoGPU(self):
     slantRangeImage.createPoly2D()
 
 
-
-
     dirname = self._insar.geometryDirname
-    if not os.path.isdir(dirname):
-        os.makedirs(dirname)
+    os.makedirs(dirname, exist_ok=True)
 
 
     latImage = isceobj.createImage()
@@ -321,9 +312,7 @@ def runTopoGPU(self):
     for swath, frame, istart in zip(swaths, frames, swathStarts):
         outname = os.path.join(dirname, 'IW{0}'.format(swath))
 
-        if not os.path.isdir(outname):
-            os.makedirs(outname)
-
+        os.makedirs(outname, exist_ok=True)
 
         for ind, burst in enumerate(frame.bursts):
             top = int(np.rint((burst.sensingStart - t0).total_seconds()/dt))

--- a/components/iscesys/DataRetriever/DataRetriever.py
+++ b/components/iscesys/DataRetriever/DataRetriever.py
@@ -127,11 +127,7 @@ class DataRetriever(Component):
     # @param listFile \c list of the filenames to be retrieved.
 
     def getFiles(self,listFile):
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
         #curl with -O downloads in working dir, so save cwd
         cwd = os.getcwd()
         #move to _downloadDir

--- a/configuration/buildHelper.py
+++ b/configuration/buildHelper.py
@@ -7,11 +7,7 @@ tmpdump = 'tmpdump.json'
 def createHelp(env,factoryFile,installDir):
     #jng: try to have scons handle all the creation but could not figure out how
     #     so handled dir creation manually
-    try:
-        os.makedirs(env['HELPER_BUILD_DIR'])
-    except:
-        # already exists
-        pass
+    os.makedirs(env['HELPER_BUILD_DIR'], exist_ok=True)
     try:
         #one could probably also use __import__ but needs to make sure the
         #the cwd is prepended to the sys.path otherwise if factoryFile = __init__.py

--- a/contrib/demUtils/demstitcher/DemStitcher.py
+++ b/contrib/demUtils/demstitcher/DemStitcher.py
@@ -352,11 +352,7 @@ class DemStitcher(Component):
             self._downloadDir = downloadDir
 
         if not (downloadDir) is  None:
-            try:
-                os.makedirs(downloadDir)
-            except:
-                #dir already exists
-                pass
+            os.makedirs(downloadDir, exist_ok=True)
         if region:
             regionList = region
         #region unknown, so try all of them
@@ -636,11 +632,7 @@ class DemStitcher(Component):
         else:
             delta = 1/3600.0
 
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
 
         width = self.getDemWidth(lon,source)
         demImage.initImage(outname,'read',width)
@@ -702,11 +694,7 @@ class DemStitcher(Component):
         demImage = self.createImage(lat,lon,source,outname)
 
         dict = {'WIDTH':demImage.width,'LENGTH':demImage.length,'X_FIRST':demImage.coord1.coordStart,'Y_FIRST':demImage.coord2.coordStart,'X_STEP':demImage.coord1.coordDelta,'Y_STEP':-demImage.coord2.coordDelta,'X_UNIT':'degrees','Y_UNIT':'degrees'}
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
         extension = '.rsc'
         outfile = outname + extension
         fp = open(outfile,'w')

--- a/contrib/demUtils/demstitcher/DemStitcherV3.py
+++ b/contrib/demUtils/demstitcher/DemStitcherV3.py
@@ -139,12 +139,8 @@ class DemStitcher(DS):
         else:
             self._downloadDir = downloadDir
 
-        if not (downloadDir) is  None:
-            try:
-                os.makedirs(downloadDir)
-            except:
-                #dir already exists
-                pass
+        if downloadDir is not None:
+            os.makedirs(downloadDir, exist_ok=True)
         for fileNow in listFile:
             url = self.getFullHttp(source)
             opener = urllib.request.URLopener()

--- a/contrib/demUtils/swbdstitcher/SWBDStitcher.py
+++ b/contrib/demUtils/swbdstitcher/SWBDStitcher.py
@@ -131,11 +131,7 @@ class SWBDStitcher(DemStitcher):
 
         delta = 1/3600.0
 
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
 
         width = self.getDemWidth(lon,1)
         image.initImage(outname,'read',width,'BYTE')
@@ -168,12 +164,8 @@ class SWBDStitcher(DemStitcher):
         else:
             self._downloadDir = downloadDir
 
-        if not (downloadDir) is  None:
-            try:
-                os.makedirs(downloadDir)
-            except:
-                #dir already exists
-                pass
+        if downloadDir is not None:
+            os.makedirs(downloadDir, exist_ok=True)
         for fileNow in listFile:
             url = self.getFullHttp(source)
             opener = urllib.request.URLopener()

--- a/contrib/demUtils/watermask/WaterMask.py
+++ b/contrib/demUtils/watermask/WaterMask.py
@@ -452,12 +452,8 @@ class MaskStitcher(Component):
         else:
             self._downloadDir = downloadDir
 
-        if not (downloadDir) is  None:
-            try:
-                os.makedirs(downloadDir)
-            except:
-                #dir already exists
-                pass
+        if downloadDir is not None:
+            os.makedirs(downloadDir, exist_ok=True)
         if region:
             regionList = region
         #region unknown, so try all of them
@@ -664,11 +660,7 @@ class MaskStitcher(Component):
 
         demImage = createDemImage()
 
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
 
         width = self._width
         demImage.initImage(outname,'read',width)
@@ -732,11 +724,7 @@ class MaskStitcher(Component):
         demImage = self.createImage(lat,lon,outname)
 
         dict = {'WIDTH':demImage.width,'LENGTH':demImage.length,'X_FIRST':demImage.coord1.coordStart,'Y_FIRST':demImage.coord2.coordStart,'X_STEP':demImage.coord1.coordDelta,'Y_STEP':-demImage.coord2.coordDelta,'X_UNIT':'degrees','Y_UNIT':'degrees'}
-        try:
-            os.makedirs(self._downloadDir)
-        except:
-            #dir already exists
-            pass
+        os.makedirs(self._downloadDir, exist_ok=True)
         extension = '.rsc'
         outfile = os.path.join(self._downloadDir,outname + extension)
         fp = open(outfile,'w')

--- a/contrib/stack/stripmapStack/MaskAndFilter.py
+++ b/contrib/stack/stripmapStack/MaskAndFilter.py
@@ -259,8 +259,7 @@ def main(iargs=None):
 
     inps = cmdLineParse(iargs)
 
-    if not os.path.exists(inps.outDir):
-        os.makedirs(inps.outD)
+    os.makedirs(inps.outD, exist_ok=True)
 
     #######################
     # masking the dense offsets based on SNR and median filter the masked offs

--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -285,15 +285,13 @@ class run(object):
         for k in inps.__dict__.keys():
             setattr(self, k, inps.__dict__[k])
         self.runDir = os.path.join(self.workDir, 'run_files')
-        if not os.path.exists(self.runDir):
-            os.makedirs(self.runDir)
+        os.makedirs(self.runDir, exist_ok=True)
 
         self.run_outname = os.path.join(self.runDir, runName)
         print ('writing ', self.run_outname)
 
         self.configDir = os.path.join(self.workDir,'configs')
-        if not os.path.exists(self.configDir):
-            os.makedirs(self.configDir)
+        os.makedirs(self.configDir, exist_ok=True)
 
         # passing argument of started from raw
         if inps.nofocus is  False:
@@ -690,8 +688,7 @@ def baselinePair(baselineDir, master, slave,doBaselines=True):
 def baselineStack(inps,stackMaster,acqDates,doBaselines=True):
     from collections import OrderedDict
     baselineDir = os.path.join(inps.workDir,'baselines')
-    if not os.path.exists(baselineDir):
-        os.makedirs(baselineDir)
+    os.makedirs(baselineDir, exist_ok=True)
     baselineDict = OrderedDict()
     timeDict = OrderedDict()
     datefmt = '%Y%m%d'

--- a/contrib/stack/stripmapStack/baselineGrid.py
+++ b/contrib/stack/stripmapStack/baselineGrid.py
@@ -57,8 +57,7 @@ def main(iargs=None):
 
     baselineDir = os.path.dirname(inps.baselineFile)
     if baselineDir != '':
-        if not os.path.exists(baselineDir):
-            os.makedirs(baselineDir)
+        os.makedirs(baselineDir, exist_ok=True)
 
 
     with shelve.open(os.path.join(inps.master, 'data'), flag='r') as mdb:

--- a/contrib/stack/stripmapStack/cropFrame.py
+++ b/contrib/stack/stripmapStack/cropFrame.py
@@ -224,12 +224,7 @@ def cropFrame(frame, limits, outdir, israw=False):
     suffix = os.path.splitext(inname)[1]
     outname = os.path.join(outdir, os.path.basename(inname)) #+ suffix
     outdirname = os.path.dirname(outname)
-
-    if os.path.isdir(outdirname):
-        print('Output directory already exists. Will be overwritten ....')
-    else:
-        os.makedirs(outdirname)
-        print('Creating {0} directory.'.format(outdirname))
+    os.makedirs(outdirname, exist_ok=True)
 
     indata = IML.mmapFromISCE(inname, logging)
     indata.bands[0][ymin:ymax,xmin*factor:xmax*factor].tofile(outname)

--- a/contrib/stack/stripmapStack/crossmul.py
+++ b/contrib/stack/stripmapStack/crossmul.py
@@ -91,8 +91,7 @@ def main(iargs=None):
     img2 = isceobj.createImage()
     img2.load(inps.slave + '.xml')
 
-    if not os.path.exists(os.path.dirname(inps.prefix)):
-       os.makedirs(os.path.dirname(inps.prefix))
+    os.makedirs(os.path.dirname(inps.prefix), exist_ok=True)
 
     run(img1, img2, inps.prefix, inps.azlooks, inps.rglooks)
 

--- a/contrib/stack/stripmapStack/denseOffsets.py
+++ b/contrib/stack/stripmapStack/denseOffsets.py
@@ -127,9 +127,8 @@ def main(iargs=None):
 
     inps = cmdLineParse(iargs)
     outDir = os.path.dirname(inps.outprefix)
-    if not os.path.exists(outDir):
-         os.makedirs(outDir)
-    
+    os.makedirs(outDir, exist_ok=True)
+
     objOffset = estimateOffsetField(inps.master, inps.slave, inps)
 
     

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -523,14 +523,11 @@ def main(iargs=None):
     print(inps.highBandconncomp)
 
     # generate the output directory if it does not exist yet, and back-up the shelve files
-    if not os.path.exists(inps.outDir):
-       os.makedirs(inps.outDir)
+    os.makedirs(inps.outDir, exist_ok=True)
     lowBandShelve = os.path.join(inps.outDir, 'lowBandShelve')
     highBandShelve = os.path.join(inps.outDir, 'highBandShelve')
-    if not os.path.exists(lowBandShelve):
-       os.makedirs(lowBandShelve)
-    if not os.path.exists(highBandShelve):
-       os.makedirs(highBandShelve)
+    os.makedirs(lowBandShelve, exist_ok=True)
+    os.makedirs(highBandShelve, exist_ok=True)
     cmdCp = 'cp ' + inps.lowBandShelve + '* ' + lowBandShelve
     os.system(cmdCp)
     cmdCp = 'cp ' + inps.highBandShelve + '* ' + highBandShelve
@@ -542,10 +539,7 @@ def main(iargs=None):
  
     '''
     outputDir = self.insar.ionosphereDirname
-    if os.path.isdir(outputDir):
-        logger.info('Ionosphere directory {0} already exists.'.format(outputDir))
-    else:
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
     '''
 
     outDispersive = os.path.join(inps.outDir, 'iono.bil')

--- a/contrib/stack/stripmapStack/geo2rdr.py
+++ b/contrib/stack/stripmapStack/geo2rdr.py
@@ -304,8 +304,7 @@ def main(iargs=None):
     lonImage.load(os.path.join(inps.geom, 'lon.rdr.xml'))
     lonImage.setAccessMode('read')
 
-    if not os.path.isdir(inps.outdir):
-        os.makedirs(inps.outdir)
+    os.makedirs(inps.outdir, exist_ok=True)
 
     
     azoff = 0.0

--- a/contrib/stack/stripmapStack/invertMisreg.py
+++ b/contrib/stack/stripmapStack/invertMisreg.py
@@ -136,8 +136,7 @@ def design_matrix(pairDirs):
 def main(iargs=None):
 
   inps = cmdLineParse(iargs)
-  if not os.path.exists(inps.output):
-      os.makedirs(inps.output)
+  os.makedirs(inps.output, exist_ok=True)
 
   pairDirs = glob.glob(os.path.join(inps.input,'*'))
   polyInfo = getPolyInfo(pairDirs[0])
@@ -185,8 +184,7 @@ def main(iargs=None):
      azpoly.initPoly(rangeOrder=polyInfo['azrgOrder'], azimuthOrder=polyInfo['azazOrder'], coeffs=azCoefs)
      rgpoly.initPoly(rangeOrder=polyInfo['rgrgOrder'], azimuthOrder=polyInfo['rgazOrder'], coeffs=rgCoefs)
 
-     if not os.path.exists(os.path.join(inps.output,dateList[i])):
-         os.makedirs(os.path.join(inps.output,dateList[i]))
+     os.makedirs(os.path.join(inps.output,dateList[i]), exist_ok=True)
 
      odb = shelve.open(os.path.join(inps.output,dateList[i]+'/misreg'))
      odb['azpoly'] = azpoly

--- a/contrib/stack/stripmapStack/invertOffsets.py
+++ b/contrib/stack/stripmapStack/invertOffsets.py
@@ -272,8 +272,7 @@ def writeDateOffsets(inps, h5File):
         d = dateList[i].decode("utf-8")
         d = datetime.datetime(*time.strptime(d,"%Y-%m-%d %H:%M:%S")[0:6]).strftime('%Y%m%d')
         outDir = os.path.join(inps.output, d)
-        if not os.path.exists(outDir):
-           os.makedirs(outDir)
+        os.makedirs(outDir, exist_ok=True)
         outName = os.path.join(outDir , d + '.bil')
         write(ds[i,:,:], outName, 1, 6)
  #       outName = os.path.join(outDir , d + '_snr.bil')
@@ -351,8 +350,7 @@ def getChunks(Ny,Nx, chunk_y, chunk_x):
 def main(iargs=None):
 
   inps = cmdLineParse(iargs)
-  if not os.path.exists(inps.output):
-      os.makedirs(inps.output)
+  os.makedirs(inps.output, exist_ok=True)
 
   h5File = write2h5(inps) 
 

--- a/contrib/stack/stripmapStack/masterStackCopy.py
+++ b/contrib/stack/stripmapStack/masterStackCopy.py
@@ -38,18 +38,14 @@ def main(iargs=None):
     # making the output direcory is non-existent
     outDir = os.path.dirname(inps.output_slc)
     inDir = os.path.dirname(inps.input_slc)
-    if not os.path.exists(outDir):
-       os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
 
     # copying shelf files as backup
     masterShelveDir = os.path.join(outDir, 'masterShelve')
     slaveShelveDir = os.path.join(outDir, 'slaveShelve')
 
-    if not os.path.exists(masterShelveDir):
-       os.makedirs(masterShelveDir)
-
-    if not os.path.exists(slaveShelveDir):
-       os.makedirs(slaveShelveDir)
+    os.makedirs(masterShelveDir, exist_ok=True)
+    os.makedirs(slaveShelveDir, exist_ok=True)
 
 
     cmd = 'cp '+ inDir + '/data* ' + slaveShelveDir

--- a/contrib/stack/stripmapStack/prepRawALOS.py
+++ b/contrib/stack/stripmapStack/prepRawALOS.py
@@ -130,8 +130,7 @@ def main(iargs=None):
 
                 # put failed files in a seperate directory
                 if not successflag_unzip:
-                    if not os.path.isdir(os.path.join(workdir,'FAILED_FILES')):
-                        os.makedirs(os.path.join(workdir,'FAILED_FILES'))
+                    os.makedirs(os.path.join(workdir,'FAILED_FILES'), exist_ok=True)
                     os.rename(ALOS_infilefolder,os.path.join(workdir,'FAILED_FILES','.'))
                 else:
                     # check if file needs to be removed or put in archive folder
@@ -139,8 +138,7 @@ def main(iargs=None):
                         os.remove(ALOS_infilefolder)
                         print('Deleting: ' + ALOS_infilefolder)
                     else:
-                        if not os.path.isdir(os.path.join(workdir,'ARCHIVED_FILES')):
-                            os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'))
+                        os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'), exist_ok=True)
                         cmd  = 'mv ' + ALOS_infilefolder + ' ' + os.path.join(workdir,'ARCHIVED_FILES','.')
                         os.system(cmd)
 
@@ -175,9 +173,8 @@ def main(iargs=None):
         if successflag:
             # move the file into the date folder
             SLC_dir = os.path.join(workdir,imgDate,'')
-            if not os.path.isdir(SLC_dir):
-                os.makedirs(SLC_dir)
-                
+            os.makedirs(SLC_dir, exist_ok=True)
+
             # check if the folder already exist in that case overwrite it
             ALOS_folder_out = os.path.join(SLC_dir,os.path.basename(ALOS_folder))
             if os.path.isdir(ALOS_folder_out):
@@ -200,8 +197,7 @@ def main(iargs=None):
             if len(AlosFiles)>0:
                 acquisitionDate = os.path.basename(dateDir)
                 slcDir = os.path.join(inps.outputDir, acquisitionDate)
-                if not os.path.exists(slcDir):
-                    os.makedirs(slcDir)     
+                os.makedirs(slcDir, exist_ok=True)
                 cmd = 'unpackFrame_ALOS_raw.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
                 IMG_files = glob.glob(os.path.join(AlosFiles[0],'IMG*'))
                 if inps.fbd2fbs:

--- a/contrib/stack/stripmapStack/prepRawCSK.py
+++ b/contrib/stack/stripmapStack/prepRawCSK.py
@@ -96,20 +96,18 @@ def main(iargs=None):
 
                 # put failed files in a seperate directory
                 if not successflag_unzip:
-                    if not os.path.isdir(os.path.join(workdir,'FAILED_FILES')):
-                        os.makedirs(os.path.join(workdir,'FAILED_FILES'))
+                    os.makedirs(os.path.join(workdir,'FAILED_FILES'), exist_ok=True)
                     os.rename(CSK_infilefolder,os.path.join(workdir,'FAILED_FILES','.'))
                 else:
                     # check if file needs to be removed or put in archive folder
-                    if rmfile:                                                                                                                                   
+                    if rmfile:
                         os.remove(CSK_infilefolder)
                         print('Deleting: ' + CSL_infilefolder)
                     else:
-                        if not os.path.isdir(os.path.join(workdir,'ARCHIVED_FILES')):
-                            os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'))
+                        os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'), exist_ok=True)
                         cmd  = 'mv ' + CSK_infilefolder + ' ' + os.path.join(workdir,'ARCHIVED_FILES','.')
                         os.system(cmd)
-                                                                                                                                      
+
         # loop over the different CSK folders and make sure the folder names are consistent.
         # this step is not needed unless the user has manually unzipped data before.
         CSK_folders = glob.glob(os.path.join(inputDir, 'EL*'))
@@ -138,9 +136,8 @@ def main(iargs=None):
         if successflag:
             # move the file into the date folder
             SLC_dir = os.path.join(workdir,imgDate,'')
-            if not os.path.isdir(SLC_dir):
-                os.makedirs(SLC_dir)
-                
+            os.makedirs(SLC_dir, exist_ok=True)
+
             # check if the folder already exist in that case overwrite it
             CSK_folder_out = os.path.join(SLC_dir,os.path.basename(CSK_folder))
             if os.path.isdir(CSK_folder_out):
@@ -176,8 +173,7 @@ def main(iargs=None):
             if len(CSKFiles)>0:
                 acquisitionDate = os.path.basename(dateDir)
                 slcDir = os.path.join(outputDir, acquisitionDate)
-                if not os.path.exists(slcDir):
-                    os.makedirs(slcDir)     
+                os.makedirs(slcDir, exist_ok=True)
                 cmd = 'unpackFrame_CSK_raw.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
                 print (cmd)
                 f.write(inps.text_cmd + cmd+'\n')
@@ -188,8 +184,7 @@ def main(iargs=None):
             if len(CSKFiles)>0:
                acquisitionDate = os.path.basename(dateDir)
                slcDir = os.path.join(outputDir, acquisitionDate)
-               if not os.path.exists(slcDir):
-                  os.makedirs(slcDir)     
+               os.makedirs(slcDir, exist_ok=True)
                cmd = 'unpackFrame_CSK_raw.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
 
                if len(CSKFiles) > 1:

--- a/contrib/stack/stripmapStack/prepSlcALOS2.py
+++ b/contrib/stack/stripmapStack/prepSlcALOS2.py
@@ -130,8 +130,7 @@ def main(iargs=None):
                 # put failed files in a seperate directory
                 if not successflag_unzip:
                     dir_failed = os.path.join(workdir,'FAILED_FILES')
-                    if not os.path.isdir(dir_failed):
-                        os.makedirs(dir_failed)
+                    os.makedirs(dir_failed, exist_ok=True)
                     cmd = 'mv {} {}'.format(fname, dir_failed)
                     os.system(cmd)
                 else:
@@ -141,8 +140,7 @@ def main(iargs=None):
                         print('Deleting: ' + fname)
                     else:
                         dir_archive = os.path.join(workdir,'ARCHIVED_FILES')
-                        if not os.path.isdir(dir_archive):
-                            os.makedirs(dir_archive)
+                        os.makedirs(dir_archive, exist_ok=True)
                         cmd = 'mv {} {}'.format(fname, dir_archive)
                         os.system(cmd)
 
@@ -177,9 +175,8 @@ def main(iargs=None):
         if successflag:
             # move the file into the date folder
             SLC_dir = os.path.join(workdir,imgDate,'')
-            if not os.path.isdir(SLC_dir):
-                os.makedirs(SLC_dir)
-                
+            os.makedirs(SLC_dir, exist_ok=True)
+
             # check if the folder already exist in that case overwrite it
             ALOS_folder_out = os.path.join(SLC_dir,os.path.basename(ALOS_folder))
             if os.path.isdir(ALOS_folder_out):
@@ -203,8 +200,7 @@ def main(iargs=None):
             if len(AlosFiles)>0:
                 acquisitionDate = os.path.basename(dateDir)
                 slcDir = os.path.join(inps.outputDir, acquisitionDate)
-                if not os.path.exists(slcDir):
-                    os.makedirs(slcDir)     
+                os.makedirs(slcDir, exist_ok=True)
                 cmd = 'unpackFrame_ALOS2.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
                 print (cmd)
                 f.write(inps.text_cmd + cmd+'\n')

--- a/contrib/stack/stripmapStack/prepSlcRSAT2.py
+++ b/contrib/stack/stripmapStack/prepSlcRSAT2.py
@@ -104,8 +104,7 @@ def main(iargs=None):
 
                 # put failed files in a seperate directory
                 if not successflag_unzip:
-                    if not os.path.isdir(os.path.join(workdir,'FAILED_FILES')):
-                        os.makedirs(os.path.join(workdir,'FAILED_FILES'))
+                    os.makedirs(os.path.join(workdir,'FAILED_FILES'), exist_ok=True)
                     os.rename(RSAT2_infilefolder,os.path.join(workdir,'FAILED_FILES','.'))
                 else:
                     # check if file needs to be removed or put in archive folder
@@ -113,8 +112,7 @@ def main(iargs=None):
                         os.remove(RSAT2_infilefolder)
                         print('Deleting: ' + RSAT2_infilefolder)
                     else:
-                        if not os.path.isdir(os.path.join(workdir,'ARCHIVED_FILES')):
-                            os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'))
+                        os.makedirs(os.path.join(workdir,'ARCHIVED_FILES'), exist_ok=True)
                         cmd  = 'mv ' + RSAT2_infilefolder + ' ' + os.path.join(workdir,'ARCHIVED_FILES','.')
                         os.system(cmd)
 
@@ -166,8 +164,7 @@ def main(iargs=None):
             if len(RSAT2Files)>0:
                 acquisitionDate = os.path.basename(dateDir)
                 slcDir = os.path.join(outputDir, acquisitionDate)
-                if not os.path.exists(slcDir):
-                    os.makedirs(slcDir)     
+                os.makedirs(slcDir, exist_ok=True)
                 cmd = 'unpackFrame_RSAT2.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
                 print (cmd)
                 f.write(inps.text_cmd + cmd+'\n')

--- a/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
@@ -76,8 +76,7 @@ def main(iargs=None):
         annFile = file.replace('_s'+inps.segment+'_1x1.slc','')+'.ann'
         print (annFile)
         imgDir = os.path.join(outputDir,imgDate)
-        if not os.path.exists(imgDir):
-           os.makedirs(imgDir)
+        os.makedirs(imgDir, exist_ok=True)
 
         cmd = 'unpackFrame_UAVSAR.py -i ' + annFile  + ' -d '+ inps.dopFile + ' -o ' + imgDir
         print (cmd)

--- a/contrib/stack/stripmapStack/refineSlaveTiming.py
+++ b/contrib/stack/stripmapStack/refineSlaveTiming.py
@@ -180,13 +180,11 @@ def main(iargs=None):
         os.remove(inps.outfile)
 
     outDir = os.path.dirname(inps.outfile)
-    if not os.path.exists(outDir):
-        os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
 
     if inps.metamaster is not None:
         masterShelveDir = os.path.join(outDir, 'masterShelve')
-        if not os.path.exists(masterShelveDir):
-            os.makedirs(masterShelveDir)
+        os.makedirs(masterShelveDir, exist_ok=True)
 
         cmd = 'cp ' + inps.metamaster + '/data* ' + masterShelveDir
         os.system(cmd)
@@ -194,8 +192,7 @@ def main(iargs=None):
 
     if inps.metaslave is not None:
         slaveShelveDir = os.path.join(outDir, 'slaveShelve')
-        if not os.path.exists(slaveShelveDir):
-            os.makedirs(slaveShelveDir)
+        os.makedirs(slaveShelveDir, exist_ok=True)
         cmd = 'cp ' + inps.metaslave + '/data* ' + slaveShelveDir
         os.system(cmd)
 

--- a/contrib/stack/stripmapStack/resampleSlc.py
+++ b/contrib/stack/stripmapStack/resampleSlc.py
@@ -136,8 +136,7 @@ def resampSlave(burst, offdir, outname, doppler, azpoly, rgpoly,
     imgOut.setWidth(width)
 
     outdir = os.path.dirname(outname)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
+    os.makedirs(outdir, exist_ok=True)
 
     if zero:
         imgOut.filename = os.path.join(outname)
@@ -171,17 +170,13 @@ def main(iargs=None):
 
     outfile = os.path.join(inps.coreg,os.path.basename(inps.coreg) + '.slc')
     outDir = inps.coreg
-    if not os.path.exists(outDir):
-       os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
 
     masterShelveDir = os.path.join(outDir, 'masterShelve')
     slaveShelveDir = os.path.join(outDir, 'slaveShelve')
 
-    if not os.path.exists(masterShelveDir):
-       os.makedirs(masterShelveDir)
-
-    if not os.path.exists(slaveShelveDir):
-       os.makedirs(slaveShelveDir)
+    os.makedirs(masterShelveDir, exist_ok=True)
+    os.makedirs(slaveShelveDir, exist_ok=True)
 
     cmd = 'cp '+ inps.slave + '/data* ' + slaveShelveDir
     print (cmd)

--- a/contrib/stack/stripmapStack/resampleSlc_subBand.py
+++ b/contrib/stack/stripmapStack/resampleSlc_subBand.py
@@ -138,8 +138,7 @@ def resampSlave(burst, offdir, outname, doppler, azpoly, rgpoly,
     imgOut.setWidth(width)
 
     outdir = os.path.dirname(outname)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
+    os.makedirs(outdir, exist_ok=True)
 
     if zero:
         imgOut.filename = os.path.join(outname)
@@ -174,17 +173,15 @@ def main(iargs=None):
 
     outfile = os.path.join(inps.coreg,os.path.basename(os.path.dirname(inps.coreg))+'.slc')
     outDir = inps.coreg
-    if not os.path.exists(outDir):
-       os.makedirs(outDir)
+    os.makedirs(outDir, exist_ok=True)
 
     masterShelveDir = os.path.join(outDir, 'masterShelve')
     slaveShelveDir = os.path.join(outDir, 'slaveShelve')
 
-    if (not os.path.exists(masterShelveDir)) and (inps.master is not None ):
-       os.makedirs(masterShelveDir)
+    if inps.master is not None:
+       os.makedirs(masterShelveDir, exist_ok=True)
 
-    if not os.path.exists(slaveShelveDir):
-       os.makedirs(slaveShelveDir)
+    os.makedirs(slaveShelveDir, exist_ok=True)
 
     cmd = 'cp '+ inps.slave + '/data* ' + slaveShelveDir
     print (cmd)

--- a/contrib/stack/stripmapStack/rubberSheeting.py
+++ b/contrib/stack/stripmapStack/rubberSheeting.py
@@ -252,9 +252,8 @@ def main(iargs=None):
         #######################
         cmd = 'isce2gis.py envi -i ' + inps.geometryAzimuthOffset
         os.system(cmd)
-        
-        if not os.path.exists(inps.outDir):
-            os.makedirs(inps.outDir)
+
+        os.makedirs(inps.outDir, exist_ok=True)
 
         #######################
         # masking the dense offsets based on SNR and median filter the masked offsets
@@ -286,9 +285,8 @@ def main(iargs=None):
         #######################
         cmd = 'isce2gis.py envi -i ' + inps.geometryRangeOffset
         os.system(cmd)
-        
-        if not os.path.exists(inps.outDir):
-            os.makedirs(inps.outDir)
+
+        os.makedirs(inps.outDir, exist_ok=True)
         #######################
         # masking the dense offsets based on SNR and median filter the masked offsets
 

--- a/contrib/stack/stripmapStack/splitSpectrum.py
+++ b/contrib/stack/stripmapStack/splitSpectrum.py
@@ -138,11 +138,8 @@ def main(iargs=None):
         outDirH = os.path.join(inps.outDir,'HighBand')
         outDirL = os.path.join(inps.outDir,'LowBand')
 
-        if not os.path.exists(outDirH):
-           os.makedirs(outDirH)
-
-        if not os.path.exists(outDirL):
-           os.makedirs(outDirL)
+        os.makedirs(outDirH, exist_ok=True)
+        os.makedirs(outDirL, exist_ok=True)
 
         fullBandSlc = os.path.basename(inps.slc)
         lowBandSlc = os.path.join(outDirL, fullBandSlc)

--- a/contrib/stack/stripmapStack/splitSpectrum_multiple.py
+++ b/contrib/stack/stripmapStack/splitSpectrum_multiple.py
@@ -78,12 +78,8 @@ def extractSubBands(slc, frame, dcL, dcH, bw, LowBand, HighBand, width, outDir):
 
     outDirH = os.path.join(outDir, HighBand)
     outDirL = os.path.join(outDir, LowBand)
-
-    if not os.path.exists(outDirH):
-        os.makedirs(outDirH)
-
-    if not os.path.exists(outDirL):
-        os.makedirs(outDirL)
+    os.makedirs(outDirH, exist_ok=True)
+    os.makedirs(outDirL, exist_ok=True)
 
     fullBandSlc = os.path.basename(slc)
     lowBandSlc = os.path.join(outDirL, fullBandSlc)

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -319,11 +319,9 @@ def main(iargs=None):
   # getting the acquisitions
   acquisitionDates, stackMasterDate, slaveDates = get_dates(inps)
   configDir = os.path.join(inps.workDir,'configs')
-  if not os.path.exists(configDir):
-       os.makedirs(configDir)
+  os.makedirs(configDir, exist_ok=True)
   runDir = os.path.join(inps.workDir,'run_files')
-  if not os.path.exists(runDir):
-       os.makedirs(runDir)
+  os.makedirs(runDir, exist_ok=True)
 
   if inps.sensor.lower() == 'uavsar_stack':    # don't try to calculate baselines for UAVSAR_STACK data
     pairs = selectPairs(inps,stackMasterDate, slaveDates, acquisitionDates,doBaselines=False)

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -59,9 +59,7 @@ def runTopoGPU(info, demImage, dop=None, nativedop=False, legendre=False):
     ## TODO GPU does not support shadow and layover and local inc file generation
     full = False
 
-
-    if not os.path.isdir(info.outdir):
-        os.makedirs(info.outdir)
+    os.makedirs(info.outdir, exist_ok=True)
 
     # define variables to be used later on
     r0 = info.rangeFirstSample + ((info.numberRangeLooks - 1)/2) * info.slantRangePixelSpacing
@@ -281,8 +279,7 @@ def runTopoCPU(info, demImage, dop=None,
     from zerodop.topozero import createTopozero
     from isceobj.Planet.Planet import Planet
 
-    if not os.path.isdir(info.outdir):
-        os.makedirs(info.outdir)
+    os.makedirs(info.outdir, exist_ok=True)
 
     #####Run Topo
     planet = Planet(pname='Earth')
@@ -366,9 +363,7 @@ def runMultilook(in_dir, out_dir, alks, rlks):
     from iscesys.Parsers.FileParserFactory import createFileParser
     FP = createFileParser('xml')
 
-    if not os.path.isdir(out_dir):
-        os.makedirs(out_dir)
-        print('create directory: {}'.format(out_dir))
+    os.makedirs(out_dir, exist_ok=True)
 
     for fbase in ['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']:
         fname = '{}.rdr'.format(fbase)
@@ -407,9 +402,7 @@ def runMultilookGdal(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr',
     import gdal
 
     # create 'geom_master' directory
-    if not os.path.isdir(out_dir):
-        os.makedirs(out_dir)
-        print('create directory: {}'.format(out_dir))
+    os.makedirs(out_dir, exist_ok=True)
 
     # multilook files one by one
     for fbase in fbase_list:

--- a/contrib/stack/stripmapStack/uncompressFile.py
+++ b/contrib/stack/stripmapStack/uncompressFile.py
@@ -84,8 +84,7 @@ def uncompressfile(inputFile,outputDir):
 
 
     # make the output directory if it does not exist 
-    if not os.path.exists(outputDir):
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
 
 
     ## loop over the different options, and if fail try the second one

--- a/contrib/stack/stripmapStack/unpackFrame_ALOS_raw.py
+++ b/contrib/stack/stripmapStack/unpackFrame_ALOS_raw.py
@@ -38,8 +38,7 @@ def unpack(hdf5, slcname, multiple=False):
     '''
     Unpack HDF5 to binary SLC file.
     '''
-    if not os.path.isdir(slcname):
-        os.makedirs(slcname)
+    os.makedirs(slcname, exist_ok=True)
 
     date = os.path.basename(slcname)
     obj = createSensor('ALOS')

--- a/contrib/stack/stripmapStack/unwrap.py
+++ b/contrib/stack/stripmapStack/unwrap.py
@@ -305,8 +305,7 @@ def main(iargs=None):
     if inps.method != 'icu':
     
         masterShelveDir = os.path.join(interferogramDir , 'masterShelve')
-        if not os.path.exists(masterShelveDir):
-            os.makedirs(masterShelveDir)
+        os.makedirs(masterShelveDir, exist_ok=True)
 
         inps.master = os.path.dirname(inps.master)
         cpCmd='cp ' + os.path.join(inps.master, 'data*') +' '+masterShelveDir

--- a/contrib/stack/topsStack/MaskAndFilter.py
+++ b/contrib/stack/topsStack/MaskAndFilter.py
@@ -203,9 +203,8 @@ def main(iargs=None):
         #######################
         #cmd = 'isce2gis.py envi -i ' + inps.geometryAzimuthOffset
         #os.system(cmd)
-        
-        if not os.path.exists(inps.outDir):
-            os.makedirs(inps.outDir)
+
+        os.makedirs(inps.outDir, exist_ok=True)
 
         #######################
         # masking the dense offsets based on SNR and median filter the masked offsets
@@ -230,9 +229,8 @@ def main(iargs=None):
         #######################
         #cmd = 'isce2gis.py envi -i ' + inps.geometryRangeOffset
         #os.system(cmd)
-        
-        if not os.path.exists(inps.outDir):
-            os.makedirs(inps.outDir)
+
+        os.makedirs(inps.outDir, exist_ok=True)
         #######################
         # masking the dense offsets based on SNR and median filter the masked offsets
 

--- a/contrib/stack/topsStack/Stack.py
+++ b/contrib/stack/topsStack/Stack.py
@@ -267,22 +267,19 @@ class run(object):
         for k in inps.__dict__.keys():
             setattr(self, k, inps.__dict__[k])
         self.runDir = os.path.join(self.work_dir, 'run_files')
-        if not os.path.exists(self.runDir):
-            os.makedirs(self.runDir)
+        os.makedirs(self.runDir, exist_ok=True)
 
         self.run_outname = os.path.join(self.runDir, runName)
         print ('writing ', self.run_outname)
 
         self.config_path = os.path.join(self.work_dir,'configs')
-        if not os.path.exists(self.config_path):
-            os.makedirs(self.config_path)
+        os.makedirs(self.config_path, exist_ok=True)
 
         self.runf= open(self.run_outname,'w')
 
     def unpackSLC(self, acquisitionDates, safe_dict):
         swath_path = self.work_dir
-        if not os.path.exists(self.config_path):
-            os.makedirs(self.config_path)
+        os.makedirs(self.config_path, exist_ok=True)
 
         for slcdate in acquisitionDates:
             configName = os.path.join(self.config_path,'config_'+slcdate)
@@ -303,8 +300,7 @@ class run(object):
 
     def unpackStackMasterSLC(self, safe_dict):
         swath_path = self.work_dir
-        if not os.path.exists(self.config_path):
-            os.makedirs(self.config_path)
+        os.makedirs(self.config_path, exist_ok=True)
         configName = os.path.join(self.config_path,'config_master')
         configObj = config(configName)
         configObj.configure(self)

--- a/contrib/stack/topsStack/baselineGrid.py
+++ b/contrib/stack/topsStack/baselineGrid.py
@@ -73,8 +73,7 @@ def main(iargs=None):
     #catalog = isceobj.Catalog.createCatalog(self._insar.procDoc.name)
     baselineDir = os.path.dirname(inps.baselineFile)
     if baselineDir != '':
-        if not os.path.exists(baselineDir):
-            os.makedirs(baselineDir)
+        os.makedirs(baselineDir, exist_ok=True)
 
     masterswaths = []
     slaveswaths = []

--- a/contrib/stack/topsStack/computeBaseline.py
+++ b/contrib/stack/topsStack/computeBaseline.py
@@ -54,8 +54,7 @@ def main(iargs=None):
 
     #catalog = isceobj.Catalog.createCatalog(self._insar.procDoc.name)
     baselineDir = os.path.dirname(inps.baselineFile)
-    if not os.path.exists(baselineDir):
-        os.makedirs(baselineDir)
+    os.makedirs(baselineDir, exist_ok=True)
 
     f = open(inps.baselineFile , 'w')
 

--- a/contrib/stack/topsStack/cuDenseOffsets.py
+++ b/contrib/stack/topsStack/cuDenseOffsets.py
@@ -303,9 +303,8 @@ def main(iargs=None):
     inps = cmdLineParse(iargs)
     outDir = os.path.dirname(inps.outprefix)
     print(inps.outprefix)
-    if not os.path.exists(outDir):
-         os.makedirs(outDir)
-    
+    os.makedirs(outDir, exist_ok=True)
+
     objOffset = estimateOffsetField(inps.master, inps.slave, inps)
 
 if __name__ == '__main__':

--- a/contrib/stack/topsStack/denseOffsets.py
+++ b/contrib/stack/topsStack/denseOffsets.py
@@ -136,9 +136,8 @@ def main(iargs=None):
 
     inps = cmdLineParse(iargs)
     outDir = os.path.dirname(inps.outprefix)
-    if not os.path.exists(outDir):
-         os.makedirs(outDir)
-    
+    os.makedirs(outDir, exist_ok=True)
+
     objOffset = estimateOffsetField(inps.master, inps.slave, inps)
 
     

--- a/contrib/stack/topsStack/estimateAzimuthMisreg.py
+++ b/contrib/stack/topsStack/estimateAzimuthMisreg.py
@@ -174,8 +174,7 @@ def main(iargs=None):
 #    slaveTimingCorrection = medianval * master.bursts[0].azimuthTimeInterval
 
     outputDir = os.path.dirname(inps.output)
-    if not os.path.exists(outputDir):
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
 
     with open(inps.output, 'w') as f:
          f.write('median : '+str(medianval) +'\n')

--- a/contrib/stack/topsStack/estimateRangeMisreg.py
+++ b/contrib/stack/topsStack/estimateRangeMisreg.py
@@ -208,8 +208,7 @@ def main(iargs=None):
     center = 0.5*(bins[:-1] + bins[1:])
 
     outputDir = os.path.dirname(inps.output)
-    if not os.path.exists(outputDir):
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
 
     try:
         import matplotlib as mpl

--- a/contrib/stack/topsStack/extractCommonValidRegion.py
+++ b/contrib/stack/topsStack/extractCommonValidRegion.py
@@ -99,8 +99,7 @@ def main(iargs=None):
 
         print('writing ', os.path.join(stackDir , 'IW{0}.xml'.format(swath)))
         ut.saveProduct(topMaster, os.path.join(stackDir , 'IW{0}.xml'.format(swath)))
-        if not os.path.exists(os.path.join(stackDir ,'IW{0}'.format(swath))):
-            os.makedirs(os.path.join(stackDir ,'IW{0}'.format(swath)))
+        os.makedirs(os.path.join(stackDir ,'IW{0}'.format(swath)), exist_ok=True)
 
 
 if __name__ == '__main__':

--- a/contrib/stack/topsStack/generateIgram.py
+++ b/contrib/stack/topsStack/generateIgram.py
@@ -125,12 +125,11 @@ def main(iargs=None):
     for swath in swathList:
         IWstr = 'IW{0}'.format(swath)
         if inps.overlap:
-            ifgdir = os.path.join(inps.interferogram, 'overlap', 'IW{0}'.format(swath))
+            ifgdir = os.path.join(inps.interferogram, 'overlap', IWstr)
         else:
-            ifgdir = os.path.join(inps.interferogram, 'IW{0}'.format(swath))
-            
-        if not os.path.exists(ifgdir):
-                os.makedirs(ifgdir)
+            ifgdir = os.path.join(inps.interferogram, IWstr)
+
+        os.makedirs(ifgdir, exist_ok=True)
 
     ####Load relevant products
         if inps.overlap:

--- a/contrib/stack/topsStack/geo2rdr.py
+++ b/contrib/stack/topsStack/geo2rdr.py
@@ -232,8 +232,7 @@ def main(iargs=None):
         else:
             outdir = os.path.join(inps.coregdir, 'IW{0}'.format(swath))
 
-        if not os.path.isdir(outdir):
-           os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
         if os.path.exists(str(inps.misreg_az)):
             with open(inps.misreg_az, 'r') as f:

--- a/contrib/stack/topsStack/invertMisreg.py
+++ b/contrib/stack/topsStack/invertMisreg.py
@@ -107,8 +107,7 @@ def design_matrix(overlapDirs):
 def main(iargs=None):
 
   inps = cmdLineParse(iargs)
-  if not os.path.exists(inps.output):
-      os.makedirs(inps.output)
+  os.makedirs(inps.output, exist_ok=True)
 
   overlapPairs = glob.glob(os.path.join(inps.input,'*/*.txt'))
 

--- a/contrib/stack/topsStack/mergeBursts.py
+++ b/contrib/stack/topsStack/mergeBursts.py
@@ -391,7 +391,7 @@ def main(iargs=None):
 
     mergedir = os.path.dirname(inps.outfile)
     os.makedirs(mergedir, exist_ok=True)
-    
+
     suffix = '.full'
     if (inps.numberRangeLooks == 1) and (inps.numberAzimuthLooks==1):
         suffix=''

--- a/contrib/stack/topsStack/overlap_withDEM.py
+++ b/contrib/stack/topsStack/overlap_withDEM.py
@@ -278,8 +278,7 @@ def main(iargs=None):
 
         ####Create ESD output directory
         esddir = os.path.join(inps.overlap, IWstr)
-        if not os.path.isdir(esddir):
-            os.makedirs(esddir)
+        os.makedirs(esddir, exist_ok=True)
 
         ####Overlap offsets directory
         masterOffdir = os.path.join(inps.master, IWstr)

--- a/contrib/stack/topsStack/resamp_withCarrier.py
+++ b/contrib/stack/topsStack/resamp_withCarrier.py
@@ -140,8 +140,7 @@ def main(iargs=None):
         else:
             outdir = os.path.join(inps.coreg, inps.overlapDir, 'IW{0}'.format(swath))
             offdir = os.path.join(inps.coreg, inps.overlapDir, 'IW{0}'.format(swath))
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
     
         ####Indices w.r.t master

--- a/contrib/stack/topsStack/topo.py
+++ b/contrib/stack/topsStack/topo.py
@@ -92,11 +92,7 @@ def main(iargs=None):
     
         ###Check if geometry directory already exists.
         dirname = os.path.join(inps.geom_masterDir, 'IW{0}'.format(swath))
-
-        if os.path.isdir(dirname):
-            print('Geometry directory {0} already exists.'.format(dirname))
-        else:
-            os.makedirs(dirname)
+        os.makedirs(dirname, exist_ok=True)
 
         for ind in range(master.numberOfBursts):
             inputs.append((dirname, demImage, master, ind))


### PR DESCRIPTION
@falkamelung noted a race condition in #106 due to non-atomic directory
checking followed by os.makedirs. This pattern exists in many places
in the codebase so I went ahead and replaced the rest of them.
The new exist_ok usage should be terser and more idiomatic.