### PR TITLE
add some includes for c header files

### DIFF
--- a/components/isceobj/Util/src/io.c
+++ b/components/isceobj/Util/src/io.c
@@ -1,11 +1,12 @@
 /* SccsId[ ]= @(#)io.c	1.1 2/5/92 */
-#include <stdio.h> 
+#include <stdio.h>
 #include <fcntl.h>
 
 /* modified to add iolen function EJF 96/8/29 */
 
 #include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
 
 #define PERMS 0666
 /* IO library:
@@ -14,10 +15,10 @@
  */
 
 /* To open a file and assign a channel to it. This must be
-   done before any attempt is made to access the file. The 
+   done before any attempt is made to access the file. The
    return value (initdk) is the file descriptor. The file can
    be closed with the closedk subroutine.
-   
+
    Remember, always open files before you need to access to them
    and close them after you don't need them any more. In UNIX,
    there is a limit (20) of number files can be opened at once.
@@ -32,7 +33,7 @@
 
          lun is the dummy variable to be compatible with VMS calls.
 
-         filename is the name of the file. Include directory paths 
+         filename is the name of the file. Include directory paths
          if necessary.
  */
 
@@ -57,20 +58,20 @@ int *lun; char *filename;
 
 /* To write data into a previous opened file. This routine
    will wait until the write operations are completed.
-  
+
    Calling sequence (from FORTRAN):
          nbytes = iowrit( chan, buff, bytes)
 	 call iowrit(chan,buff,bytes)
    where:
          nbytes is the number bytes that transfered.
-   
+
          chan is the file descriptor.
 
          buff is the buffer or array containing the data you
          wish to write.
 
          bytes is the number of bytes you wish to write.
-*/ 
+*/
 
 #ifndef UL
 int iowrit(chan, buff, bytes)
@@ -79,7 +80,7 @@ int iowrit_(chan, buff, bytes)
 #endif
 int *chan, *bytes;
 char *buff;
-{  
+{
    int nbytes;
    nbytes = write(*chan, buff, *bytes);
    if(nbytes != *bytes) fprintf(stderr,
@@ -96,9 +97,9 @@ char *buff;
        call ioread( chan, buff, bytes)
    where:
        nbytes is the number bytes that transfered.
-  
+
        chan is the file descriptor.
- 
+
        buff is the buffer or array containning the data you wish
        to read.
 
@@ -114,7 +115,7 @@ int ioread_(chan, buff, bytes)
 
 int *chan, *bytes ;
 char *buff;
-{  
+{
    int nbytes;
    nbytes = read(*chan, buff, *bytes);
    if(nbytes != *bytes) fprintf(stderr,
@@ -124,7 +125,7 @@ char *buff;
 }
 
 
-/* To position the file pointer. This routine will call the lseek 
+/* To position the file pointer. This routine will call the lseek
    to update the file pointer.
 
    Calling sequence (from FORTRAN):
@@ -139,7 +140,7 @@ char *buff;
         must be greater or equal to zero for positioning the file at
         that location. If loc_byte is negative, the file pointer will
         move abs(loc_byte) from the current location.
-        
+
 */
 
 #ifdef C32_IO
@@ -150,7 +151,7 @@ int ioseek_(chan, loc_byte)
 #endif
 
 int *chan, *loc_byte;
-{  
+{
    int ibytes,nloc;
    ibytes = *loc_byte ;
    if(ibytes >= 0) nloc = lseek(*chan, ibytes, 0);
@@ -171,7 +172,7 @@ off64_t ioseek_(chan, loc_byte)
 
 int *chan;
 off64_t *loc_byte;
-{  
+{
    off64_t ibytes,nloc;
    ibytes = *loc_byte ;
    if(ibytes >= 0) nloc = lseek64(*chan, ibytes, 0);
@@ -190,7 +191,7 @@ off64_t *loc_byte;
       call closedk( lun, chan)
    where:
       istatus is the return value (0 is success, -1 is error)
- 
+
       lun is the dummy variable to be compatible the VAX VMS call.
 
       chan is the file descriptor that you want to close.
@@ -209,7 +210,7 @@ int *lun, *chan;
 
 
 
-/* To determine the file length. This routine will call lseek 
+/* To determine the file length. This routine will call lseek
    to find the end of the file, and return the length in bytes.
    The file pointer is then set back to the beginning.
 
@@ -232,7 +233,7 @@ int iolen(chan)
 int iolen_(chan)
 #endif
 int *chan;
-{  
+{
    off_t nloc, junk;
    nloc = lseek(*chan, (off_t)0, SEEK_END); /* go to end, get length */
    printf("length 32bits=%d\n",(int)nloc);
@@ -248,7 +249,7 @@ int iolen(chan)
 int iolen_(chan)
 #endif
 int *chan;
-{  
+{
    off64_t nloc, junk;
    nloc = lseek64(*chan, (off64_t)0, SEEK_END); /* go to end, get length */
    printf("length 64bits=%d\n",(int)nloc);

--- a/components/isceobj/Util/src/second.c
+++ b/components/isceobj/Util/src/second.c
@@ -1,8 +1,8 @@
-#include	<unistd.h>
-#include	<sys/time.h>
-#include	<sys/times.h>
-#include	<sys/resource.h>
-#include    <stdio.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/times.h>
+#include <sys/resource.h>
+#include <stdio.h>
 
 #if defined(NEEDS_F77_TRANSLATION)
 

--- a/components/isceobj/Util/src/second.c
+++ b/components/isceobj/Util/src/second.c
@@ -2,6 +2,7 @@
 #include	<sys/time.h>
 #include	<sys/times.h>
 #include	<sys/resource.h>
+#include    <stdio.h>
 
 #if defined(NEEDS_F77_TRANSLATION)
 
@@ -58,7 +59,7 @@
     return (0.0);							\
   }									\
   return ((double) s_val.tv_sec + 0.000001*s_val.tv_usec - t0);
-  
+
 /* Returns the current value of the wall clock timer.
  * Fortran or C entry point.
  */
@@ -68,7 +69,7 @@ wc_second()
 {
   WC_GUTS;
 }
-  
+
 #define	US_GUTS								\
 									\
   static int	first = 1;						\
@@ -99,7 +100,7 @@ us_second()
 }
 
 /* Returns the current value of the wall clock timer, or
- * user+system timer depending on the valueof tmode: 
+ * user+system timer depending on the valueof tmode:
  * less than zero the wall-clock timer, and greater than zero
  * user+system time.
  * If/when called from C, tmode must be passed by reference.

--- a/components/mroipac/geolocate/src/geolocate_wrapper.c
+++ b/components/mroipac/geolocate/src/geolocate_wrapper.c
@@ -1,5 +1,3 @@
-
-//
 void geolocate_(double *, double *, double *, double *, int *, double *, double *, double *, double *, double *);
 
 // A wrapper for the Fortran geolocation code

--- a/components/mroipac/geolocate/src/geolocate_wrapper.c
+++ b/components/mroipac/geolocate/src/geolocate_wrapper.c
@@ -1,3 +1,7 @@
+
+//
+void geolocate_(double *, double *, double *, double *, int *, double *, double *, double *, double *, double *);
+
 // A wrapper for the Fortran geolocation code
 int geolocate_wrapper(double *pos, double *vel, double range, double squint, int side, double a, double e2, double *llh, double *lookAngle, double *incidenceAngle)
 {

--- a/contrib/mdx/src/graphx_mdx.c
+++ b/contrib/mdx/src/graphx_mdx.c
@@ -41,6 +41,7 @@ here insofar as such code may exist in this Software.
 #include <Xm/DrawnB.h>
 #include <Xm/ScrolledW.h>
 #include <Xm/Label.h>
+#include <Xm/ScrollBar.h>
 #include <X11/cursorfont.h>
 #include <X11/keysym.h>    /* for popup window only */
 


### PR DESCRIPTION
Apple clang 12.0.0 reports errors for implicit declarations. This PR fixes some missing header file includes. Now ISCE2 can be compiled with the newest Bug Sur + Xcode 12.3, together with brew installed gfortran and conda. 

PS: my editor automatically removes the extra spaces at the end of line. For io.c, the only change is adding #include <string.h> for calling strlen(). 