### PR TITLE
Sentinel1 GRD thermal noise removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ The inputs are Sentinel GRD zipfiles
         <property name="epsg id">32618</property>
         <property name="geocode spacing">100</property>
         <property name="geocode interpolation method">bilinear</property>
+        <property name="apply thermal noise correction">True</property>
         <component name="reference">
         <property name="safe">$dir$/rtcApp/data/S1A_IW_GRDH_1SDV_20181221T225104_20181221T225129_025130_02C664_B46C.zip</property>
         <property name="orbit directory">$dir$/orbits</property>

--- a/applications/rtcApp.py
+++ b/applications/rtcApp.py
@@ -192,6 +192,14 @@ GEOCODE_LIST = Application.Parameter(
      doc = "List of products to geocode."
                                       )
 
+APPLY_THERMAL_NOISE_CORRECTION = Application.Parameter(
+        'apply_thermal_noise_correction',
+        public_name='apply thermal noise correction',
+        default=False,
+        type=bool,
+        mandatory=False,
+        doc = 'Flag to apply thermal noise correction. Currently only available for Sentinel-1.')
+
 
 #Facility declarations
 REFERENCE = Application.Facility(
@@ -244,7 +252,8 @@ class GRDSAR(Application):
                       PICKLE_LOAD_DIR,
                       RENDERER,
                       POLARIZATIONS,
-                      GEOCODE_LIST)
+                      GEOCODE_LIST,
+                      APPLY_THERMAL_NOISE_CORRECTION)
 
     facility_list = (REFERENCE,
                      DEM_STITCHER,

--- a/components/isceobj/RtcProc/runPreprocessor.py
+++ b/components/isceobj/RtcProc/runPreprocessor.py
@@ -42,7 +42,7 @@ def runPreprocessor(self):
         frame.product.endingSlantRange = r0max
 
         try:
-            reference = extract_slc(frame, slantRange=(not slantRangeExtracted))
+            reference = extract_slc(frame, slantRange=(not slantRangeExtracted), removeNoise=self.apply_thermal_noise_correction)
             success=True
             if not slantRangeExtracted:
                 r0min = frame.product.startingSlantRange
@@ -72,10 +72,10 @@ def runPreprocessor(self):
     catalog.printToLog(logger, "runPreprocessor")
     self._grd.procDoc.addAllFromCatalog(catalog)
 
-def extract_slc(sensor, slantRange=False):
+def extract_slc(sensor, slantRange=False, removeNoise=False):
 #    sensor.configure()
     sensor.parse()
-    sensor.extractImage()
+    sensor.extractImage(removeNoise=removeNoise)
    
     if slantRange:
         sensor.extractSlantRange()

--- a/components/isceobj/RtcProc/runPreprocessor.py
+++ b/components/isceobj/RtcProc/runPreprocessor.py
@@ -7,6 +7,7 @@ import logging
 import isceobj
 import copy
 import os
+import inspect
 logger = logging.getLogger('isce.grdsar.runPreprocessor')
 
 def runPreprocessor(self):
@@ -75,7 +76,12 @@ def runPreprocessor(self):
 def extract_slc(sensor, slantRange=False, removeNoise=False):
 #    sensor.configure()
     sensor.parse()
-    sensor.extractImage(removeNoise=removeNoise)
+    sensor_extractImage_spec = inspect.getfullargspec(sensor.extractImage)
+    if "removeNoise" in sensor_extractImage_spec.args or "removeNoise" in sensor_extractImage_spec.kwonlyargs:
+        sensor.extractImage(removeNoise=removeNoise)
+    else:
+        print('Noise removal requested, but sensor does not support noise removal.')
+        sensor.extractImage()
    
     if slantRange:
         sensor.extractSlantRange()


### PR DESCRIPTION
This PR implements the Thermal Noise Removal for Sentinel-1 GRD data in the rtcApp. It finalizes what was already there, and further enhances it (azimuth noise vectors, more accurate interpolation). A new parameter is added to rtcApp: "apply thermal noise correction", which defaults to False to not change the default behaviour.

The implementation tries to follow (the spirit of) https://sentinel.esa.int/documents/247904/2142675/Thermal-Denoising-of-Products-Generated-by-Sentinel-1-IPF. (though it differs a bit implementation-wise from what is suggested in that document, to improve performance).

I've tested this on several S1 GRD products with and without the noise correction applied, and then subtracted both results to check the final noise image. The noise images look as expected.

I hope this is a welcome addition, and that you are willing to consider inclusion in ISCE2.

PS sorry for the whitespace changes that kind of disturb the diff view, it's my editor doing that automatically. If it bothers you I could create a new PR without those.