### PR TITLE
stripmapStack/topo: call gdal2isce_xml.py inside runMultilook() if xml file missing

### DIFF
--- a/contrib/stack/stripmapStack/crossmul.py
+++ b/contrib/stack/stripmapStack/crossmul.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-import isce
+
+
 import os
-import logging
-from components.stdproc.stdproc import crossmul
-import isceobj
-from iscesys.ImageUtil.ImageUtil import ImageUtil as IU
-import isceobj
 import argparse
+import logging
+
+import isce
+import isceobj
+from components.stdproc.stdproc import crossmul
+from iscesys.ImageUtil.ImageUtil import ImageUtil as IU
+
 
 def createParser():
 

--- a/contrib/stack/stripmapStack/resampleSlc.py
+++ b/contrib/stack/stripmapStack/resampleSlc.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
+import os
+import argparse
+import shelve
+import json
+import logging
+import numpy as np
+
 import isce
 import isceobj
 import stdproc
 from stdproc.stdproc import crossmul
-import numpy as np
-from isceobj.Util.Poly2D import Poly2D
-import argparse
-import os
-import shelve
-from iscesys.ImageUtil.ImageUtil import ImageUtil as IU
-import json
-import logging
 from isceobj.Util.decorators import use_api
+from isceobj.Util.Poly2D import Poly2D
+from iscesys.ImageUtil.ImageUtil import ImageUtil as IU
 
 def createParser():
     parser = argparse.ArgumentParser( description='Use polynomial offsets and create burst by burst interferograms')

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -366,7 +366,12 @@ def runMultilook(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr', met
     from iscesys.Parsers.FileParserFactory import createFileParser
     from mroipac.looks.Looks import Looks
 
-    print('generate multilooked geometry files with alks={} and rlks={}'.format(alks, rlks))
+    msg = 'generate multilooked geometry files with alks={} and rlks={}'.format(alks, rlks)
+    if method == 'isce':
+        msg += ' using mroipac.looks.Looks() ...'
+    else:
+        msg += ' using gdal.Translate() ...'
+    print('-'*50+'\n'+msg)
 
     # create 'geom_master' directory
     os.makedirs(out_dir, exist_ok=True)
@@ -377,6 +382,7 @@ def runMultilook(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr', met
         out_file = os.path.join(out_dir, '{}{}'.format(fbase, out_ext))
 
         if all(os.path.isfile(in_file+ext) for ext in ['','.vrt','.xml']):
+            print('multilook {}'.format(in_file))
 
             # option 1 - Looks module (isce)
             if method == 'isce':
@@ -407,10 +413,9 @@ def runMultilook(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr', met
                 src_wid = out_wid * rlks
                 src_len = out_len * alks
 
-                cmd = 'gdal_translate -of ENVI -a_nodata 0 -outsize {ox} {oy} '.format(ox=out_wid, oy=out_len)
-                cmd += ' -srcwin 0 0 {sx} {sy} {fi} {fo} '.format(sx=src_wid, sy=src_len, fi=in_file, fo=out_file)
-                print(cmd)
-                os.system(cmd)
+                options_str = '-of ENVI -a_nodata 0 -outsize {ox} {oy} -srcwin 0 0 {sx} {sy} '.format(
+                    ox=out_wid, oy=out_len, sx=src_wid, sy=src_len)
+                gdal.Translate(out_file, ds, options=options_str)
 
                 # generate ISCE .xml file
                 if not os.path.isfile(out_file+'.xml'):

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -6,11 +6,12 @@ import shelve
 import datetime
 import shutil
 import numpy as np
+import gdal
 import isce
 import isceobj
 from isceobj.Constants import SPEED_OF_LIGHT
 from isceobj.Util.Poly2D import Poly2D
-from mroipac.looks.Looks import Looks
+
 
 def createParser():
     '''
@@ -49,12 +50,11 @@ class Dummy(object):
 
 def runTopoGPU(info, demImage, dop=None, nativedop=False, legendre=False):
 
-    from isceobj.Planet.Planet import Planet
-    from zerodop.GPUtopozero.GPUtopozero import PyTopozero
     from isceobj import Constants as CN
+    from isceobj.Planet.Planet import Planet
     from isceobj.Util.Poly2D import Poly2D
     from iscesys import DateTimeUtil as DTU
-
+    from zerodop.GPUtopozero.GPUtopozero import PyTopozero
 
     ## TODO GPU does not support shadow and layover and local inc file generation
     full = False
@@ -358,48 +358,15 @@ def runSimamp(outdir, hname='z.rdr'):
     return
 
 
-def runMultilook(in_dir, out_dir, alks, rlks):
-    print('generate multilooked geometry files with alks={} and rlks={}'.format(alks, rlks))
+def runMultilook(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr', method='gdal',
+                 fbase_list=['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']):
+    """
+    Multilook geometry files.
+    """
     from iscesys.Parsers.FileParserFactory import createFileParser
-    FP = createFileParser('xml')
+    from mroipac.looks.Looks import Looks
 
-    os.makedirs(out_dir, exist_ok=True)
-
-    for fbase in ['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']:
-        fname = '{}.rdr'.format(fbase)
-        in_file = os.path.join(in_dir, fname)
-        out_file = os.path.join(out_dir, fname)
-
-        if os.path.isfile(in_file):
-            xmlProp = FP.parse(in_file+'.xml')[0]
-            if('image_type' in xmlProp and xmlProp['image_type'] == 'dem'):
-                inImage = isceobj.createDemImage()
-            else:
-                inImage = isceobj.createImage()
-
-            inImage.load(in_file+'.xml')
-            inImage.filename = in_file
-
-            lkObj = Looks()
-            lkObj.setDownLooks(alks)
-            lkObj.setAcrossLooks(rlks)
-            lkObj.setInputImage(inImage)
-            lkObj.setOutputFilename(out_file)
-            lkObj.looks()
-
-            # copy the full resolution xml/vrt file from ./merged/geom_master to ./geom_master
-            # to facilitate the number of looks extraction
-            # the file path inside .xml file is not, but should, updated
-            shutil.copy(in_file+'.xml', out_file+'.full.xml')
-            shutil.copy(in_file+'.vrt', out_file+'.full.vrt')
-
-    return out_dir
-
-
-def runMultilookGdal(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr',
-                     fbase_list=['hgt', 'incLocal', 'lat', 'lon', 'los', 'shadowMask', 'waterMask']):
     print('generate multilooked geometry files with alks={} and rlks={}'.format(alks, rlks))
-    import gdal
 
     # create 'geom_master' directory
     os.makedirs(out_dir, exist_ok=True)
@@ -409,20 +376,50 @@ def runMultilookGdal(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr',
         in_file = os.path.join(in_dir, '{}{}'.format(fbase, in_ext))
         out_file = os.path.join(out_dir, '{}{}'.format(fbase, out_ext))
 
-        if os.path.isfile(in_file):
-            ds = gdal.Open(in_file, gdal.GA_ReadOnly)
-            in_wid = ds.RasterXSize
-            in_len = ds.RasterYSize
+        if all(os.path.isfile(in_file+ext) for ext in ['','.vrt','.xml']):
 
-            out_wid = int(in_wid / rlks)
-            out_len = int(in_len / alks)
-            src_wid = out_wid * rlks
-            src_len = out_len * alks
+            # option 1 - Looks module (isce)
+            if method == 'isce':
+                xmlProp = createFileParser('xml').parse(in_file+'.xml')[0]
+                if('image_type' in xmlProp and xmlProp['image_type'] == 'dem'):
+                    inImage = isceobj.createDemImage()
+                else:
+                    inImage = isceobj.createImage()
 
-            cmd = 'gdal_translate -of ENVI -a_nodata 0 -outsize {ox} {oy} '.format(ox=out_wid, oy=out_len)
-            cmd += ' -srcwin 0 0 {sx} {sy} {fi} {fo} '.format(sx=src_wid, sy=src_len, fi=in_file, fo=out_file)
-            print(cmd)
-            os.system(cmd)
+                inImage.load(in_file+'.xml')
+                inImage.filename = in_file
+
+                lkObj = Looks()
+                lkObj.setDownLooks(alks)
+                lkObj.setAcrossLooks(rlks)
+                lkObj.setInputImage(inImage)
+                lkObj.setOutputFilename(out_file)
+                lkObj.looks()
+
+            # option 2 - gdal_translate (gdal)
+            elif method == 'gdal':
+                ds = gdal.Open(in_file, gdal.GA_ReadOnly)
+                in_wid = ds.RasterXSize
+                in_len = ds.RasterYSize
+
+                out_wid = int(in_wid / rlks)
+                out_len = int(in_len / alks)
+                src_wid = out_wid * rlks
+                src_len = out_len * alks
+
+                cmd = 'gdal_translate -of ENVI -a_nodata 0 -outsize {ox} {oy} '.format(ox=out_wid, oy=out_len)
+                cmd += ' -srcwin 0 0 {sx} {sy} {fi} {fo} '.format(sx=src_wid, sy=src_len, fi=in_file, fo=out_file)
+                print(cmd)
+                os.system(cmd)
+
+                # generate ISCE .xml file
+                if not os.path.isfile(out_file+'.xml'):
+                    cmd = 'gdal2isce_xml.py -i {}.vrt'.format(out_file)
+                    print(cmd)
+                    os.system(cmd)
+
+            else:
+                raise ValueError('un-supported multilook method: {}'.format(method))
 
             # copy the full resolution xml/vrt file from ./merged/geom_master to ./geom_master
             # to facilitate the number of looks extraction
@@ -521,8 +518,7 @@ def main(iargs=None):
     # write multilooked geometry files in "geom_master" directory, same level as "Igrams"
     if inps.rlks * inps.rlks > 1:
         out_dir = os.path.join(os.path.dirname(os.path.dirname(info.outdir)), 'geom_master')
-        runMultilookGdal(in_dir=info.outdir, out_dir=out_dir, alks=inps.alks, rlks=inps.rlks)
-        #runMultilook(in_dir=info.outdir, out_dir=out_dir, alks=inps.alks, rlks=inps.rlks)
+        runMultilook(in_dir=info.outdir, out_dir=out_dir, alks=inps.alks, rlks=inps.rlks)
 
     return
 


### PR DESCRIPTION
This PR fixes the bug of sometimes missing xml files during runMultilook() with gdal. Detailed changes are as below:

+ topo: merge runMultilookGdal() into runMultilook() with new argument "method" to control to use isce Looks module (averaging) or gdal_translate (extraction; default, same as before).

+ topo: call gdal2isce_xml.py so that xml file for multilooked data are always generate. This fix the warning message from gdal_translate: "Warning 1: Geotransform matrix has non rotational terms"

+ topo: skip multilooking if the data file has vrt/xml file missing, which sometimes happens to incLocal and shadowMask (don't know the cause yet; I used GPU version).

+ crossmul/resampleSlc: re-organize module import at the top of scripts