### PR TITLE
Baseline bug fix

### DIFF
--- a/components/isceobj/TopsProc/runComputeBaseline.py
+++ b/components/isceobj/TopsProc/runComputeBaseline.py
@@ -77,6 +77,8 @@ def runComputeBaseline(self):
                     mxyz = np.array(masterSV.getPosition())
                     mvel = np.array(masterSV.getVelocity())
                     sxyz = np.array(slaveSV.getPosition())
+                    mvelunit = mvel / np.linalg.norm(mvel)
+                    sxyz = sxyz - np.dot ( sxyz-mxyz, mvelunit) * mvelunit
 
                     aa = np.linalg.norm(sxyz-mxyz)
                     costheta = (rng*rng + aa*aa - slvrng*slvrng)/(2.*rng*aa)

--- a/components/zerodop/baseline/Baseline.py
+++ b/components/zerodop/baseline/Baseline.py
@@ -103,6 +103,8 @@ class Baseline(Component):
             mxyz = np.array(masterSV.getPosition())
             mvel = np.array(masterSV.getVelocity())
             sxyz = np.array(slaveSV.getPosition())
+            mvelunit = mvel / np.linalg.norm(mvel)
+            sxyz = sxyz - np.dot ( sxyz-mxyz, mvelunit) * mvelunit
 
             aa = np.linalg.norm(sxyz-mxyz)
 


### PR DESCRIPTION
Following solution suggested by @piyushrpt in issue #137, estimation of slave satellite position adjusted in topsApp and zerodop associated baseline codes to address artifacts in metadata fields.