### PR TITLE
Fixing linking order and flags for mdx

### DIFF
--- a/.cmake/TargetX11.cmake
+++ b/.cmake/TargetX11.cmake
@@ -5,9 +5,6 @@ set(components
 
 find_package(X11 COMPONENTS ${components})
 
-# The X11::{component} targets only exist for CMake ≥ 3.14,
-# so we create them here for backwards compatibility.
-
 if(X11_FOUND)
 
     # make X11 look like a regular find_package component

--- a/contrib/mdx/CMakeLists.txt
+++ b/contrib/mdx/CMakeLists.txt
@@ -3,22 +3,30 @@ if(TARGET Motif::Motif
    AND TARGET X11::Xau
    AND TARGET X11::Xt
    )
+
+    #Only for this folder - ensure openmp is not used for compiling
+    #Modifying flags here have directory scope
+    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+        string(REPLACE "-fopenmp" " " CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
+    endif()
+    
     add_executable(mdx
         src/graphx_mdx.c
         src/rdf_reader_subs.f
         src/mdx_main.F
-        src/mdx.F
+        src/mdx_subs.F
         )
     target_compile_definitions(mdx PRIVATE SUN IO64)
-    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-        target_compile_definitions(mdx PRIVATE GFORTRAN)
-    endif()
+    target_include_directories(mdx PUBLIC 
+        ${X11_Xt_INCLUDE_PATH}
+        ${X11_X11_INCLUDE_PATH}
+        ${MOTIF_INCLUDE_DIR})
     target_link_libraries(mdx PUBLIC
-        Motif::Motif
-        X11::X11
-        X11::Xau
-        X11::Xt
+        ${X11_X11_LIB}
+        ${MOTIF_LIBRARIES}
+        ${X11_Xt_LIB}
         )
+
     install(TARGETS mdx
             RUNTIME DESTINATION bin
             )


### PR DESCRIPTION
Fixes #155 

1. disable openmp flag explicitly for mdx 
2. linking order of libraries - I would like to use the nice target management but that seems to make a mess of the order in which mdx expects libs. 

This PR should probably be updated with changes to TargetX11 and TargetMotif. Feel free to push to this branch and make changes. 