### PR TITLE
GPU modules: add GPU_ACC_ENABLED flag to cmake

### DIFF
--- a/components/zerodop/GPUampcor/CMakeLists.txt
+++ b/components/zerodop/GPUampcor/CMakeLists.txt
@@ -11,8 +11,11 @@ cython_add_module(GPUampcor
     src/AmpcorFFT.cpp
     src/AmpcorMethods.cpp
     )
-target_include_directories(GPUampcor PUBLIC
+target_include_directories(GPUampcor PRIVATE
     include
+    )
+target_compile_definitions(GPUampcor PRIVATE
+    GPU_ACC_ENABLED
     )
 target_link_libraries(GPUampcor PRIVATE
     CUDA::cublas

--- a/components/zerodop/GPUgeo2rdr/CMakeLists.txt
+++ b/components/zerodop/GPUgeo2rdr/CMakeLists.txt
@@ -8,8 +8,11 @@ cython_add_module(GPUgeo2rdr
     src/Orbit.cpp
     src/Poly1d.cpp
     )
-target_include_directories(GPUgeo2rdr PUBLIC
+target_include_directories(GPUgeo2rdr PRIVATE
     include
+    )
+target_compile_definitions(GPUgeo2rdr PRIVATE
+    GPU_ACC_ENABLED
     )
 target_link_libraries(GPUgeo2rdr PRIVATE
     isce2::DataAccessorLib

--- a/components/zerodop/GPUresampslc/CMakeLists.txt
+++ b/components/zerodop/GPUresampslc/CMakeLists.txt
@@ -9,6 +9,9 @@ cython_add_module(GPUresampslc
 target_include_directories(GPUresampslc PRIVATE
     include
     )
+target_compile_definitions(GPUresampslc PRIVATE
+    GPU_ACC_ENABLED
+    )
 target_link_libraries(GPUresampslc PRIVATE
     isce2::DataAccessorLib
     OpenMP::OpenMP_CXX

--- a/components/zerodop/GPUtopozero/CMakeLists.txt
+++ b/components/zerodop/GPUtopozero/CMakeLists.txt
@@ -16,6 +16,9 @@ cython_add_module(GPUtopozero
 target_include_directories(GPUtopozero PRIVATE
     include
     )
+target_compile_definitions(GPUtopozero PRIVATE
+    GPU_ACC_ENABLED
+    )
 target_link_libraries(GPUtopozero PRIVATE
     isce2::DataAccessorLib
     OpenMP::OpenMP_CXX


### PR DESCRIPTION
GPU modules under components/zerodop seem to include both CPU and GPU versions and use a GPU_ACC_ENABLED flag to control which version to run. Therefore, we need to add this flag to cmake, as also included in SCons. 

GPUtopozero, GPUgeo2rdr, as included in Alos2Proc, TopsProc, have been tested to run as expected. 

GPUresampslc is not included in any script, and has not been tested. 

GPUampcor is out-dated and has not been tested.