### PR TITLE
CMake: Fix missing modules required for UAVSAR stripmap stack

### DIFF
--- a/components/isceobj/Sensor/CMakeLists.txt
+++ b/components/isceobj/Sensor/CMakeLists.txt
@@ -7,6 +7,7 @@ isce2_add_cdll(asa_im_decode src/asa_im_decode/asa_im_decode.c)
 set(installfiles
     asa_im_decode
     alos
+    cosar
     __init__.py
     ALOS.py
     ALOS2.py
@@ -91,5 +92,16 @@ target_include_directories(alos PUBLIC
     src/ALOS_pre_process
     )
 target_link_libraries(alos PUBLIC isce2::DataAccessorLib)
+
+Python_add_library(cosar MODULE
+    bindings/cosarmodule.cpp
+    src/cosar/Header.cpp
+    src/cosar/Burst.cpp
+    src/cosar/Cosar.cpp
+    )
+target_include_directories(cosar PUBLIC
+    include
+    src/cosar
+    )
 
 InstallSameDir(${installfiles})

--- a/components/isceobj/Util/CMakeLists.txt
+++ b/components/isceobj/Util/CMakeLists.txt
@@ -65,6 +65,7 @@ InstallSameDir(
     decorators.py
     mathModule.py
     offoutliers/Offoutliers.py
+    py2to3.py
     StringUtils.py
     Library/python/Poly1D.py
     Library/python/Poly2D.py

--- a/components/isceobj/Util/CMakeLists.txt
+++ b/components/isceobj/Util/CMakeLists.txt
@@ -58,7 +58,10 @@ target_include_directories(combinedLib INTERFACE
     $<$<COMPILE_LANGUAGE:Fortran>:${mdir}>
     )
 
+add_subdirectory(simamplitude)
+
 InstallSameDir(
+    simamplitude
     combinedlibmodule
     offoutliers
     __init__.py
@@ -71,4 +74,5 @@ InstallSameDir(
     Library/python/Poly2D.py
     Library/python/PolyFactory.py
     Library/python/Polynomial.py
+    simamplitude/Simamplitude.py
     )

--- a/components/isceobj/Util/simamplitude/CMakeLists.txt
+++ b/components/isceobj/Util/simamplitude/CMakeLists.txt
@@ -1,0 +1,10 @@
+Python_add_library(simamplitude MODULE
+    bindings/simamplitudemodule.cpp
+    src/simamplitudeSetState.F
+    src/simamplitude.f90
+    src/simamplitudeState.F
+    )
+target_include_directories(simamplitude PRIVATE include)
+target_link_libraries(simamplitude PRIVATE
+    isce2::DataAccessorLib
+    )

--- a/components/iscesys/Parsers/rdf/language/CMakeLists.txt
+++ b/components/iscesys/Parsers/rdf/language/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(grammar)
+add_subdirectory(lexis)
 InstallSameDir(
     __init__.py
     errors.py


### PR DESCRIPTION
Thanks to @nicodalse for pointing out these missing modules, which were needed to run the UAVSAR stripmap stack.

This is based on https://github.com/isce-framework/isce2/pull/168 - will rebase and remove draft status once that is merged.