### PR TITLE
Fix downloading incorrect restituted orbit when running topsStack

### DIFF
--- a/contrib/stack/topsStack/Stack.py
+++ b/contrib/stack/topsStack/Stack.py
@@ -922,7 +922,7 @@ class sentinelSLC(object):
            orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt)
            orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt)
 
-           if self.start_date_time > orbit_start_date_time and self.start_date_time < orbit_stop_date_time:
+           if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
                self.orbit = os.path.join(orbitDir,orbit)
                self.orbitType = 'precise'
                match = True
@@ -941,7 +941,7 @@ class sentinelSLC(object):
               fields = os.path.basename(orbitFile).split('_')
               orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt)
               orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt)
-              if self.start_date_time > orbit_start_date_time and self.start_date_time < orbit_stop_date_time:
+              if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
                   print ("restituted orbit already exists.")
                   self.orbit =  orbitFile
                   self.orbitType = 'restituted'

--- a/contrib/stack/topsStack/Stack.py
+++ b/contrib/stack/topsStack/Stack.py
@@ -909,7 +909,8 @@ class sentinelSLC(object):
 
         self.SNWE=[min(lats),max(lats),min(lons),max(lons)]
 
-    def get_orbit(self, orbitDir, workDir):
+    def get_orbit(self, orbitDir, workDir, margin=60.0):
+        margin = datetime.timedelta(seconds=margin)
         datefmt = "%Y%m%dT%H%M%S"
         orbit_files = glob.glob(os.path.join(orbitDir,  self.platform + '*.EOF'))
         if len(orbit_files) == 0:
@@ -919,10 +920,10 @@ class sentinelSLC(object):
         for orbit in orbit_files:
            orbit = os.path.basename(orbit)
            fields = orbit.split('_')
-           orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt)
-           orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt)
+           orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt) + margin
+           orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt) - margin
 
-           if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
+           if self.start_date_time >= orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
                self.orbit = os.path.join(orbitDir,orbit)
                self.orbitType = 'precise'
                match = True
@@ -941,7 +942,7 @@ class sentinelSLC(object):
               fields = os.path.basename(orbitFile).split('_')
               orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt)
               orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt)
-              if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
+              if self.start_date_time >= orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
                   print ("restituted orbit already exists.")
                   self.orbit =  orbitFile
                   self.orbitType = 'restituted'

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
 
     inps = cmdLineParse()
 
-    fileTS, satName, , fileTSStart = FileToTimeStamp(inps.input)
+    fileTS, satName, fileTSStart = FileToTimeStamp(inps.input)
     print('Reference time: ', fileTS)
     print('Satellite name: ', satName)
     

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -38,9 +38,11 @@ def FileToTimeStamp(safename):
     '''
     safename = os.path.basename(safename)
     fields = safename.split('_')
+    sstamp = []  # sstamp for getting SAFE file start time, not needed for orbit file timestamps
 
     try:
         tstamp = datetime.datetime.strptime(fields[-4], datefmt)
+        sstamp = datetime.datetime.strptime(fields[-5], datefmt)
     except: 
         p = re.compile(r'(?<=_)\d{8}')  
         dt2 = p.search(safename).group() 
@@ -48,7 +50,7 @@ def FileToTimeStamp(safename):
 
     satName = fields[0]
 
-    return tstamp, satName
+    return tstamp, satName, sstamp
 
 
 class MyHTMLParser(HTMLParser):
@@ -144,7 +146,7 @@ if __name__ == '__main__':
 
     inps = cmdLineParse()
 
-    fileTS, satName = FileToTimeStamp(inps.input)
+    fileTS, satName, , fileTSStart = FileToTimeStamp(inps.input)
     print('Reference time: ', fileTS)
     print('Satellite name: ', satName)
     
@@ -198,7 +200,7 @@ if __name__ == '__main__':
                 for result in results:
                     tbef, taft, mission = fileToRange(os.path.basename(result))
 
-                    if (tbef <= fileTS) and (taft >= fileTS):
+                    if (tbef <= fileTSStart) and (taft >= fileTS):
                         datestr2 = FileToTimeStamp(result)[0].strftime(queryfmt2) 
                         match = (server2 + spec[1].replace('aux_', '').upper() +
                                  '/' +datestr2+ result + '.EOF')


### PR DESCRIPTION
I encountered this error when running the topsStack processor, run_4_geo2rdr_resample, where IW{i}.xml files were missing from the slaves directory for dates 20200424 and 20200506: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-geo2rdr_resample_orig-log-L37

Upon checking the run_2_unpack_slave_slc logs for these dates, this is likely due to an issue with the restituted orbit downloaded for these dates: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-geo2rdr_resample_orig-log-L37

The not so ideal restituted orbit was downloaded when running stackSentinel.py: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-stacksentinel_orig-log-L83 No pre-prepared orbits were used, all orbits for this stack were downloaded via topsStack.

Using 20200424 as an example:
Affected SAFE file is: S1A_IW_SLC__1SDV_20200424T112520_20200424T112547_032268_03BBB1_7546.SAFE
Downloaded restituted orbit is: S1A_OPER_AUX_RESORB_OPOD_20200424T163824_V20200424T112525_20200424T144255.EOF
The "falls outside of the interpolation interval" is likely because the SAFE file start and end times are not completely within the orbit file start and end times i.e. SAFE file start time is before the orbit file start time in this case. Tracing back the orbit download process:
stackSentinel.py uses get_orbit: https://github.com/isce-framework/isce2/blob/master/contrib/stack/topsStack/stackSentinel.py#L246
get_orbit calls fetchOrbit.py: https://github.com/isce-framework/isce2/blob/4282bb8e0a7e49ce7b83c51b214040034e17a64b/contrib/stack/topsStack/Stack.py#L912
fetchOrbit.py uses the following criteria where only the SAFE file end time needs to be within the orbit file start and end times: https://github.com/isce-framework/isce2/blob/4282bb8e0a7e49ce7b83c51b214040034e17a64b/contrib/stack/topsStack/fetchOrbit.py#L201

Here is a short list of orbit files from https://qc.sentinel1.eo.esa.int/aux_resorb/?validity_start=2020&validity_start=2020-04&validity_start=2020-04-22..2020-04-25&sentinel1__mission=S1A&page=3, where the most recent in the list passed the condition and was downloaded, but there is also an earlier version which will capture the SAFE file start and end times:
S1A_OPER_AUX_RESORB_OPOD_20200424T163824_V20200424T112525_20200424T144255 --> downloaded
S1A_OPER_AUX_RESORB_OPOD_20200424T153918_V20200424T112525_20200424T144255
S1A_OPER_AUX_RESORB_OPOD_20200424T151904_V20200424T112525_20200424T144255
S1A_OPER_AUX_RESORB_OPOD_20200424T135320_V20200424T094640_20200424T130410 --> 'desired'
______________
I made the following tentative changes for Stack.py and fetchOrbit.py so that the condition to match an orbit file to a SAFE file considers both the start and end times of a SAFE file:
```
$ diff Stack_ori.py Stack.py
905c905
<      if self.start_date_time > orbit_start_date_time and self.start_date_time < orbit_stop_date_time:
---
>      if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
924c924
<        if self.start_date_time > orbit_start_date_time and self.start_date_time < orbit_stop_date_time:
---
>        if self.start_date_time > orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
```
```
$ diff fetchOrbit_ori.py fetchOrbit.py
40a41
>   sstamp = [] # sstamp for getting SAFE file start time, not needed for orbit file timestamps
43a45
>     sstamp = datetime.datetime.strptime(fields[-5], datefmt)
51c53
<   return tstamp, satName
---
>   return tstamp, satName, sstamp
146c148
<   fileTS, satName = FileToTimeStamp(inps.input)
---
>   fileTS, satName, fileTSStart = FileToTimeStamp(inps.input)
200c202
<           if (tbef <= fileTS) and (taft >= fileTS):
---
>           if (tbef <= fileTSStart) and (taft >= fileTS):
```
With these changes, the 'desired' orbit files were downloaded instead. The topsStack processor could be run from start to end successfully. Logs as shown:
Orbit download logs: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-stacksentinel_edit-log-L83
No "falls outside of the interpolation interval" when unpacking slave SLC: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-unpack_slave_slc_edit-log
No error running geo2rdr_resample: https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-geo2rdr_resample_edit-log

See https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-directories_orig-txt for SAFE and orbit files with original scripts.
See https://gist.github.com/cheryltwj/4fa54a98308124254f42f652c193c3fc#file-directories_edit-txt for SAFE and orbit files after script changes.