### PR TITLE
Add openmp to stdproc modules

### DIFF
--- a/components/stdproc/stdproc/CMakeLists.txt
+++ b/components/stdproc/stdproc/CMakeLists.txt
@@ -11,6 +11,11 @@ set_property(TARGET formslcLib PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(formslcLib PUBLIC
     utilLib
     )
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(formslcLib PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 
 set(mdir ${CMAKE_CURRENT_BINARY_DIR}/formslc_fortran_modules)
 set_property(TARGET formslcLib PROPERTY Fortran_MODULE_DIRECTORY ${mdir})

--- a/components/stdproc/stdproc/correct/CMakeLists.txt
+++ b/components/stdproc/stdproc/correct/CMakeLists.txt
@@ -5,7 +5,11 @@ Python_add_library(correct MODULE
     src/correctState.f
     )
 target_include_directories(correct PUBLIC include)
-
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(correct PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 InstallSameDir(
     correct
     __init__.py

--- a/components/stdproc/stdproc/crossmul/CMakeLists.txt
+++ b/components/stdproc/stdproc/crossmul/CMakeLists.txt
@@ -4,7 +4,11 @@ Python_add_library(crossmul MODULE
     src/crossmul.f90
     )
 target_include_directories(crossmul PUBLIC include)
-
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(crossmul PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 InstallSameDir(
     crossmul
     __init__.py

--- a/components/stdproc/stdproc/mocompTSX/CMakeLists.txt
+++ b/components/stdproc/stdproc/mocompTSX/CMakeLists.txt
@@ -12,7 +12,11 @@ target_link_libraries(mocompTSX
     formslcLib
     utilLib
     )
-
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(mocompTSX PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 InstallSameDir(
     mocompTSX
     __init__.py

--- a/components/stdproc/stdproc/offsetpoly/CMakeLists.txt
+++ b/components/stdproc/stdproc/offsetpoly/CMakeLists.txt
@@ -11,7 +11,11 @@ target_link_libraries(offsetpoly PUBLIC
     combinedLib
     utilLib
     )
-
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(offsetpoly PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 InstallSameDir(
     offsetpoly
     __init__.py

--- a/components/stdproc/stdproc/resamp/CMakeLists.txt
+++ b/components/stdproc/stdproc/resamp/CMakeLists.txt
@@ -10,7 +10,11 @@ target_include_directories(resamp PUBLIC include)
 target_link_libraries(resamp PUBLIC
     utilLib
     )
-
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(resamp PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 InstallSameDir(
     resamp
     __init__.py

--- a/components/stdproc/stdproc/resamp_slc/CMakeLists.txt
+++ b/components/stdproc/stdproc/resamp_slc/CMakeLists.txt
@@ -13,6 +13,11 @@ target_link_libraries(resamp_slc PUBLIC
 target_compile_options(resamp_slc PRIVATE
     -ffree-line-length-none
     )
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(resamp_slc PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 
 InstallSameDir(
     resamp_slc

--- a/components/stdproc/stdproc/topo/CMakeLists.txt
+++ b/components/stdproc/stdproc/topo/CMakeLists.txt
@@ -11,6 +11,11 @@ target_link_libraries(topo PUBLIC
     combinedLib
     utilLib
     )
+if(TARGET OpenMP::OpenMP_Fortran)
+    target_link_libraries(topo PUBLIC
+        OpenMP::OpenMP_Fortran
+        )
+endif()
 
 InstallSameDir(
     topo


### PR DESCRIPTION
Adding openmp to stdproc modules.
crossmul and resamp_slc are used in active workflows and others possibly in historic/ unmaintained workflows.