### PR TITLE
GPUtopozero: change isnan reference for compatibility with gcc<6

### DIFF
--- a/components/zerodop/GPUtopozero/src/AkimaLib.cpp
+++ b/components/zerodop/GPUtopozero/src/AkimaLib.cpp
@@ -9,14 +9,13 @@
 
 #include <algorithm>
 #include <vector>
-#include <cmath>
+#include <math.h>
 #include <cstdio>
 #include "AkimaLib.h"
 #include "Constants.h"
 using std::max;
 using std::min;
 using std::vector;
-using std::isnan;
 
 bool AkimaLib::aki_almostEqual(double x, double y) {
     bool ret = (abs(x - y) <= AKI_EPS) ? true : false; // Compressed version is a little cleaner


### PR DESCRIPTION
gcc 4.8 on RHEL7 reports an error when compiling GPUtopozero/AkimaLib.cpp:

```
‘isnan’ is already declared in this scope
 using std::isnan;
```

According to [this](https://stackoverflow.com/questions/39130040/cmath-hides-isnan-in-math-h-in-c14-c11), the most compatible solution is to use math.h and call isnan directly. 

Now all cuda modules can be compiled by gcc>=4.8, as [promised](https://github.com/isce-framework/isce2#basic); though different versions of CUDA may have [their own recommended compilers](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements). 
