### PR TITLE
Negative valid samples/lines now set to 0

### DIFF
--- a/contrib/stack/topsStack/s1a_isce_utils.py
+++ b/contrib/stack/topsStack/s1a_isce_utils.py
@@ -193,6 +193,12 @@ def adjustCommonValidRegion(master,slave):
     master.firstValidLine = max(master.firstValidLine, slave.firstValidLine)
     master.firstValidSample = max(master.firstValidSample, slave.firstValidSample)
 
+    #set to 0 to avoid negative values
+    if master.firstValidLine<0:
+        master.firstValidLine=0
+    if master.firstValidSample<0:
+        master.firstValidSample=0
+
     master.numValidLines = igram_lastValidLine - master.firstValidLine + 1
     master.numValidSamples = igram_lastValidSample - master.firstValidSample + 1
 


### PR DESCRIPTION
Computed ifg bursts are empty when negative valid samples and/or lines are estimated. Valid samples and/or lines now set to 0 in such instances to circumvent this problem

This issue was also documented on the Earthdef forums: http://earthdef.caltech.edu/boards/4/topics/2834?r=2844#message-2844

Below are examples of products generated before and after this bug-fix is implemented:
<img width="324" alt="Screen Shot 2020-06-06 at 2 30 34 PM" src="https://user-images.githubusercontent.com/13227405/83959878-f62bfe00-a836-11ea-9821-96f9e27cf7db.png">
<img width="417" alt="Screen Shot 2020-06-06 at 4 23 08 PM" src="https://user-images.githubusercontent.com/13227405/83959880-f926ee80-a836-11ea-8c8b-765aa4911892.png">
