### PR TITLE
added option to pass segment number through unpackFrame_UAVSAR

### DIFF
--- a/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# modified to pass the segment number to unpackFrame_UAVSAR EJF 2020/08/02
 # modified to work for different UAVSAR stack segments EJF 2019/05/04
 
 import os
@@ -78,7 +79,7 @@ def main(iargs=None):
         imgDir = os.path.join(outputDir,imgDate)
         os.makedirs(imgDir, exist_ok=True)
 
-        cmd = 'unpackFrame_UAVSAR.py -i ' + annFile  + ' -d '+ inps.dopFile + ' -o ' + imgDir
+        cmd = 'unpackFrame_UAVSAR.py -i ' + annFile  + ' -d '+ inps.dopFile + ' -s '+ inps.segment + ' -o ' + imgDir
         print (cmd)
         os.system(cmd)
         

--- a/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
@@ -23,7 +23,7 @@ def createParser():
             help='Doppler file for the stack. Needs to be in directory where command is run.')
     parser.add_argument('-o', '--output', dest='output', type=str, required=True,
             help='output directory which will be used for unpacking.')
-    parser.add_argument('-s', '--segment', dest='segment', type=str, default='1',
+    parser.add_argument('-s', '--segment', dest='segment', type=int, default='1',
             help='segment of the UAVSAR stack to prepare. For "s2" use "2", etc. Default is "1" ')
     parser.add_argument('-t', '--text_cmd', dest='text_cmd', type=str, default='source ~/.bash_profile;', 
             help='text command to be added to the beginning of each line of the run files. Default: source ~/.bash_profile;')

--- a/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
@@ -23,7 +23,7 @@ def createParser():
             help='Doppler file for the stack. Needs to be in directory where command is run.')
     parser.add_argument('-o', '--output', dest='output', type=str, required=True,
             help='output directory which will be used for unpacking.')
-    parser.add_argument('-s', '--segment', dest='segment', type=int, default='1',
+    parser.add_argument('-s', '--segment', dest='segment', type=str, default='1',
             help='segment of the UAVSAR stack to prepare. For "s2" use "2", etc. Default is "1" ')
     parser.add_argument('-t', '--text_cmd', dest='text_cmd', type=str, default='source ~/.bash_profile;', 
             help='text command to be added to the beginning of each line of the run files. Default: source ~/.bash_profile;')

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# modified to pass the segment number to UAVSAR_STACK sensor EJF 2020/08/02
 
 import isce
 from isceobj.Sensor import createSensor
@@ -14,17 +15,19 @@ def cmdLineParse():
     Command line parser.
     '''
 
-    parser = argparse.ArgumentParser(description='Unpack CSK SLC data and store metadata in pickle file.')
+    parser = argparse.ArgumentParser(description='Unpack UAVSAR SLC data and store metadata in pickle file.')
     parser.add_argument('-i','--input', dest='h5dir', type=str,
-            required=True, help='Input CSK directory')
+            required=True, help='Input UAVSAR directory')
     parser.add_argument('-d','--dop_file', dest='dopFile', type=str,
             default=None, help='Doppler file')
+    parser.add_argument('-s','--segment', dest='stackSegment', type=str,
+            default=1, help='stack segment')
     parser.add_argument('-o', '--output', dest='slcdir', type=str,
             required=True, help='Output SLC directory')
     return parser.parse_args()
 
 
-def unpack(hdf5, slcname, dopFile, parse=False):
+def unpack(hdf5, slcname, dopFile, stackSegment, parse=False):
     '''
     Unpack HDF5 to binary SLC file.
     '''
@@ -33,6 +36,7 @@ def unpack(hdf5, slcname, dopFile, parse=False):
     obj.configure()
     obj.metadataFile = hdf5
     obj.dopplerFile = dopFile
+    obj.segment_index = stackSegment
     obj.parse()
 
     if not os.path.isdir(slcname):
@@ -54,4 +58,4 @@ if __name__ == '__main__':
     if inps.h5dir.endswith('/'):
         inps.h5dir = inps.h5dir[:-1]
 
-    unpack(inps.h5dir, inps.slcdir, inps.dopFile)
+    unpack(inps.h5dir, inps.slcdir, inps.dopFile, inps.stackSegment)

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
@@ -20,7 +20,7 @@ def cmdLineParse():
             required=True, help='Input UAVSAR directory')
     parser.add_argument('-d','--dop_file', dest='dopFile', type=str,
             default=None, help='Doppler file')
-    parser.add_argument('-s','--segment', dest='stackSegment', type=int,
+    parser.add_argument('-s','--segment', dest='stackSegment', type=str,
             default=1, help='stack segment')
     parser.add_argument('-o', '--output', dest='slcdir', type=str,
             required=True, help='Output SLC directory')

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
@@ -20,7 +20,7 @@ def cmdLineParse():
             required=True, help='Input UAVSAR directory')
     parser.add_argument('-d','--dop_file', dest='dopFile', type=str,
             default=None, help='Doppler file')
-    parser.add_argument('-s','--segment', dest='stackSegment', type=str,
+    parser.add_argument('-s','--segment', dest='stackSegment', type=int,
             default=1, help='stack segment')
     parser.add_argument('-o', '--output', dest='slcdir', type=str,
             required=True, help='Output SLC directory')


### PR DESCRIPTION
Modified `stripmapStack` `prepareUAVSAR_coregStack.py` and `unpackFrame_UAVSAR.py` to pass requested segment number to the `UAVSAR_stack` sensor object. Default is still segment 1, but this allows processing other segments of a multi-segment UAVSAR SLC stack.