### PR TITLE
topsStack: use OMP_NUM_THREADS for topo and drop ".full" for non-full-reso cpx cor file in FilterAndCoh

### DIFF
--- a/applications/downsampleDEM.py
+++ b/applications/downsampleDEM.py
@@ -30,11 +30,12 @@
 
 
 
-
+import os
 import sys
 import argparse
-import os
 from osgeo import gdal
+from isce.applications.gdal2isce_xml import gdal2isce_xml
+
 
 # command line parsing of input file
 def cmdLineParse():
@@ -62,11 +63,11 @@ if __name__ == '__main__':
 
     # check if the input file exist
     if not os.path.isfile(inps.input_dem_vrt):
-       raise Exception('Input file is not found ....')
+        raise Exception('Input file is not found ....')
     # check if the provided input file is a .vrt file and also get the envi filename
     input_dem_envi, file_extension = os.path.splitext(inps.input_dem_vrt)
     if file_extension != '.vrt':
-       raise Exception('Input file is not a vrt file ....')
+        raise Exception('Input file is not a vrt file ....')
     # get the file path
     input_path = os.path.dirname(os.path.abspath(inps.input_dem_vrt))
 
@@ -74,10 +75,20 @@ if __name__ == '__main__':
     # convert the output resolution from m in degrees
     # (this is approximate, could use instead exact expression)
     if inps.res_meter != '':
-        gdal_opts =  gdal.WarpOptions(format='ENVI',outputType=gdal.GDT_Int16,dstSRS='EPSG:4326',xRes=float(inps.res_meter)/110/1000,yRes=float(inps.res_meter)/110/1000,targetAlignedPixels=True)
+        gdal_opts =  gdal.WarpOptions(format='ENVI',
+                                      outputType=gdal.GDT_Int16,
+                                      dstSRS='EPSG:4326',
+                                      xRes=float(inps.res_meter)/110/1000,
+                                      yRes=float(inps.res_meter)/110/1000,
+                                      targetAlignedPixels=True)
 #        res_degree = float(inps.res_meter)/110/1000
     elif inps.res_seconds != '':
-        gdal_opts =  gdal.WarpOptions(format='ENVI',outputType=gdal.GDT_Int16,dstSRS='EPSG:4326',xRes=float(inps.res_seconds)*1/60*1/60,yRes=float(inps.res_seconds)*1/60*1/60,targetAlignedPixels=True)
+        gdal_opts =  gdal.WarpOptions(format='ENVI',
+                                      outputType=gdal.GDT_Int16,
+                                      dstSRS='EPSG:4326',
+                                      xRes=float(inps.res_seconds)*1/60*1/60,
+                                      yRes=float(inps.res_seconds)*1/60*1/60,
+                                      targetAlignedPixels=True)
 #        res_degree = float(1/60*1/60*float(inps.res_seconds))
 
     # The ENVI filename of the coarse DEM to be generated
@@ -90,5 +101,5 @@ if __name__ == '__main__':
     ds = None
 
     # Generating the ISCE xml and vrt of this coarse DEM
-    cmd = "gdal2isce_xml.py -i " + coarse_dem_envi
-    os.system(cmd)
+    gdal2isce_xml(coarse_dem_envi+'.vrt')
+

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -419,9 +419,8 @@ def runMultilook(in_dir, out_dir, alks, rlks, in_ext='.rdr', out_ext='.rdr', met
 
                 # generate ISCE .xml file
                 if not os.path.isfile(out_file+'.xml'):
-                    cmd = 'gdal2isce_xml.py -i {}.vrt'.format(out_file)
-                    print(cmd)
-                    os.system(cmd)
+                    from isce.applications.gdal2isce_xml import gdal2isce_xml
+                    gdal2isce_xml(out_file+'.vrt')
 
             else:
                 raise ValueError('un-supported multilook method: {}'.format(method))

--- a/contrib/stack/topsStack/FilterAndCoherence.py
+++ b/contrib/stack/topsStack/FilterAndCoherence.py
@@ -128,25 +128,31 @@ def estCpxCoherence(slc1_file, slc2_file, cpx_coh_file, alks=3, rlks=9):
     from isceobj.TopsProc.runBurstIfg import computeCoherence
     from mroipac.looks.Looks import Looks
 
+    # get the full resolution file name
+    if alks * rlks == 1:
+        cpx_coh_file_full = cpx_coh_file
+    else:
+        cpx_coh_file_full = cpx_coh_file+'.full'
+
     # calculate complex coherence in full resolution
-    computeCoherence(slc1_file, slc2_file, cpx_coh_file)
+    computeCoherence(slc1_file, slc2_file, cpx_coh_file_full)
 
     # multilook
-    print('Multilooking {0} ...'.format(cpx_coh_file))
+    if alks * rlks > 1:
+        print('Multilooking {0} ...'.format(cpx_coh_file_full))
 
-    inimg = isceobj.createImage()
-    inimg.load(cpx_coh_file + '.xml')
+        inimg = isceobj.createImage()
+        inimg.load(cpx_coh_file_full + '.xml')
 
-    outname = os.path.splitext(inimg.filename)[0]
-    lkObj = Looks()
-    lkObj.setDownLooks(alks)
-    lkObj.setAcrossLooks(rlks)
-    lkObj.setInputImage(inimg)
-    lkObj.setOutputFilename(outname)
-    lkObj.looks()
+        lkObj = Looks()
+        lkObj.setDownLooks(alks)
+        lkObj.setAcrossLooks(rlks)
+        lkObj.setInputImage(inimg)
+        lkObj.setOutputFilename(cpx_coh_file)
+        lkObj.looks()
 
-    # remove full resolution coherence file
-    ret=os.system('rm '+cpx_coh_file)
+        # remove full resolution coherence file
+        os.remove(cpx_coh_file_full)
     return
 
 

--- a/contrib/stack/topsStack/Stack.py
+++ b/contrib/stack/topsStack/Stack.py
@@ -76,7 +76,7 @@ class config(object):
         self.f.write('dem : ' + self.dem + '\n')
         self.f.write('geom_referenceDir : ' + self.geom_referenceDir + '\n')
         self.f.write('##########################' + '\n')
-    
+
     def geo2rdr(self,function):
         self.f.write('##########################' + '\n')
         self.f.write(function + '\n')
@@ -207,10 +207,10 @@ class config(object):
         self.f.write('strength : ' + self.filtStrength + '\n')
         self.f.write('slc1 : ' + self.slc1 + '\n')
         self.f.write('slc2 : ' + self.slc2 + '\n')
-        self.f.write('complex_coh : '+ self.cpxcor + '\n')
+        self.f.write('complex_coh : '+ self.cpxCohName + '\n')
         self.f.write('range_looks : ' + self.rangeLooks + '\n')
         self.f.write('azimuth_looks : ' + self.azimuthLooks + '\n')
-	
+
     def unwrap(self, function):
         self.f.write('###################################'+'\n')
         self.f.write(function + '\n')
@@ -248,18 +248,18 @@ class config(object):
 
         # CPU or GPU
         self.f.write('denseOffsets : ' + '\n')
-        #self.f.write('DenseOffsets : ' + '\n') 
-        #self.f.write('cuDenseOffsets : ' + '\n') 
+        #self.f.write('DenseOffsets : ' + '\n')
+        #self.f.write('cuDenseOffsets : ' + '\n')
         self.f.write('reference : ' + self.reference + '\n')
         self.f.write('secondary : ' + self.secondary + '\n')
         self.f.write('outprefix : ' + self.output + '\n')
-        
+
         #self.f.write('ww : 256\n')
         #self.f.write('wh : 128\n')
 
     def finalize(self):
         self.f.close()
- 
+
 
 class run(object):
     """
@@ -360,7 +360,7 @@ class run(object):
             configObj.reference = os.path.join(self.work_dir,'reference/')
             configObj.secondary = os.path.join(self.work_dir,'secondarys/'+secondary)
             configObj.baselineFile = os.path.join(self.work_dir, 'merged/baselines/' + secondary + '/' + secondary )
-            configObj.computeGridBaseline('[Function-1]')                                                                                                            
+            configObj.computeGridBaseline('[Function-1]')
             configObj.finalize()
             del configObj
             self.runf.write(self.text_cmd + 'SentinelWrapper.py -c ' + configName+'\n')
@@ -370,8 +370,8 @@ class run(object):
         configObj.configure(self)
         configObj.reference = os.path.join(self.work_dir,'reference/')
         configObj.secondary = os.path.join(self.work_dir,'reference/')
-        configObj.baselineFile = os.path.join(self.work_dir, 'merged/baselines/' + stackReferenceDate + '/' + stackReferenceDate) 
-        configObj.computeGridBaseline('[Function-1]')                                                                                                            
+        configObj.baselineFile = os.path.join(self.work_dir, 'merged/baselines/' + stackReferenceDate + '/' + stackReferenceDate)
+        configObj.computeGridBaseline('[Function-1]')
         configObj.finalize()
         del configObj
         self.runf.write(self.text_cmd + 'SentinelWrapper.py -c ' + configName+'\n')
@@ -476,11 +476,11 @@ class run(object):
             configObj.misregFile = os.path.join(self.work_dir , 'misreg/range/pairs/' + reference+'_'+secondary + '/' + reference+'_'+secondary + '.txt')
             configObj.rangeMisreg('[Function-4]')
             configObj.finalize()
-            
+
             self.runf.write(self.text_cmd + 'SentinelWrapper.py -c ' + configName + '\n')
             ########################
-    
-    
+
+
 
     def timeseries_misregistration(self):
         #inverting the misregistration offsets of the overlap pairs to estimate the offsets of each date
@@ -588,7 +588,7 @@ class run(object):
         geometryList = ['lat*rdr', 'lon*rdr', 'los*rdr', 'hgt*rdr', 'shadowMask*rdr','incLocal*rdr']
         multiookToolDict = {'lat*rdr': 'gdal', 'lon*rdr': 'gdal', 'los*rdr': 'gdal' , 'hgt*rdr':"gdal", 'shadowMask*rdr':"isce",'incLocal*rdr':"gdal"}
         noDataDict = {'lat*rdr': '0', 'lon*rdr': '0', 'los*rdr': '0' , 'hgt*rdr':None, 'shadowMask*rdr':None,'incLocal*rdr':"0"}
-        
+
         for i in range(len(geometryList)):
             pattern = geometryList[i]
             configName = os.path.join(self.config_path,'config_merge_' + pattern.split('*')[0])
@@ -629,7 +629,7 @@ class run(object):
             configObj.mergeBurst('[Function-1]')
             configObj.finalize()
             self.runf.write(self.text_cmd + 'SentinelWrapper.py -c ' + configName + '\n')
-    
+
             geometryList = ['lat*rdr', 'lon*rdr', 'los*rdr', 'hgt*rdr', 'shadowMask*rdr','incLocal*rdr']
             for i in range(len(geometryList)):
                 pattern = geometryList[i]
@@ -656,16 +656,18 @@ class run(object):
             reference = pair[0]
             secondary = pair[1]
             mergedDir = os.path.join(self.work_dir, 'merged/interferograms/' + reference + '_' + secondary)
-            mergedSLCDir = os.path.join(self.work_dir, 'merged/SLC')        
-            configName = os.path.join(self.config_path ,'config_igram_filt_coh_' + reference + '_' + secondary)
+            mergedSLCDir = os.path.join(self.work_dir, 'merged/SLC')
+            configName = os.path.join(self.config_path, 'config_igram_filt_coh_' + reference + '_' + secondary)
             configObj = config(configName)
             configObj.configure(self)
-            configObj.input = os.path.join(mergedDir,'fine.int')
-            configObj.filtName = os.path.join(mergedDir,'filt_fine.int')
-            configObj.cohName = os.path.join(mergedDir,'filt_fine.cor')
-            configObj.slc1=os.path.join(mergedSLCDir, '{}/{}.slc.full'.format(reference, reference))
-            configObj.slc2=os.path.join(mergedSLCDir, '{}/{}.slc.full'.format(secondary, secondary))
-            configObj.cpxcor=os.path.join(mergedDir,'fine.cor.full')
+            configObj.input = os.path.join(mergedDir, 'fine.int')
+            configObj.filtName = os.path.join(mergedDir, 'filt_fine.int')
+            configObj.cohName = os.path.join(mergedDir, 'filt_fine.cor')
+            configObj.slc1 = os.path.join(mergedSLCDir, '{}/{}.slc.full'.format(reference, reference))
+            configObj.slc2 = os.path.join(mergedSLCDir, '{}/{}.slc.full'.format(secondary, secondary))
+            configObj.cpxCohName = os.path.join(mergedDir, 'fine.cor')
+            if int(self.rangeLooks) * int(self.azimuthLooks) == 1:
+                configObj.cpxCohName += '.full'
             #configObj.filtStrength = str(self.filtStrength)
             configObj.FilterAndCoherence('[Function-1]')
             configObj.finalize()
@@ -769,7 +771,7 @@ class sentinelSLC(object):
             start = '<coordinates>'
             end = '</coordinates>'
             pnts = xmlstr[xmlstr.find(start)+len(start):xmlstr.find(end)].split()
-        
+
         else:
             file=os.path.join(safe,'preview/map-overlay.kml')
             kmlFile = open( file, 'r' ).read(-1)
@@ -777,7 +779,7 @@ class sentinelSLC(object):
             kmlData = ET.fromstring( kmlFile )
             document = kmlData.find('Document/Folder/GroundOverlay/gxLatLonQuad')
             pnts = document.find('coordinates').text.split()
-    
+
         # convert the pnts to a list
         from scipy.spatial import distance as dist
         import numpy as np
@@ -816,7 +818,7 @@ class sentinelSLC(object):
         # our bottom-right point
         D = dist.cdist(tl[np.newaxis], rightMost, "euclidean")[0]
         (br, tr) = rightMost[np.argsort(D)[::-1], :]
-        
+
         # return the coordinates in top-left, top-right,
         # bottom-right, and bottom-left order
         temp = np.array([tl, tr, br, bl], dtype="float32")
@@ -839,7 +841,7 @@ class sentinelSLC(object):
         for safe in self.safe_file.split():
            safeObj=sentinelSLC(safe)
            pnts = safeObj.getkmlQUAD(safe)
-           # The coordinates must be specified in counter-clockwise order with the first coordinate corresponding 
+           # The coordinates must be specified in counter-clockwise order with the first coordinate corresponding
            # to the lower-left corner of the overlayed image
            counter=0
            for pnt in pnts:
@@ -852,7 +854,7 @@ class sentinelSLC(object):
               elif counter==3:
                   lat_frame_max.append(float(pnt.split(',')[1]))
               counter+=1
-        
+
         self.SNWE=[min(lats),max(lats),min(lons),max(lons)]
 
         # checking for missing gaps, by doing a difference between end and start of frames
@@ -864,7 +866,7 @@ class sentinelSLC(object):
         lat_frame_min.sort()
         lat_frame_max.append(temp2)
         lat_frame_max.sort()
-        
+
         # combining the frame north and south left edge
         lat_frame_min = np.transpose(np.array(lat_frame_min))
         lat_frame_max = np.transpose(np.array(lat_frame_max))
@@ -882,7 +884,7 @@ class sentinelSLC(object):
             print(lat_frame_max)
             print(lat_frame_min-lat_frame_max)
             print("gap")"""
-        
+
         #raise Exception("STOP")
         self.frame_nogap=overlap_check
 
@@ -899,7 +901,7 @@ class sentinelSLC(object):
            print(obj.polarization)
            # add by Minyan
            obj.polarization='vv'
-          #obj.output = '{0}-SW{1}'.format(safe,swathnum)    
+          #obj.output = '{0}-SW{1}'.format(safe,swathnum)
            obj.parse()
 
            s,n,w,e = obj.product.bursts[0].getBbox()
@@ -1001,7 +1003,7 @@ echo This jobs runs on the following processors:
 echo `cat $PBS_NODEFILE`
 echo " "
 
-# 
+#
 # Run the parallel with the nodelist and command file
 #
 
@@ -1010,8 +1012,5 @@ echo " "
   f.write('parallel --sshloginfile $PBS_NODEFILE  -a ' + os.path.basename(runFile) + '\n')
   f.write('')
   f.close()
-  
+
 """
-
-
-

--- a/contrib/stack/topsStack/extractCommonValidRegion.py
+++ b/contrib/stack/topsStack/extractCommonValidRegion.py
@@ -2,16 +2,17 @@
 
 #Author: Heresh Fattahi
 
+import os
+import argparse
+import glob
+import numpy as np
+import gdal
 import isce
 import isceobj
-import numpy as np
-import argparse
-import os
 from isceobj.Sensor.TOPS import createTOPSSwathSLCProduct
 from mroipac.correlation.correlation import Correlation
 import s1a_isce_utils as ut
-import gdal
-import glob
+
 
 def createParser():
     parser = argparse.ArgumentParser( description='Extract valid overlap region for the stack')
@@ -76,7 +77,7 @@ def main(iargs=None):
     if not os.path.exists(stackDir):
         print('creating ', stackDir)
         os.makedirs(stackDir)
-    else:
+    elif len(glob.glob(os.path.join(stackDir, '*.xml'))) > 0:
         print(stackDir , ' already exists.')
         print('Replacing reference with existing stack.')
         inps.reference = stackDir
@@ -139,7 +140,7 @@ swath = ut.loadProduct(os.path.join(slcPath , 'IW{0}.xml'.format(2)))
 
 tref = swath.sensingStart
 rref = swath.bursts[0].startingRange
-dt = swath.bursts[0].azimuthTimeInterval 
+dt = swath.bursts[0].azimuthTimeInterval
 dr = swath.bursts[0].rangePixelSize
 
 

--- a/contrib/stack/topsStack/mergeBursts.py
+++ b/contrib/stack/topsStack/mergeBursts.py
@@ -1,4 +1,4 @@
-#
+#!/usr/bin/env python3
 # Author: Piyush Agram
 # Copyright 2016
 #

--- a/contrib/stack/topsStack/topo.py
+++ b/contrib/stack/topsStack/topo.py
@@ -97,7 +97,12 @@ def main(iargs=None):
         for ind in range(reference.numberOfBursts):
             inputs.append((dirname, demImage, reference, ind))
 
-    pool = mp.Pool(mp.cpu_count())
+    # parallel processing
+    numThread = int(os.environ.get('OMP_NUM_THREADS', mp.cpu_count()))
+    numThread = min(numThread, mp.cpu_count())
+    print('running in parallel with {} processes'.format(numThread))
+
+    pool = mp.Pool(numThread)
     results = pool.map(call_topo, inputs)
     pool.close()
 
@@ -106,7 +111,7 @@ def main(iargs=None):
 
     boxes = np.array(boxes)
     bbox = [np.min(boxes[:,0]), np.max(boxes[:,1]), np.min(boxes[:,2]), np.max(boxes[:,3])]
-    print ('bbox : ',bbox)
+    print('bbox : ', bbox)
     
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a few changes to the topsStack processor:

+ topsStack/topo: use `OMP_NUM_THREADS` if it's defined in the environment variables for the parallel processing; otherwise, use all available CPUs, same as before.
+ topsStack/FilterAndCoherence: drop the `.full` suffix to the output complex coherence filename if multilooking (>1) is applied.
+ topsStack/FilterAndCoherence: skip running `Looks()` module if no multilooking is applied.
+ topsStack/extractCommonValidRegion: check stack/*.xml file existance
+ replace the os.system() call of `gdal2isce_xml.py` with python funcation call, in `stripmapStack/topo.py` and `applications/downsampleDEM.py` (#126).

Supersedes #187.