### PR TITLE
Suppress zero sized isce.log file creation

### DIFF
--- a/defaults/logging/logging.conf
+++ b/defaults/logging/logging.conf
@@ -21,7 +21,8 @@ propagate=0
 class=handlers.RotatingFileHandler
 formatter=simpleFormatter
 # Filename, file mode, maximum file size in bytes,number of backups to keep
-args=('isce.log','a',1048576,5)
+# encoding, delay
+args=('isce.log','a',1048576,5,None,True)
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
Change defaults in logging.conf to suppress zero-size isce.log file creation.

TO DO: Suppress logging entirely when there are no write permissions. 