### PR TITLE
Update rtcApp.py

### DIFF
--- a/applications/rtcApp.py
+++ b/applications/rtcApp.py
@@ -424,8 +424,7 @@ class GRDSAR(Application):
         self.step('normalize', func=self.runNormalize)
 
         # Geocode
-        self.step('geocode', func=self.runGeocode,
-                args=(self.geocode_list, self.geocode_bbox))
+        self.step('geocode', func=self.runGeocode)
 
         return None
 


### PR DESCRIPTION
I recommend to remove the arguments args=(self.geocode_list, self.geocode_bbox) since it passes the arguments on the runGeocode.py of the RtcProc which prevents geocoding of the sigma nought product generated from the rtcApp.py. This could be added later if someone would incorporate the geocode_list and geocode_bbox on the runGeocode.py later.