### PR TITLE
Update Sentinel download URL

### DIFF
--- a/contrib/stack/topsStack/README.md
+++ b/contrib/stack/topsStack/README.md
@@ -37,7 +37,7 @@ The following calibration auxliary (AUX_CAL) file is used for **antenna pattern 
 Run the command below to download the AUX_CAL file once and store it somewhere (_i.e._ ~/aux/aux_cal) so that you can use it all the time, for `stackSentinel.py -a` or `auxiliary data directory` in `topsApp.py`.
 
 ```
-wget https://qc.sentinel1.eo.esa.int/product/S1A/AUX_CAL/20140908T000000/S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE.TGZ
+wget https://aux.sentinel1.eo.esa.int/product/S1A/AUX_CAL/20140908T000000/S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE.TGZ
 tar zxvf S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE.TGZ
 rm S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE.TGZ
 ```

--- a/contrib/stack/topsStack/dloadOrbits.py
+++ b/contrib/stack/topsStack/dloadOrbits.py
@@ -14,7 +14,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 fmt = '%Y%m%d'
 today  = datetime.datetime.now().strftime(fmt)
 
-server = 'https://qc.sentinel1.eo.esa.int/'
+server = 'https://aux.sentinel1.eo.esa.int/'
 queryfmt = '%Y-%m-%d'
 datefmt = '%Y%m%dT%H%M%S'
 

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -8,8 +8,7 @@ import argparse
 import datetime
 from html.parser import HTMLParser
 
-server = 'https://qc.sentinel1.eo.esa.int/'
-server2 = 'http://aux.sentinel1.eo.esa.int/'
+server = 'https://aux.sentinel1.eo.esa.int/'
 
 orbitMap = [('precise','aux_poeorb'),
             ('restituted','aux_resorb')]
@@ -202,7 +201,7 @@ if __name__ == '__main__':
 
                     if (tbef <= fileTSStart) and (taft >= fileTS):
                         datestr2 = FileToTimeStamp(result)[0].strftime(queryfmt2) 
-                        match = (server2 + spec[1].replace('aux_', '').upper() +
+                        match = (server + spec[1].replace('aux_', '').upper() +
                                  '/' +datestr2+ result + '.EOF')
                         break
 

--- a/examples/input_files/reference_TOPS_SENTINEL1.xml
+++ b/examples/input_files/reference_TOPS_SENTINEL1.xml
@@ -24,7 +24,7 @@ All file paths in the input files should either be absolute paths or relative to
     For more details on what these corrections are and where to get the aux files, see: https://sentinel.esa.int/documents/247904/1653440/Sentinel-1-IPF_EAP_Phase_correction
 
     Aux data can be accessed here: 
-    https://qc.sentinel1.eo.esa.int/aux_cal/?instrument_configuration_id=3
+    https://aux.sentinel1.eo.esa.int/aux_cal/?instrument_configuration_id=3
 
     
     Note 3: Precise orbits
@@ -33,10 +33,10 @@ All file paths in the input files should either be absolute paths or relative to
     Use of precise / restituted orbits are highly recommend for precise processing of Sentinel-1A interferograms. You can dump all the orbits in a common folder and ISCE will automatically identify the right orbit file to use with your data.
 
     Precise orbit data can be accessed here and are typically available 3 weeks after the SLCs are available:
-    https://qc.sentinel1.eo.esa.int/aux_poeorb/
+    https://aux.sentinel1.eo.esa.int/aux_poeorb/
 
     Restituted orbits can be accessed here and are available at the same time as the SLCs:
-    https://qc.sentinel1.eo.esa.int/aux_resorb/
+    https://aux.sentinel1.eo.esa.int/aux_resorb/
 
 
     Note 3: Multiple slices


### PR DESCRIPTION
The old S1 orbits site is no longer active, as noted by @piyushrpt: https://github.com/isce-framework/isce2/issues/249#issuecomment-791778686

qc.sentinel1.eo.esa.int -> aux.sentinel1.eo.esa.int

@mohseniaref-InSAR, can you verify that this fixes your issue?