### PR TITLE
topsStack: ignore coreg_secondary images with inconsistent num of bursts

### DIFF
--- a/components/isceobj/Util/ImageUtil/ImageLib.py
+++ b/components/isceobj/Util/ImageUtil/ImageLib.py
@@ -262,7 +262,7 @@ class memmap(object):
                 nyy = nbytes//(fsize*nchannels*nxx)
 
                 if (nxx*nyy*fsize*nchannels) != nbytes:
-                    raise ValueError('File size mismatch for %s. Fractional number of lines'(fname))
+                    raise ValueError('File size mismatch for %s. Fractional number of lines'%(fname))
             elif (nxx*nyy*fsize*nchannels) > nbytes:
                     raise ValueError('File size mismatch for %s. Number of bytes expected: %d'%(nbytes))
              

--- a/contrib/stack/topsStack/mergeBursts.py
+++ b/contrib/stack/topsStack/mergeBursts.py
@@ -362,6 +362,12 @@ def main(iargs=None):
             stack =  ut.loadProduct(os.path.join(inps.stack , 'IW{0}.xml'.format(swath)))
         if inps.isaligned:
             reference = ifg.reference
+
+            # checking inconsistent number of bursts in the secondary acquisitions
+            if reference.numberOfBursts != ifg.numberOfBursts:
+                raise ValueError('{} has different number of bursts ({}) than the reference ({})'.format(
+                    inps.reference, ifg.numberOfBursts, reference.numberOfBursts))
+
         else:
             reference = ifg
 
@@ -376,9 +382,7 @@ def main(iargs=None):
         if inps.stack:
             minStack = stack.bursts[0].burstNumber
             print('Updating the valid region of each burst to the common valid region of the stack')
-        ####Updating the valid region of each burst to the common valid region of the stack
             for ii in range(minBurst, maxBurst + 1):
-
                 ifg.bursts[ii-minBurst].firstValidLine = stack.bursts[ii-minStack].firstValidLine
                 ifg.bursts[ii-minBurst].firstValidSample = stack.bursts[ii-minStack].firstValidSample
                 ifg.bursts[ii-minBurst].numValidLines = stack.bursts[ii-minStack].numValidLines

--- a/contrib/stack/topsStack/s1a_isce_utils.py
+++ b/contrib/stack/topsStack/s1a_isce_utils.py
@@ -161,7 +161,6 @@ def adjustValidSampleLine_V2(reference, secondary, minAz=0, maxAz=0, minRng=0, m
 
     elif (minAz < 0) and  (maxAz < 0):
             reference.firstValidLine = secondary.firstValidLine - int(np.floor(minAz) - 4)
-            lastValidLine = reference.firstValidLine + secondary.numValidLines + int(np.floor(minAz) - 8)
             lastValidLine = reference.firstValidLine + secondary.numValidLines  - 8
             if lastValidLine < reference.numberOfLines:
                reference.numValidLines = secondary.numValidLines - 8

--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -523,7 +523,7 @@ def slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe_di
     if mergeSLC:
         i+=1
         runObj = run()
-        runObj.configure(inps, 'run_{:02d}_merge'.format(i))
+        runObj.configure(inps, 'run_{:02d}_merge_reference_secondary_slc'.format(i))
         runObj.mergeReference(stackReferenceDate, virtual = 'False')
         runObj.mergeSecondarySLC(secondaryDates, virtual = 'False')
         runObj.finalize()


### PR DESCRIPTION
This PR adds checking in `extractCommonValidRegion.py` and `mergeBursts.py` to skip images in the `coreg_secondarys` folder that have different numbers of bursts than the reference. Thanks to @piyushrpt for guidance on debugging and fixing.

The PR also rename the `merge` step run file in slc workflow to be consistent with the one from interferogram/correlation workflow.