### PR TITLE
Modernize gdal imports

### DIFF
--- a/components/isceobj/StripmapProc/runInterferogram.py
+++ b/components/isceobj/StripmapProc/runInterferogram.py
@@ -9,7 +9,7 @@ import logging
 from components.stdproc.stdproc import crossmul
 from iscesys.ImageUtil.ImageUtil import ImageUtil as IU
 import os
-import gdal
+from osgeo import gdal
 import numpy as np
 
 logger = logging.getLogger('isce.insar.runInterferogram')

--- a/contrib/UnwrapComp/unwrapComponents.py
+++ b/contrib/UnwrapComp/unwrapComponents.py
@@ -7,7 +7,7 @@ import isce
 import isceobj
 from imageMath import IML
 from osgeo import gdal
-from gdalconst import *
+from osgeo.gdalconst import *
 
 import logging
 import scipy.spatial as SS

--- a/contrib/stack/stripmapStack/MaskAndFilter.py
+++ b/contrib/stack/stripmapStack/MaskAndFilter.py
@@ -9,8 +9,8 @@ import argparse
 import numpy as np
 from scipy import ndimage
 import matplotlib.pyplot as plt
-import gdal
-from gdalconst import GA_ReadOnly
+from osgeo import gdal
+from osgeo.gdalconst import GA_ReadOnly
 
 # suppress the DEBUG message
 import logging

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -9,7 +9,7 @@ import isce
 import isceobj
 from isceobj.Constants import SPEED_OF_LIGHT
 import numpy as np
-import gdal
+from osgeo import gdal
 import shelve
 
 from scipy import ndimage

--- a/contrib/stack/stripmapStack/geocodeGdal.py
+++ b/contrib/stack/stripmapStack/geocodeGdal.py
@@ -7,7 +7,7 @@ import argparse
 import isce
 import isceobj
 import os
-import gdal
+from osgeo import gdal
 import xml.etree.ElementTree as ET
 
 def createParser():

--- a/contrib/stack/stripmapStack/invertOffsets.py
+++ b/contrib/stack/stripmapStack/invertOffsets.py
@@ -15,7 +15,7 @@ from isceobj.Util.Poly2D import Poly2D
 import h5py
 from insarPair import insarPair
 from insarStack import insarStack
-import gdal
+from osgeo import gdal
 
 
 #################################################################

--- a/contrib/stack/stripmapStack/prepStripmap4timeseries.py
+++ b/contrib/stack/stripmapStack/prepStripmap4timeseries.py
@@ -8,8 +8,8 @@ import os
 import glob
 import isce
 import isceobj
-import gdal
-from gdalconst import GA_ReadOnly
+from osgeo import gdal
+from osgeo.gdalconst import GA_ReadOnly
 #import s1a_isce_utils as ut
 from isceobj.Planet.Planet import Planet
 import shelve

--- a/contrib/stack/stripmapStack/reader.py
+++ b/contrib/stack/stripmapStack/reader.py
@@ -2,8 +2,8 @@
 # Heresh Fattahi
 
 import os
-import gdal
-from gdalconst import GA_ReadOnly
+from osgeo import gdal
+from osgeo.gdalconst import GA_ReadOnly
 import numpy as np
 from lxml import objectify
 

--- a/contrib/stack/stripmapStack/resampleOffsets.py
+++ b/contrib/stack/stripmapStack/resampleOffsets.py
@@ -7,9 +7,8 @@ import os
 import isce
 import isceobj
 import shelve
-import gdal
-import osr
-from gdalconst import GA_ReadOnly
+from osgeo import gdal, osr
+from osgeo.gdalconst import GA_ReadOnly
 from scipy import ndimage
 
 

--- a/contrib/stack/stripmapStack/rubberSheeting.py
+++ b/contrib/stack/stripmapStack/rubberSheeting.py
@@ -8,9 +8,8 @@ import os
 import isce
 import isceobj
 import shelve
-import gdal
-import osr  
-from gdalconst import GA_ReadOnly
+from osgeo import gdal, osr
+from osgeo.gdalconst import GA_ReadOnly
 from scipy import ndimage
 
 

--- a/contrib/stack/stripmapStack/saveKml.py
+++ b/contrib/stack/stripmapStack/saveKml.py
@@ -7,7 +7,7 @@ import argparse
 import isce
 import isceobj
 import os
-import gdal
+from osgeo import gdal
 import matplotlib as mpl;  #mpl.use('Agg')
 import matplotlib.pyplot as plt
 from pykml.factory import KML_ElementMaker as KML

--- a/contrib/stack/stripmapStack/splitSpectrum.py
+++ b/contrib/stack/stripmapStack/splitSpectrum.py
@@ -16,7 +16,7 @@ import time
 #import matplotlib.pyplot as plt
 from contrib.splitSpectrum import SplitRangeSpectrum as splitSpectrum
 from isceobj.Constants import SPEED_OF_LIGHT
-import gdal
+from osgeo import gdal
 
 
 def createParser():

--- a/contrib/stack/stripmapStack/splitSpectrum_multiple.py
+++ b/contrib/stack/stripmapStack/splitSpectrum_multiple.py
@@ -16,7 +16,7 @@ import time
 #import matplotlib.pyplot as plt
 from contrib.splitSpectrum import SplitRangeSpectrum as splitSpectrum
 from isceobj.Constants import SPEED_OF_LIGHT
-import gdal
+from osgeo import gdal
 
 
 def createParser():

--- a/contrib/stack/stripmapStack/topo.py
+++ b/contrib/stack/stripmapStack/topo.py
@@ -6,7 +6,7 @@ import shelve
 import datetime
 import shutil
 import numpy as np
-import gdal
+from osgeo import gdal
 import isce
 import isceobj
 from isceobj.Constants import SPEED_OF_LIGHT

--- a/contrib/stack/topsStack/MaskAndFilter.py
+++ b/contrib/stack/topsStack/MaskAndFilter.py
@@ -9,8 +9,8 @@ import argparse
 import os   
 import isce
 import isceobj
-import gdal
-from gdalconst import GA_ReadOnly
+from osgeo import gdal
+from osgeo.gdalconst import GA_ReadOnly
 from scipy import ndimage
 
 

--- a/contrib/stack/topsStack/extractCommonValidRegion.py
+++ b/contrib/stack/topsStack/extractCommonValidRegion.py
@@ -6,7 +6,7 @@ import os
 import argparse
 import glob
 import numpy as np
-import gdal
+from osgeo import gdal
 import isce
 import isceobj
 from isceobj.Sensor.TOPS import createTOPSSwathSLCProduct

--- a/contrib/stack/topsStack/generateIgram.py
+++ b/contrib/stack/topsStack/generateIgram.py
@@ -13,7 +13,7 @@ import copy
 from isceobj.Sensor.TOPS import createTOPSSwathSLCProduct 
 from mroipac.correlation.correlation import Correlation
 import s1a_isce_utils as ut
-import gdal
+from osgeo import gdal
 
 
 def createParser():

--- a/contrib/stack/topsStack/geocodeGdal.py
+++ b/contrib/stack/topsStack/geocodeGdal.py
@@ -7,7 +7,7 @@ import argparse
 import isce
 import isceobj
 import os
-import gdal
+from osgeo import gdal
 import numpy as np
 import xml.etree.ElementTree as ET
 

--- a/contrib/stack/topsStack/grossOffsets.py
+++ b/contrib/stack/topsStack/grossOffsets.py
@@ -12,7 +12,7 @@ from iscesys.Component.ProductManager import ProductManager as PM
 import numpy as np
 from netCDF4 import Dataset
 #from mpl_toolkits.basemap import Basemap
-import gdal
+from osgeo import gdal
 
 from scipy.interpolate import interp2d, griddata
 

--- a/contrib/stack/topsStack/prep4timeseries.py
+++ b/contrib/stack/topsStack/prep4timeseries.py
@@ -8,8 +8,8 @@ import os
 import glob
 import isce
 import isceobj
-import gdal
-from gdalconst import GA_ReadOnly
+from osgeo import gdal
+from osgeo.gdalconst import GA_ReadOnly
 import s1a_isce_utils as ut
 from isceobj.Planet.Planet import Planet
 

--- a/contrib/stack/topsStack/rubberSheeting.py
+++ b/contrib/stack/topsStack/rubberSheeting.py
@@ -11,9 +11,8 @@ import os
 import isce
 import isceobj
 import shelve
-import gdal
-import osr  
-from gdalconst import GA_ReadOnly
+from osgeo import gdal, osr
+from osgeo.gdalconst import GA_ReadOnly
 from scipy import ndimage
 
 

--- a/contrib/stack/topsStack/saveKml.py
+++ b/contrib/stack/topsStack/saveKml.py
@@ -7,7 +7,7 @@ import argparse
 import isce
 import isceobj
 import os
-import gdal
+from osgeo import gdal
 import matplotlib as mpl;  #mpl.use('Agg')
 import matplotlib.pyplot as plt
 from pykml.factory import KML_ElementMaker as KML

--- a/contrib/stack/topsStack/unwrap.py
+++ b/contrib/stack/topsStack/unwrap.py
@@ -38,7 +38,7 @@ from isceobj.Constants import SPEED_OF_LIGHT
 import argparse
 import os
 import pickle
-import gdal
+from osgeo import gdal
 import numpy as np
 #import shelve
 import s1a_isce_utils as ut

--- a/contrib/timeseries/prepStackToStaMPS/bin/step_baseline_stack.py
+++ b/contrib/timeseries/prepStackToStaMPS/bin/step_baseline_stack.py
@@ -56,7 +56,7 @@ def baselinegrid(inps):
     """ 
         Basline files are given as grids
     """
-    import gdal 
+    from osgeo import gdal
 
     # parsing the command line inputs
     baseline_dir = inps.baseline_dir


### PR DESCRIPTION
GDAL has dropped support for the older toplevel `import gdal`
in version 3.2, now requiring `from osgeo import gdal`.