### PR TITLE
make sure the orbit file glob also finds files starting with S1B

### DIFF
--- a/components/isceobj/Sensor/GRD/Sentinel1.py
+++ b/components/isceobj/Sensor/GRD/Sentinel1.py
@@ -467,7 +467,7 @@ class Sentinel1(Component):
         timeStamp = self.product.sensingStart+(self.product.sensingStop - self.product.sensingStart)/2.
         
         for orbType in types:
-            files = glob.glob( os.path.join(self.orbitDir, 'S1A_OPER_AUX_' + orbType + '_OPOD*'))
+            files = glob.glob( os.path.join(self.orbitDir, 'S1?_OPER_AUX_' + orbType + '_OPOD*'))
             filelist.extend(files)
             ###List all orbit files
 


### PR DESCRIPTION
Orbit files from Sentinel1B start with "S1B". However, the file globbing in the sentinel1.py code had "S1A" hardcoded, and thus it would fail to find orbit files for S1B.