### PR TITLE
Add URL support to DataAccessor

### DIFF
--- a/components/iscesys/ImageApi/DataAccessor/DataAccessorPy.py
+++ b/components/iscesys/ImageApi/DataAccessor/DataAccessorPy.py
@@ -142,7 +142,12 @@ class DataAccessor(object):
         caster = '' or self.caster
         filename = self.filename
         scheme = self.scheme
-        self.extraFilename = self.filename + '.' + self._extra_reader
+        #if the filename is a URL, the extraFilename should indicate the file from the local machine
+        #instead of from the remote server.
+        if self.filename.startswith('http'):
+            self.extraFilename = os.path.basename(self.filename) + '.' + self._extra_reader
+        else:
+            self.extraFilename = self.filename + '.' + self._extra_reader
 
         if self._accessor is None:#to avoid creating duplicates
             selection = self.methodSelector()

--- a/components/iscesys/ImageApi/DataAccessor/DataAccessorPy.py
+++ b/components/iscesys/ImageApi/DataAccessor/DataAccessorPy.py
@@ -144,7 +144,7 @@ class DataAccessor(object):
         scheme = self.scheme
         #if the filename is a URL, the extraFilename should indicate the file from the local machine
         #instead of from the remote server.
-        if self.filename.startswith('http'):
+        if self.filename.startswith('http://') or self.filename.startswith('https://'):
             self.extraFilename = os.path.basename(self.filename) + '.' + self._extra_reader
         else:
             self.extraFilename = self.filename + '.' + self._extra_reader


### PR DESCRIPTION
As discussed in #243, I edited the rule for finding the VRT -- if the file name is actually a URL, the Data Accessor will read the corresponding VRT file (that points to the remote, original file) on the local machine. It should be compatible with almost all the ICSE use cases. Let me know if you have any questions about this change.

Thanks!