### PR TITLE
Updating circleci config to handle alpine changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           name: Install dependencies
           command: |
             apk add --no-cache \
-              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+              python3-dev py3-pip bash pigz build-base libffi-dev openssl-dev
             pip install \
               docker-compose awscli
       - run:
@@ -170,7 +170,7 @@ jobs:
           name: Install dependencies
           command: |
             apk add --no-cache \
-              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+              python3-dev py3-pip bash pigz build-base libffi-dev openssl-dev
             pip install \
               docker-compose awscli
       - run:
@@ -196,7 +196,7 @@ jobs:
           name: Install dependencies
           command: |
             apk add --no-cache \
-              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+              python3-dev py3-pip bash pigz build-base libffi-dev openssl-dev
             pip install \
               docker-compose awscli
       - run:


### PR DESCRIPTION
Alpine has started removing python2 from it's base images and this impacts the docker:* images that are built on top. 

Making changes to fix the build-deploy, build-periodically and build-release CI workflows. 
Also tagging @pymonger 