### PR TITLE
stripmapStack: expose --polarization, --filter_strength of "0" and --unw_method of "no"

### DIFF
--- a/contrib/stack/stripmapStack/FilterAndCoherence.py
+++ b/contrib/stack/stripmapStack/FilterAndCoherence.py
@@ -28,13 +28,13 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-
 import logging
 import isce
 import isceobj
 import argparse
 import os
 logger = logging.getLogger('isce.tops.runFilter')
+
 
 def runFilter(infile, outfile, filterStrength):
     from mroipac.filter.Filter import Filter
@@ -61,10 +61,11 @@ def runFilter(infile, outfile, filterStrength):
 
     intImage.finalizeImage()
     filtImage.finalizeImage()
-   
+
 
 def estCoherence(outfile, corfile):
     from mroipac.icu.Icu import Icu
+    logger.info("Estimating spatial coherence based phase sigma")
 
     #Create phase sigma correlation file here
     filtImage = isceobj.createIntImage()
@@ -110,6 +111,7 @@ def createParser():
 
     return parser
 
+
 def cmdLineParse(iargs=None):
     parser = createParser()
     return parser.parse_args(args=iargs)
@@ -121,7 +123,11 @@ def main(iargs=None):
     if inps.filtfile is None:
         inps.filtfile = 'filt_' + inps.infile
 
-    runFilter(inps.infile, inps.filtfile, inps.filterstrength)
+    if inps.filterstrength <= 0.:
+        inps.filtfile = inps.infile
+        logger.info('input filter strength "{}" <= 0, skip filtering.'.format(inps.filterstrength))
+    else:
+        runFilter(inps.infile, inps.filtfile, inps.filterstrength)
 
     estCoherence(inps.filtfile, inps.cohfile)
 

--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -614,10 +614,15 @@ class run(object):
                                             pair[0] + '_'  + pair[1])
 
             configObj.generateIgram('[Function-1]')
+
             configObj.igram = configObj.outDir+'.int'
-            configObj.filtIgram = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.int'
-            configObj.coherence = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.cor'
-            #configObj.filtStrength = filtStrength
+            if float(configObj.filtStrength) > 0.:
+                configObj.filtIgram = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.int'
+                configObj.coherence = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.cor'
+            else:
+                # do not add prefix filt_ to output file if no filtering is applied.
+                configObj.filtIgram = os.path.dirname(configObj.outDir) + '/' + pair[0] + '_'  + pair[1] + '.int'
+                configObj.coherence = os.path.dirname(configObj.outDir) + '/' + pair[0] + '_'  + pair[1] + '.cor'
             configObj.filterCoherence('[Function-2]')
 
             # skip phase unwrapping if input method == no

--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -598,12 +598,14 @@ class run(object):
              #configObj.filtStrength = filtStrength
              configObj.filterCoherence('[Function-2]')
 
-             configObj.igram = configObj.filtIgram
-             configObj.unwIfg = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] 
-             configObj.noMCF = noMCF
-             configObj.master = os.path.join(self.slcDir,stackMaster +'/data') 
-             configObj.defoMax = defoMax
-             configObj.unwrap('[Function-3]')
+             # skip phase unwrapping if input method == no
+             if self.unwMethod.lower() != 'no':
+                 configObj.igram = configObj.filtIgram
+                 configObj.unwIfg = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] 
+                 configObj.noMCF = noMCF
+                 configObj.master = os.path.join(self.slcDir,stackMaster +'/data') 
+                 configObj.defoMax = defoMax
+                 configObj.unwrap('[Function-3]')
 
              configObj.finalize()
              self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')

--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -12,27 +12,28 @@ import isce
 import isceobj
 from mroipac.baseline.Baseline import Baseline
 
+
 filtStrength = '0.8'
 noMCF = 'False'
 defoMax = '2'
 maxNodes = 72
 
-    
+
 class config(object):
     """
        A class representing the config file
     """
     def __init__(self, outname):
-       self.f= open(outname,'w')
-       self.f.write('[Common]'+'\n')
-       self.f.write('')
-       self.f.write('##########################'+'\n')
+        self.f= open(outname,'w')
+        self.f.write('[Common]'+'\n')
+        self.f.write('')
+        self.f.write('##########################'+'\n')
 
     def configure(self,inps):
-       for k in inps.__dict__.keys():
-           setattr(self, k, inps.__dict__[k])
-       self.plot = 'False'
-       self.misreg = None
+        for k in inps.__dict__.keys():
+            setattr(self, k, inps.__dict__[k])
+        self.plot = 'False'
+        self.misreg = None
 
     def cropFrame(self, function):
         self.f.write('##########################'+'\n')
@@ -112,7 +113,7 @@ class config(object):
         self.f.write('coreg : ' + self.coregSlaveSlc +'\n')
         self.f.write('offsets : ' + self.offsetDir +'\n')
         if self.misreg:
-           self.f.write('poly : ' + self.misreg + '\n')
+            self.f.write('poly : ' + self.misreg + '\n')
         self.f.write('##########################'+'\n')
 
     def resampleSlc_subband(self, function):
@@ -124,7 +125,7 @@ class config(object):
         self.f.write('coreg : ' + self.coregSlaveSlc +'\n')
         self.f.write('offsets : ' + self.offsetDir +'\n')
         if self.misreg:
-           self.f.write('poly : ' + self.misreg + '\n')
+            self.f.write('poly : ' + self.misreg + '\n')
         self.f.write('##########################'+'\n')
 
     def baselineGrid(self, function):
@@ -223,9 +224,9 @@ class config(object):
         self.f.write('outDir : ' + self.outDir + '\n')
         self.f.write('shelve : ' + self.shelve + '\n')
         if self.fL and self.fH and self.bandWidth:
-           self.f.write('dcL : ' + self.fL + '\n')
-           self.f.write('dcH : ' + self.fH + '\n')
-           self.f.write('bw : ' + self.bandWidth + '\n')
+            self.f.write('dcL : ' + self.fL + '\n')
+            self.f.write('dcH : ' + self.fH + '\n')
+            self.f.write('bw : ' + self.bandWidth + '\n')
         self.f.write('##########################'+'\n')
    
     def estimateDispersive(self, function):
@@ -257,23 +258,23 @@ class config(object):
 
 def get_dates(inps):
  
-  dirs = glob.glob(inps.slcDir+'/*')
-  acuisitionDates = []
-  for dir in dirs:
-     expectedRaw = os.path.join(dir,os.path.basename(dir) + '.slc')
-     if os.path.exists(expectedRaw):
-        acuisitionDates.append(os.path.basename(dir))
-
-  acuisitionDates.sort()
-  print (dirs)
-  print (acuisitionDates)
-  if inps.masterDate not in acuisitionDates:
-     print ('master date was not found. The first acquisition will be considered as the stack master date.')
-  if inps.masterDate is None or inps.masterDate not in acuisitionDates:
-     inps.masterDate = acuisitionDates[0]
-  slaveDates = acuisitionDates.copy()
-  slaveDates.remove(inps.masterDate)
-  return acuisitionDates, inps.masterDate, slaveDates 
+    dirs = glob.glob(inps.slcDir+'/*')
+    acuisitionDates = []
+    for dir in dirs:
+        expectedRaw = os.path.join(dir,os.path.basename(dir) + '.slc')
+        if os.path.exists(expectedRaw):
+            acuisitionDates.append(os.path.basename(dir))
+  
+    acuisitionDates.sort()
+    print (dirs)
+    print (acuisitionDates)
+    if inps.masterDate not in acuisitionDates:
+        print ('master date was not found. The first acquisition will be considered as the stack master date.')
+    if inps.masterDate is None or inps.masterDate not in acuisitionDates:
+        inps.masterDate = acuisitionDates[0]
+    slaveDates = acuisitionDates.copy()
+    slaveDates.remove(inps.masterDate)
+    return acuisitionDates, inps.masterDate, slaveDates 
   
 class run(object):
     """
@@ -299,7 +300,6 @@ class run(object):
         else:
             self.raw_string = '' 
 
-
         # folder structures
         self.stack_folder = inps.stack_folder
         selfdense_offsets_folder = inps.dense_offsets_folder
@@ -308,16 +308,16 @@ class run(object):
 
     def crop(self, acquisitionDates, config_prefix, native=True, israw=True):
         for d in acquisitionDates:
-             configName = os.path.join(self.configDir, config_prefix + d)
-             configObj = config(configName)
-             configObj.configure(self)
-             configObj.inputDir = os.path.join(self.fullFrameSlcDir, d)
-             configObj.cropOutputDir = os.path.join(self.slcDir, d)
-             configObj.bbox = self.bbox
-             configObj.nativeDoppler = native
-             configObj.israw = israw
-             configObj.cropFrame('[Function-1]')
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir, config_prefix + d)
+            configObj = config(configName)
+            configObj.configure(self)
+            configObj.inputDir = os.path.join(self.fullFrameSlcDir, d)
+            configObj.cropOutputDir = os.path.join(self.slcDir, d)
+            configObj.bbox = self.bbox
+            configObj.nativeDoppler = native
+            configObj.israw = israw
+            configObj.cropFrame('[Function-1]')
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
  
     def master_focus_split_geometry(self, stackMaster, config_prefix, split=False, focus=True, native=True):
         """focusing master and producing geometry files"""
@@ -357,115 +357,121 @@ class run(object):
 
     def slaves_focus_split(self, slaveDates, config_prefix, split=False, focus=True, native=True):
         for slave in slaveDates:
-             configName = os.path.join(self.configDir, config_prefix + '_'+slave)
-             configObj = config(configName)
-             configObj.configure(self)
-             configObj.slcDir = os.path.join(self.slcDir,slave)
-
-             counter=1
-             if focus:
-                 configObj.focus('[Function-{0}]'.format(counter))
-                 counter += 1
-
-             if split:
-                  configObj.slc = os.path.join(configObj.slcDir,slave + self.raw_string + '.slc')
-                  configObj.outDir = configObj.slcDir
-                  configObj.shelve = os.path.join(configObj.slcDir, 'data')
-                  configObj.splitRangeSpectrum('[Function-{0}]'.format(counter))
-
-             configObj.finalize()
-             del configObj
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir, config_prefix + '_'+slave)
+            configObj = config(configName)
+            configObj.configure(self)
+            configObj.slcDir = os.path.join(self.slcDir,slave)
+            counter=1
+            if focus:
+                configObj.focus('[Function-{0}]'.format(counter))
+                counter += 1
+            if split:
+                configObj.slc = os.path.join(configObj.slcDir,slave + self.raw_string + '.slc')
+                configObj.outDir = configObj.slcDir
+                configObj.shelve = os.path.join(configObj.slcDir, 'data')
+                configObj.splitRangeSpectrum('[Function-{0}]'.format(counter))
+            configObj.finalize()
+            del configObj
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
     def slaves_geo2rdr_resampleSlc(self, stackMaster, slaveDates, config_prefix, native=True):
 
         for slave in slaveDates:
-             configName = os.path.join(self.configDir,config_prefix+slave) 
-             configObj = config(configName)
-             configObj.configure(self)
-             configObj.masterSlc = os.path.join(self.slcDir, stackMaster)
-             configObj.slaveSlc = os.path.join(self.slcDir, slave)
-             configObj.geometryDir = os.path.join(self.workDir, self.stack_folder,'geom_master')
-             configObj.offsetDir = os.path.join(self.workDir, 'offsets',slave)
-             configObj.nativeDoppler = native
-
-             configObj.geo2rdr('[Function-1]')
-             configObj.coregSlaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse',slave)
-             configObj.resampleSlc('[Function-2]')
-             configObj.finalize()
-             del configObj
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir,config_prefix+slave) 
+            configObj = config(configName)
+            configObj.configure(self)
+            configObj.masterSlc = os.path.join(self.slcDir, stackMaster)
+            configObj.slaveSlc = os.path.join(self.slcDir, slave)
+            configObj.geometryDir = os.path.join(self.workDir, self.stack_folder,'geom_master')
+            configObj.offsetDir = os.path.join(self.workDir, 'offsets',slave)
+            configObj.nativeDoppler = native
+            configObj.geo2rdr('[Function-1]')
+            configObj.coregSlaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse',slave)
+            configObj.resampleSlc('[Function-2]')
+            configObj.finalize()
+            del configObj
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
 
     def refineSlaveTiming_singleMaster(self, stackMaster, slaveDates, config_prefix):
   
         for slave in slaveDates:
-             configName = os.path.join(self.configDir,config_prefix+slave)
-             configObj = config(configName)  
-             configObj.configure(self)
-             configObj.masterSlc = os.path.join(self.slcDir, stackMaster,stackMaster+self.raw_string+'.slc')
-             configObj.slaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse', slave,slave +'.slc')
-             configObj.masterMetaData = os.path.join(self.slcDir, stackMaster)
-             configObj.slaveMetaData = os.path.join(self.slcDir, slave)
-             configObj.outfile = os.path.join(self.workDir, 'offsets', slave ,'misreg')
-             configObj.refineSlaveTiming('[Function-1]')
-             configObj.finalize()
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir,config_prefix+slave)
+            configObj = config(configName)  
+            configObj.configure(self)
+            configObj.masterSlc = os.path.join(self.slcDir, stackMaster,stackMaster+self.raw_string+'.slc')
+            configObj.slaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse', slave,slave +'.slc')
+            configObj.masterMetaData = os.path.join(self.slcDir, stackMaster)
+            configObj.slaveMetaData = os.path.join(self.slcDir, slave)
+            configObj.outfile = os.path.join(self.workDir, 'offsets', slave ,'misreg')
+            configObj.refineSlaveTiming('[Function-1]')
+            configObj.finalize()
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
 
     def refineSlaveTiming_Network(self, pairs, stackMaster, slaveDates,  config_prefix):
   
         for pair in pairs:
-             configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
-             configObj = config(configName)
-             configObj.configure(self)
-
-             if pair[0] == stackMaster:
-                  configObj.masterSlc = os.path.join(self.slcDir,stackMaster,stackMaster+self.raw_string+'.slc')
-             else:
-                 configObj.masterSlc = os.path.join(self.workDir, 'coregSLC','Coarse', pair[0]  , pair[0] + '.slc')
-
-             if pair[1] == stackMaster:
-                 configObj.slaveSlc = os.path.join(self.slcDir,stackMaster, stackMaster+self.raw_string+'.slc')
-             else:
-                 configObj.slaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse', pair[1], pair[1] + '.slc')
-
-             configObj.masterMetaData = os.path.join(self.slcDir, pair[0])
-             configObj.slaveMetaData = os.path.join(self.slcDir, pair[1])
-             configObj.outfile = os.path.join(self.workDir, 'refineSlaveTiming','pairs', pair[0] + '_' + pair[1] ,'misreg')
-             configObj.refineSlaveTiming('[Function-1]')
-             configObj.finalize()
-             del configObj
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
+            configObj = config(configName)
+            configObj.configure(self)
+            if pair[0] == stackMaster:
+                configObj.masterSlc = os.path.join(self.slcDir,stackMaster,stackMaster+self.raw_string+'.slc')
+            else:
+                configObj.masterSlc = os.path.join(self.workDir, 'coregSLC','Coarse', pair[0]  , pair[0] + '.slc')
+            if pair[1] == stackMaster:
+                configObj.slaveSlc = os.path.join(self.slcDir,stackMaster, stackMaster+self.raw_string+'.slc')
+            else:
+                configObj.slaveSlc = os.path.join(self.workDir, 'coregSLC','Coarse', pair[1], pair[1] + '.slc')
+            configObj.masterMetaData = os.path.join(self.slcDir, pair[0])
+            configObj.slaveMetaData = os.path.join(self.slcDir, pair[1])
+            configObj.outfile = os.path.join(self.workDir, 'refineSlaveTiming','pairs', pair[0] + '_' + pair[1] ,'misreg')
+            configObj.refineSlaveTiming('[Function-1]')
+            configObj.finalize()
+            del configObj
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
 
     def denseOffsets_Network(self, pairs, stackMaster, slaveDates, config_prefix):
 
         for pair in pairs:
-             configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
-             configObj = config(configName)
-             configObj.configure(self)
+            configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
+            configObj = config(configName)
+            configObj.configure(self)
+            if pair[0] == stackMaster:
+                 configObj.masterSlc = os.path.join(self.slcDir,
+                                                    stackMaster,
+                                                    stackMaster+self.raw_string + '.slc')
+            else:
+                 configObj.masterSlc = os.path.join(self.workDir,
+                                                    self.stack_folder,
+                                                    'SLC',
+                                                    pair[0],
+                                                    pair[0] + '.slc')
+            if pair[1] == stackMaster:
+                 configObj.slaveSlc = os.path.join(self.slcDir,
+                                                   stackMaster,
+                                                   stackMaster+self.raw_string+'.slc')
+            else:
+                 configObj.slaveSlc = os.path.join(self.workDir,
+                                                   self.stack_folder,
+                                                   'SLC',
+                                                   pair[1],
+                                                   pair[1] + '.slc')
+            configObj.outfile = os.path.join(self.workDir,
+                                             self.dense_offsets_folder,
+                                             'pairs',
+                                             pair[0] + '_' + pair[1],
+                                             pair[0] + '_' + pair[1])
 
-
-             if pair[0] == stackMaster:
-                  configObj.masterSlc = os.path.join(self.slcDir,stackMaster , stackMaster+self.raw_string + '.slc')
-             else:
-                  configObj.masterSlc = os.path.join(self.workDir, self.stack_folder, 'SLC', pair[0] , pair[0] + '.slc')
-
-             if pair[1] == stackMaster:
-                  configObj.slaveSlc = os.path.join(self.slcDir,stackMaster, stackMaster+self.raw_string+'.slc')
-             else:
-                  configObj.slaveSlc = os.path.join(self.workDir, self.stack_folder,'SLC', pair[1] , pair[1] + '.slc')
-
-             configObj.outfile = os.path.join(self.workDir, self.dense_offsets_folder,'pairs',  pair[0] + '_' + pair[1] ,  pair[0] + '_' + pair[1])
-             configObj.denseOffsets('[Function-1]')
-             configObj.denseOffset = configObj.outfile + '.bil'
-             configObj.snr = configObj.outfile + '_snr.bil'
-             configObj.outDir = os.path.join(self.workDir, self.dense_offsets_folder,'pairs' , pair[0] + '_' + pair[1])
-             configObj.filterOffsets('[Function-2]')
-             configObj.finalize()
-             del configObj
-             self.runf.write(self.text_cmd + 'stripmapWrapper.py -c '+ configName+'\n')
+            configObj.denseOffsets('[Function-1]')
+            configObj.denseOffset = configObj.outfile + '.bil'
+            configObj.snr = configObj.outfile + '_snr.bil'
+            configObj.outDir = os.path.join(self.workDir, self.dense_offsets_folder,'pairs' , pair[0] + '_' + pair[1])
+            configObj.filterOffsets('[Function-2]')
+            configObj.finalize()
+            del configObj
+            self.runf.write(self.text_cmd + 'stripmapWrapper.py -c '+ configName+'\n')
 
   
     def invertMisregPoly(self):
@@ -474,7 +480,7 @@ class run(object):
         dateDirs = os.path.join(self.workDir, 'refineSlaveTiming/dates/')
         cmd = self.text_cmd + 'invertMisreg.py -i ' + pairDirs + ' -o ' + dateDirs
         self.runf.write(cmd + '\n')
-        
+
 
     def  invertDenseOffsets(self):
 
@@ -486,43 +492,43 @@ class run(object):
     def rubbersheet(self, slaveDates, config_prefix):
 
         for slave in slaveDates:
-             configName = os.path.join(self.configDir, config_prefix+slave)
-             configObj = config(configName)
-             configObj.configure(self)
-             configObj.geometry_azimuth_offset = os.path.join(self.workDir, 'offsets' , slave , 'azimuth.off')
-             configObj.dense_offset = os.path.join(self.workDir,self.dense_offsets_folder,'dates', slave , slave + '.bil')
-             configObj.snr = os.path.join(self.workDir,self.dense_offsets_folder,'dates' , slave , slave + '_snr.bil')
-             configObj.output_azimuth_offset = 'azimuth.off'
-             configObj.output_directory = os.path.join(self.workDir,self.dense_offsets_folder,'dates', slave)
-             configObj.rubbersheet('[Function-1]')
-             configObj.finalize()
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir, config_prefix+slave)
+            configObj = config(configName)
+            configObj.configure(self)
+            configObj.geometry_azimuth_offset = os.path.join(self.workDir, 'offsets' , slave , 'azimuth.off')
+            configObj.dense_offset = os.path.join(self.workDir,self.dense_offsets_folder,'dates', slave , slave + '.bil')
+            configObj.snr = os.path.join(self.workDir,self.dense_offsets_folder,'dates' , slave , slave + '_snr.bil')
+            configObj.output_azimuth_offset = 'azimuth.off'
+            configObj.output_directory = os.path.join(self.workDir,self.dense_offsets_folder,'dates', slave)
+            configObj.rubbersheet('[Function-1]')
+            configObj.finalize()
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
    
 
     def resampleOffset(self, slaveDates, config_prefix):
 
         for slave in slaveDates:
-             configName = os.path.join(self.configDir, config_prefix+slave)
-             configObj = config(configName)
-             configObj.configure(self)
-             configObj.targetFile = os.path.join(self.workDir, 'offsets/'+slave + '/azimuth.off')
-             configObj.input = os.path.join(self.workDir,self.dense_offsets_folder,'dates',slave  , slave + '.bil')
-             configObj.output = os.path.join(self.workDir,self.dense_offsets_folder,'dates',slave, 'azimuth.off')
-             configObj.resampleOffset('[Function-1]')
-             configObj.finalize()
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir, config_prefix+slave)
+            configObj = config(configName)
+            configObj.configure(self)
+            configObj.targetFile = os.path.join(self.workDir, 'offsets/'+slave + '/azimuth.off')
+            configObj.input = os.path.join(self.workDir,self.dense_offsets_folder,'dates',slave  , slave + '.bil')
+            configObj.output = os.path.join(self.workDir,self.dense_offsets_folder,'dates',slave, 'azimuth.off')
+            configObj.resampleOffset('[Function-1]')
+            configObj.finalize()
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
   
 
-    def  replaceOffsets(self, slaveDates):
+    def replaceOffsets(self, slaveDates):
 
         dateDirs = os.path.join(self.workDir, self.dense_offsets_folder,'dates')
         for slave in slaveDates:
-             geometryOffset = os.path.join(self.workDir, 'offsets', slave  , 'azimuth.off')
-             geometryOnlyOffset = os.path.join(self.workDir, 'offsets' , slave , 'azimuth.off.geometry')
-             rubberSheeted = os.path.join(self.workDir,self.dense_offsets_folder,'dates' , slave , 'azimuth.off')
-             cmd = self.text_cmd + 'mv ' + geometryOffset + ' ' + geometryOnlyOffset
-             cmd = cmd + '; mv ' + rubberSheeted + ' ' + geometryOffset
-             self.runf.write(cmd + '\n')
+            geometryOffset = os.path.join(self.workDir, 'offsets', slave  , 'azimuth.off')
+            geometryOnlyOffset = os.path.join(self.workDir, 'offsets' , slave , 'azimuth.off.geometry')
+            rubberSheeted = os.path.join(self.workDir,self.dense_offsets_folder,'dates' , slave , 'azimuth.off')
+            cmd = self.text_cmd + 'mv ' + geometryOffset + ' ' + geometryOnlyOffset
+            cmd = cmd + '; mv ' + rubberSheeted + ' ' + geometryOffset
+            self.runf.write(cmd + '\n')
 
   
     def gridBaseline(self, stackMaster, slaveDates, config_prefix, split=False):
@@ -546,8 +552,16 @@ class run(object):
 
     def slaves_fine_resampleSlc(self, stackMaster, slaveDates, config_prefix, split=False):
         # copy over the master into the final SLC folder as well
-        self.runf.write(self.text_cmd + ' masterStackCopy.py -i ' + os.path.join(self.slcDir,stackMaster, stackMaster+self.raw_string + '.slc') + ' -o ' + os.path.join(self.workDir, self.stack_folder,'SLC', stackMaster, stackMaster+'.slc' )+ '\n')
-        
+        self.runf.write(self.text_cmd + ' masterStackCopy.py -i ' + 
+                        os.path.join(self.slcDir, 
+                                     stackMaster,
+                                     stackMaster + self.raw_string + '.slc') + ' -o ' +
+                        os.path.join(self.workDir,
+                                     self.stack_folder,
+                                     'SLC',
+                                     stackMaster,
+                                     stackMaster+'.slc' )+ '\n')
+
         # now resample each of the slaves to the master geometry
         for slave in slaveDates:
             configName = os.path.join(self.configDir, config_prefix+slave)
@@ -574,62 +588,76 @@ class run(object):
     def igrams_network(self,  pairs, acuisitionDates, stackMaster,low_or_high, config_prefix):
 
         for pair in pairs:
-             configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
-             configObj = config(configName)
-             configObj.configure(self)
-             
-             if pair[0] == stackMaster:
-                  configObj.masterSlc = os.path.join(self.slcDir,stackMaster + low_or_high + stackMaster+self.raw_string +'.slc')
-             else:
-                  configObj.masterSlc = os.path.join(self.workDir, self.stack_folder, 'SLC',  pair[0] + low_or_high + pair[0] + '.slc')
+            configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
+            configObj = config(configName)
+            configObj.configure(self)
+            
+            if pair[0] == stackMaster:
+                 configObj.masterSlc = os.path.join(self.slcDir,
+                                                    stackMaster + low_or_high + stackMaster+self.raw_string +'.slc')
+            else:
+                 configObj.masterSlc = os.path.join(self.workDir,
+                                                    self.stack_folder,
+                                                    'SLC',
+                                                    pair[0] + low_or_high + pair[0] + '.slc')
+            if pair[1] == stackMaster:
+                 configObj.slaveSlc = os.path.join(self.slcDir,
+                                                   stackMaster + low_or_high + stackMaster+self.raw_string+'.slc')
+            else:
+                 configObj.slaveSlc = os.path.join(self.workDir,
+                                                   self.stack_folder,
+                                                   'SLC',
+                                                   pair[1] + low_or_high + pair[1] + '.slc')
 
-             if pair[1] == stackMaster:
-                  configObj.slaveSlc = os.path.join(self.slcDir,stackMaster + low_or_high + stackMaster+self.raw_string+'.slc')
-             else:
-                  configObj.slaveSlc = os.path.join(self.workDir, self.stack_folder, 'SLC',  pair[1] + low_or_high + pair[1] + '.slc')
+            configObj.outDir = os.path.join(self.workDir,
+                                            'Igrams' + low_or_high + pair[0] + '_'  + pair[1],
+                                            pair[0] + '_'  + pair[1])
 
-             configObj.outDir = os.path.join(self.workDir, 'Igrams' + low_or_high + 
-                         pair[0] + '_'  + pair[1] +'/'+pair[0] + '_'  + pair[1])
-             configObj.generateIgram('[Function-1]')
+            configObj.generateIgram('[Function-1]')
+            configObj.igram = configObj.outDir+'.int'
+            configObj.filtIgram = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.int'
+            configObj.coherence = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.cor'
+            #configObj.filtStrength = filtStrength
+            configObj.filterCoherence('[Function-2]')
 
-             configObj.igram = configObj.outDir+'.int'
-             configObj.filtIgram = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.int'
-             configObj.coherence = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] + '.cor'
-             #configObj.filtStrength = filtStrength
-             configObj.filterCoherence('[Function-2]')
-
-             # skip phase unwrapping if input method == no
-             if self.unwMethod.lower() != 'no':
-                 configObj.igram = configObj.filtIgram
-                 configObj.unwIfg = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] 
-                 configObj.noMCF = noMCF
-                 configObj.master = os.path.join(self.slcDir,stackMaster +'/data') 
-                 configObj.defoMax = defoMax
-                 configObj.unwrap('[Function-3]')
-
-             configObj.finalize()
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            # skip phase unwrapping if input method == no
+            if self.unwMethod.lower() != 'no':
+                configObj.igram = configObj.filtIgram
+                configObj.unwIfg = os.path.dirname(configObj.outDir) + '/filt_' + pair[0] + '_'  + pair[1] 
+                configObj.noMCF = noMCF
+                configObj.master = os.path.join(self.slcDir,stackMaster +'/data') 
+                configObj.defoMax = defoMax
+                configObj.unwrap('[Function-3]')
+            configObj.finalize()
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
 
     def dispersive_nonDispersive(self, pairs, acuisitionDates, stackMaster, 
                            lowBand, highBand, config_prefix):
         for pair in pairs:
-             configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
-             configObj = config(configName) 
-             configObj.configure(self)
-             configObj.lowBandIgram = os.path.join(self.workDir, 'Igrams' + lowBand + pair[0] + '_'  + pair[1]                      + '/filt_'+pair[0] + '_'  + pair[1])    
-             configObj.highBandIgram = os.path.join(self.workDir, 'Igrams' + highBand + pair[0] + '_'  + pair[1] 
-                   + '/filt_'+pair[0] + '_'  + pair[1])
-             configObj.lowBandCor = os.path.join(self.workDir, 'Igrams' + lowBand + pair[0] + '_'  + pair[1]
-                   + '/filt_'+pair[0] + '_'  + pair[1] + '.cor')
-             configObj.highBandCor = os.path.join(self.workDir, 'Igrams' + highBand + pair[0] + '_'  + pair[1]
-                   + '/filt_'+pair[0] + '_'  + pair[1] + '.cor')
-             configObj.lowBandShelve = os.path.join(self.slcDir,pair[0] + lowBand  + 'data') 
-             configObj.highBandShelve = os.path.join(self.slcDir,pair[0] + highBand  + 'data')   
-             configObj.outDir = os.path.join(self.workDir, 'Ionosphere/'+pair[0]+'_'+pair[1])
-             configObj.estimateDispersive('[Function-1]')
-             configObj.finalize()
-             self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
+            configName = os.path.join(self.configDir,config_prefix + pair[0] + '_' + pair[1])
+            configObj = config(configName) 
+            configObj.configure(self)
+            configObj.lowBandIgram  = os.path.join(self.workDir,
+                                                   'Igrams' + lowBand + pair[0] + '_'  + pair[1],
+                                                   'filt_' + pair[0] + '_'  + pair[1])
+            configObj.highBandIgram = os.path.join(self.workDir,
+                                                   'Igrams' + highBand + pair[0] + '_'  + pair[1],
+                                                   'filt_' + pair[0] + '_'  + pair[1])
+
+            configObj.lowBandCor  = os.path.join(self.workDir,
+                                                 'Igrams' + lowBand + pair[0] + '_'  + pair[1],
+                                                 'filt_' + pair[0] + '_'  + pair[1] + '.cor')
+            configObj.highBandCor = os.path.join(self.workDir,
+                                                 'Igrams' + highBand + pair[0] + '_'  + pair[1],
+                                                 'filt_' + pair[0] + '_'  + pair[1] + '.cor')
+
+            configObj.lowBandShelve = os.path.join(self.slcDir,pair[0] + lowBand  + 'data') 
+            configObj.highBandShelve = os.path.join(self.slcDir,pair[0] + highBand  + 'data')   
+            configObj.outDir = os.path.join(self.workDir, 'Ionosphere/'+pair[0]+'_'+pair[1])
+            configObj.estimateDispersive('[Function-1]')
+            configObj.finalize()
+            self.runf.write(self.text_cmd+'stripmapWrapper.py -c '+ configName+'\n')
 
     def finalize(self):
         self.runf.close() 
@@ -666,7 +694,6 @@ def baselinePair(baselineDir, master, slave,doBaselines=True):
 
         mFrame = mdb['frame']
         sFrame = sdb['frame']
-
 
         bObj = Baseline()
         bObj.configure()
@@ -712,15 +739,15 @@ def selectPairs(inps,stackMaster, slaveDates, acuisitionDates,doBaselines=True):
 
     baselineDict, timeDict = baselineStack(inps, stackMaster, acuisitionDates,doBaselines)
     for slave in slaveDates:
-       print (slave,' : ' , baselineDict[slave])
+        print (slave,' : ' , baselineDict[slave])
     numDates = len(acuisitionDates)
     pairs = []
     for i in range(numDates-1):
-       for j in range(i+1,numDates):
-          db = np.abs(baselineDict[acuisitionDates[j]] - baselineDict[acuisitionDates[i]])
-          dt  = np.abs(timeDict[acuisitionDates[j]].days - timeDict[acuisitionDates[i]].days)
-          if (db < inps.dbThr) and (dt < inps.dtThr):
-              pairs.append((acuisitionDates[i],acuisitionDates[j]))
+        for j in range(i+1,numDates):
+            db = np.abs(baselineDict[acuisitionDates[j]] - baselineDict[acuisitionDates[i]])
+            dt = np.abs(timeDict[acuisitionDates[j]].days - timeDict[acuisitionDates[i]].days)
+            if (db < inps.dbThr) and (dt < inps.dtThr):
+                pairs.append((acuisitionDates[i],acuisitionDates[j]))
 
     plotNetwork(baselineDict, timeDict, pairs,os.path.join(inps.workDir,'pairs.pdf'))
     return pairs 
@@ -738,9 +765,11 @@ def plotNetwork(baselineDict, timeDict, pairs,save_name='pairs.png'):
     ax1.cla()
     for ni in range(len(pairs)):
 #        ax1.plot(np.array([timeDict[pairs[ni][0]].days,timeDict[pairs[ni][1]].days]), 
-         ax1.plot([datetime.datetime.strptime(pairs[ni][0],datefmt), datetime.datetime.strptime(pairs[ni][1], datefmt)], 
-                 np.array([baselineDict[pairs[ni][0]],baselineDict[pairs[ni][1]]]),
-                 '-ko',lw=1, ms=4, alpha=0.7, mfc='r')
+         ax1.plot([datetime.datetime.strptime(pairs[ni][0],datefmt),
+                   datetime.datetime.strptime(pairs[ni][1], datefmt)], 
+                  np.array([baselineDict[pairs[ni][0]],
+                            baselineDict[pairs[ni][1]]]),
+                  '-ko',lw=1, ms=4, alpha=0.7, mfc='r')
   
     
 
@@ -778,19 +807,19 @@ def plotNetwork(baselineDict, timeDict, pairs,save_name='pairs.png'):
 def writeJobFile(runFile):
 
   
-  jobName = runFile + ".job"
-  dirName = os.path.dirname(runFile)
-  with open(runFile) as ff:
-    nodes = len(ff.readlines())
-  if nodes >maxNodes:
-     nodes = maxNodes
+    jobName = runFile + ".job"
+    dirName = os.path.dirname(runFile)
+    with open(runFile) as ff:
+        nodes = len(ff.readlines())
+    if nodes >maxNodes:
+        nodes = maxNodes
 
-  f = open (jobName,'w')
-  f.write('#!/bin/bash '+ '\n')
-  f.write('#PBS -N Parallel_GNU'+ '\n')
-  f.write('#PBS -l nodes=' + str(nodes) + '\n')
+    f = open (jobName,'w')
+    f.write('#!/bin/bash '+ '\n')
+    f.write('#PBS -N Parallel_GNU'+ '\n')
+    f.write('#PBS -l nodes=' + str(nodes) + '\n')
 
-  jobTxt='''#PBS -V
+    jobTxt='''#PBS -V
 #PBS -l walltime=05:00:00
 #PBS -q default
 
@@ -815,10 +844,10 @@ echo " "
 #
 
 '''
-  f.write(jobTxt+ '\n')
-  f.write('parallel --sshloginfile $PBS_NODEFILE  -a '+runFile+'\n')
-  f.write('')
-  f.close()
+    f.write(jobTxt+ '\n')
+    f.write('parallel --sshloginfile $PBS_NODEFILE  -a '+runFile+'\n')
+    f.write('')
+    f.close()
 
 
 def main(iargs=None):
@@ -826,7 +855,7 @@ def main(iargs=None):
 
 if __name__ == "__main__":
        
-  # Main engine  
-  main()
+    # Main engine  
+    main()
        
 

--- a/contrib/stack/stripmapStack/prepSlcALOS2.py
+++ b/contrib/stack/stripmapStack/prepSlcALOS2.py
@@ -17,17 +17,22 @@ def createParser():
     Create command line parser.
     '''
 
-    parser = argparse.ArgumentParser(description='Prepare ALOS2 slc for processing (unzip/untar files, '
+    parser = argparse.ArgumentParser(description='Prepare ALOS2 SLC for processing (unzip/untar files, '
                                      'organize in date folders, generate script to unpack into isce formats).')
     parser.add_argument('-i', '--input', dest='inputDir', type=str, required=True,
             help='directory with the downloaded SLC data')
-    parser.add_argument('-rmfile', '--rmfile', dest='rmfile',action='store_true', default=False,
-            help='Optional: remove zip/tar/compressed files after unpacking into date structure '
-                 '(default is to keep in archive fo  lder)')
     parser.add_argument('-o', '--output', dest='outputDir', type=str, required=False,
             help='output directory where data needs to be unpacked into isce format (for script generation).')
+
     parser.add_argument('-t', '--text_cmd', dest='text_cmd', type=str, default='source ~/.bash_profile;',
-            help='text command to be added to the beginning of each line of the run files. Default: source ~/.bash_profile;')
+            help='text command to be added to the beginning of each line of the run files (default: %(default)s).')
+
+    parser.add_argument('-p', '--polarization', dest='polarization', type=str,
+            help='polarization in case if quad or full pol data exists (default: %(default)s).')
+
+    parser.add_argument('-rmfile', '--rmfile', dest='rmfile',action='store_true', default=False,
+            help='Optional: remove zip/tar/compressed files after unpacking into date structure '
+                 '(default is to keep in archive folder)')
     return parser
 
 
@@ -201,7 +206,9 @@ def main(iargs=None):
                 acquisitionDate = os.path.basename(dateDir)
                 slcDir = os.path.join(inps.outputDir, acquisitionDate)
                 os.makedirs(slcDir, exist_ok=True)
-                cmd = 'unpackFrame_ALOS2.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir      
+                cmd = 'unpackFrame_ALOS2.py -i ' + os.path.abspath(dateDir) + ' -o ' + slcDir
+                if inps.polarization:
+                    cmd += ' --polarization {} '.format(inps.polarization)
                 print (cmd)
                 f.write(inps.text_cmd + cmd+'\n')
         f.close()

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -8,6 +8,13 @@ import configparser
 import datetime
 import numpy as np
 import shelve
+
+# suppress matplotlib DEBUG message
+from matplotlib.path import Path as Path
+import logging
+mpl_logger = logging.getLogger('matplotlib')
+mpl_logger.setLevel(logging.WARNING)
+
 import isce
 import isceobj
 from mroipac.baseline.Baseline import Baseline

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -58,11 +58,11 @@ def createParser():
             help='SAR sensor used to define square multi-look pixels')
 
     parser.add_argument('-u', '--unw_method', dest='unwMethod', type=str, default='snaphu', 
-            help='unwrapping method (icu, snaphu, or snaphu2stage)')
+            help='unwrapping method (icu, snaphu, or snaphu2stage), no to skip phase unwrapping.')
 
     parser.add_argument('-f','--filter_strength', dest='filtStrength', type=str, default=filtStrength,
             help='strength of Goldstein filter applied to the wrapped phase before spatial coherence estimation.'
-                 ' Default: {}'.format(filtStrength))
+                 ' Default: {}. 0 to skip filtering.'.format(filtStrength))
 
     iono = parser.add_argument_group('Ionosphere', 'Configurationas for ionospheric correction')
     iono.add_argument('-L', '--low_band_frequency', dest='fL', type=str, default=None,


### PR DESCRIPTION
This PR exposes the following three options for command line usage in stripmapStack:

+ `prepSlcALOS2.py --polarization` to pass it to unpackFrame_ALOS2.py for processing with different polarizations. [133bafe](https://github.com/isce-framework/isce2/commit/133bafe80362d037754496e93dbeaefd916f75ff)

+ `stackStripMap.py --filter_strength 0` to skip the filtering step. If chosen, the output file will not add the "filt_" prefix in their filename. [72bce2d](https://github.com/isce-framework/isce2/commit/72bce2dd37c1f389693bd0163861aa03b697a007)

+ `stackStripMap.py --unw_method no` to skip the phase unwrapping step. [912b31b](https://github.com/isce-framework/isce2/commit/912b31b8b53d1d13a06fd1f186aeef3254bd8934)

There is one commit that only adjust the indentation in `Stack.py`. This commit change could overlap with changes from other commits, thus, I recommend you to review the code change in each commit separately.