### PR TITLE
Fix bug in DenseAmpcor.py

### DIFF
--- a/components/mroipac/ampcor/DenseAmpcor.py
+++ b/components/mroipac/ampcor/DenseAmpcor.py
@@ -345,9 +345,12 @@ class DenseAmpcor(Component):
         yMargin = 2*self.searchWindowSizeHeight + self.windowSizeHeight
 
         #####Set image limits for search
-        # limit_setting_option = 0 is the default and conventional way of setting limits
-        # limit_setting_option = 1 is a simpler way of setting limits which is used in the driver of GPU ampcor (PyCuAmpcor)
+        # limit_setting_option = 0 is the default and conventional logic of setting limits
+        # limit_setting_option = 1 is a simpler logic of setting limits 
+        # which is used in the driver (cuDenseOffsets.py) of GPU ampcor (PyCuAmpcor) (Add by Minyan Zhong)
+
         limit_setting_option = 0
+
         if limit_setting_option == 0:
             offAc = max(self.margin,-coarseAcross)+xMargin
             if offAc % self.skipSampleAcross != 0:
@@ -384,20 +387,17 @@ class DenseAmpcor(Component):
             length = self.fileLength1
 
             # determine the max number of windows
-            self.numberWindowAcross = (width - 2*self.margin - xMargin)//self.skipSampleAcross
-            self.numberWindowDown = (length - 2*self.margin - yMargin)//self.skipSampleDown
+            self.numLocationAcross = (width - 2*self.margin - xMargin)//self.skipSampleAcross
+            self.numLocationDown = (length - 2*self.margin - yMargin)//self.skipSampleDown
 
             # deterimine the location of windows
-            self.gridLocAcross = self.margin + self.skipSampleAcross * np.arange(self.numberWindowAcross) + self.pixLocOffAc
-            self.gridLocDown = self.margin + self.skipSampleDown * np.arange(self.numberWindowDown) + self.pixLocOffDn
+            self.gridLocAcross = self.margin + self.skipSampleAcross * np.arange(self.numLocationAcross) + self.pixLocOffAc
+            self.gridLocDown = self.margin + self.skipSampleDown * np.arange(self.numLocationDown) + self.pixLocOffDn
 
             startAc = self.gridLocAcross[0] - self.pixLocOffAc
             endAc = self.gridLocAcross[-1] - self.pixLocOffAc
 
             self.offsetCols, self.offsetLines = self.numLocationAcross, self.numLocationDown
-
-            self.numLocationAcross = self.numberWindowAcross
-            self.numLocationDown = self.numberWindowDown
         else:
             raise Exception("limit_setting_option must be 0 or 1")
 


### PR DESCRIPTION
This pull request for two purposes (1) fix a bug in DenseAmpcor.py, the script that calls the low-level fortran ampcor.F to generate (dense) offset fields and (2) add a simpler way of setting the location of chips given the parameters of chip and search window sizes.

(1) Fix the bug in DenseAmpcor.py
The bug I find is at line 419:
`startDown, endDown = proc_loc_down[0], proc_loc_down[-1]`
It should be:
`startDown, endDown = proc_loc_down[0] - self.pixLocOffDn, proc_loc_down[-1] - self.pixLocOffDn`


Some explanation for understanding the code and bug-fix:
1. `self.pixLocOffAc`, `self.pixLocOffDn` are the half reference chip size + search window size in across and down direction (see line 647 and 648). The are used as the offset from the starting pixel of the secondary chip to the center of the reference/seconsary chip.

2. `self.gridLocAcross` and `self.gridLocDown` store the the locations of the centers of all reference/secondary chips on the image in across and down directions. They are set at line 369 and 370: given the first and last valid pixel of the image (offAc, lastAc, offDn, lastDn), both self.pixLocOffAc and self.pixLocOffDn are used to determine the chip center.

3. `startAc, endAc, startDown, endDown` are the starting pixel of the first and last secondary chips. They are passed to low-level ampcor.F. To set these four parameters:

At line 372:
`startAc, endAc = offAc, self.gridLocAcross[-1] - self.pixLocOffAc`
startAc and endAc are correctly set as the starting pixel of the secondary chip.

But at line 418-419:
`proc_loc_down = self.gridLocDown[istart:iend]`
`startDown, endDown = proc_loc_down[0], proc_loc_down[-1]`

startDown and endDown are set as the center of the reference/secondary chip by mistake.

It should be:
`startDown, endDown = proc_loc_down[0] - self.pixLocOffDn, proc_loc_down[-1] - self.pixLocOffDn`

4. This code was correct in its original version. I find that it is correct in isce-2.1.0 (released in 2017). However, it is changed into this way in another version of isce2 in May 2018.

(2) Add a simpler way of setting the location of chips.
The current way of setting the location of chips is a bit complicated and difficult to understand. When developing GPU ampcor, we use a much simpler logic of determining this.  I use `limit_setting_option` to determine which logic to use. The default logic is the conventional one (limit_setting_option=0). To turn on the new logic, user needs to set limit_setting_option manually to 1 in the code. I don't expose this as a configurable parameter because it will introduce unnecessary complexity to common users of ISCE, but would like to keep it there for future developers of GPU ampcor for benchmark purposes.


