### PR TITLE
Proposed changes to the fetchOrbit.py

### DIFF
--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
         oType = spec[0]
 
         if oType == 'precise':
-            end_date = fileTS + datetime.timedelta(days=19)
+            end_date = fileTS + datetime.timedelta(days=20)
         elif oType == 'restituted':
             end_date = fileTS
         else:
@@ -159,6 +159,7 @@ if __name__ == '__main__':
         match = None
 
         try:
+            
             for url in urls:
                 r = session.get(url, verify=False)
                 r.raise_for_status()
@@ -166,12 +167,9 @@ if __name__ == '__main__':
                 parser.feed(r.text)
                 
                 for resulturl, result in parser.fileList:
-                    if oType == 'precise':
+                    tbef, taft, mission = fileToRange(os.path.basename(result))
+                    if (tbef <= fileTSStart) and (taft >= fileTS):
                         match = os.path.join(resulturl, result)
-                    elif oType == 'restituted':
-                        tbef, taft, mission = fileToRange(os.path.basename(result))
-                        if (tbef <= fileTSStart) and (taft >= fileTS):
-                            match = os.path.join(resulturl, result)
 
             if match is not None:
                 success = True

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -153,9 +153,7 @@ if __name__ == '__main__':
         else:
             raise ValueError("Unexpected orbit type: '" + oType + "'")
         end_date2 = end_date + datetime.timedelta(days=1)
-        url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
-            '/' + str(end_date.day).zfill(2) + '/', server + spec[1] + str(end_date2.year).zfill(2) + '/' + str(end_date2.month).zfill(2) + \
-            '/' + str(end_date2.day).zfill(2) + '/'
+        url = (server + spec[1] + end_date.strftime("%Y/%m/%d/") for end_date in (end_date, end_date2))
 
         success = False
         match = None

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -158,9 +158,9 @@ if __name__ == '__main__':
             delta = datetime.timedelta(days=1)
             timebef = (fileTS - delta).strftime(queryfmt)
             timeaft = (fileTS + delta).strftime(queryfmt)
-            url = (server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
+            url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
                 '/' + str(fileTS.day).zfill(2) + '/' + '?validity_start={0}..{1}&sentinel1__mission={2}'.\
-                format(timebef, timeaft,satName))
+                format(timebef, timeaft,satName)
 
 
 

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -152,17 +152,20 @@ if __name__ == '__main__':
             end_date = fileTS
         else:
             raise ValueError("Unexpected orbit type: '" + oType + "'")
+        end_date2 = end_date + datetime.timedelta(days=1)
         url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
-            '/' + str(end_date.day).zfill(2) + '/'
+            '/' + str(end_date.day).zfill(2) + '/', server + spec[1] + str(end_date2.year).zfill(2) + '/' + str(end_date2.month).zfill(2) + \
+            '/' + str(end_date2.day).zfill(2) + '/'
 
         success = False
         match = None
 
         try:
-            r = session.get(url, verify=False)
-            r.raise_for_status()
-            parser = MyHTMLParser(satName, url)
-            parser.feed(r.text)
+            for url1 in url:
+                r = session.get(url1, verify=False)
+                r.raise_for_status()
+                parser = MyHTMLParser(satName, url1)
+                parser.feed(r.text)
             for resulturl, result in parser.fileList:
                 if oType == 'precise':
                     match = os.path.join(resulturl, result)

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -166,7 +166,7 @@ if __name__ == '__main__':
             for resulturl, result in parser.fileList:
                 if oType == 'precise':
                     match = os.path.join(resulturl, result)
-                elif oType == "restituted":
+                elif oType == 'restituted':
                     tbef, taft, mission = fileToRange(os.path.basename(result))
                     if (tbef <= fileTSStart) and (taft >= fileTS):
                         match = url + result

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-#!/usr/bin/env python3
-
 import numpy as np
 import re
 import requests

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -148,12 +148,12 @@ if __name__ == '__main__':
 
         if oType == 'precise':
             end_date = fileTS + datetime.timedelta(days=20)
-            url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
-            '/' + str(end_date.day).zfill(2) + '/'
-            
         elif oType == 'restituted':
-            url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
-                '/' + str(fileTS.day).zfill(2) +'/'
+            end_date = fileTS
+        else:
+            throw ValueError("Unexpected orbit type: '" + oType + "'")
+        url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
+            '/' + str(end_date.day).zfill(2) + '/'
 
         success = False
         match = None

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -161,7 +161,6 @@ if __name__ == '__main__':
         match = None
 
         try:
-            
             for url1 in url:
                 r = session.get(url1, verify=False)
                 r.raise_for_status()

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -152,11 +152,17 @@ if __name__ == '__main__':
             end_date = dt + datetime.timedelta(days=20)
             fileTS1 = end_date.strftime(queryfmt3)   
             url = server + spec[1] + str(fileTS1[0:4]) + '/' + str(fileTS1[5:7]) + \
-                               '/' + str(fileTS1[8:10]) + '/'
+            '/' + str(fileTS1[8:10]) + '/'
             
         elif oType == 'restituted':
-            url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
-                               '/' + str(fileTS.day).zfill(2) + '/'
+            delta = datetime.timedelta(days=1)
+            timebef = (fileTS - delta).strftime(queryfmt)
+            timeaft = (fileTS + delta).strftime(queryfmt)
+            url = (server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
+                '/' + str(fileTS.day).zfill(2) + '/' + '?validity_start={0}..{1}&sentinel1__mission={2}'.\
+                format(timebef, timeaft,satName))
+
+
 
         success = False
         match = None
@@ -164,22 +170,20 @@ if __name__ == '__main__':
         try:
             r = session.get(url, verify=False)
             r.raise_for_status()
-
             parser = MyHTMLParser(satName, url)
             parser.feed(r.text)
             for resulturl, result in parser.fileList:
                 match = os.path.join(resulturl, result)
                 if match is not None:
                     success = True
-            
         except:
             pass
-        
+
         if success:
             break
-            
+
     if match is not None:
-            
+
         res = download_file(match, inps.outdir, session)
         if res is False:
             print('Failed to download URL: ', match)

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
                 for resulturl, result in parser.fileList:
                     if oType == 'precise':
                         match = os.path.join(resulturl, result)
-                    elif oType == "restituted":
+                    elif oType == 'restituted':
                         tbef, taft, mission = fileToRange(os.path.basename(result))
                         if (tbef <= fileTSStart) and (taft >= fileTS):
                             match = os.path.join(resulturl, result)

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -149,21 +149,15 @@ if __name__ == '__main__':
         oType = spec[0]
 
         if oType == 'precise':
+            end_date = fileTS + datetime.timedelta(days=20)
             queryfmt3 = "%Y-%m-%d %H:%M:%S"
-            dt = datetime.datetime.strptime(str(fileTS), queryfmt3)
-            end_date = dt + datetime.timedelta(days=20)
             fileTS1 = end_date.strftime(queryfmt3)   
             url = server + spec[1] + str(fileTS1[0:4]) + '/' + str(fileTS1[5:7]) + \
             '/' + str(fileTS1[8:10]) + '/'
             
         elif oType == 'restituted':
-            delta = datetime.timedelta(days=1)
-            timebef = (fileTS - delta).strftime(queryfmt)
-            timeaft = (fileTS + delta).strftime(queryfmt)
             url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
                 '/' + str(fileTS.day).zfill(2) +'/'
-
-
 
         success = False
         match = None

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -179,7 +179,6 @@ if __name__ == '__main__':
                 elif oType == "restituted":
                     tbef, taft, mission = fileToRange(os.path.basename(result))
                     if (tbef <= fileTSStart) and (taft >= fileTS):
-                        datestr2 = FileToTimeStamp(result)[0].strftime(queryfmt2) 
                         match = url + result
 
             if match is not None:

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -150,10 +150,8 @@ if __name__ == '__main__':
 
         if oType == 'precise':
             end_date = fileTS + datetime.timedelta(days=20)
-            queryfmt3 = "%Y-%m-%d %H:%M:%S"
-            fileTS1 = end_date.strftime(queryfmt3)   
-            url = server + spec[1] + str(fileTS1[0:4]) + '/' + str(fileTS1[5:7]) + \
-            '/' + str(fileTS1[8:10]) + '/'
+            url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
+            '/' + str(end_date.day).zfill(2) + '/'
             
         elif oType == 'restituted':
             url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -153,17 +153,17 @@ if __name__ == '__main__':
         else:
             raise ValueError("Unexpected orbit type: '" + oType + "'")
         end_date2 = end_date + datetime.timedelta(days=1)
-        url = (server + spec[1] + end_date.strftime("%Y/%m/%d/") for end_date in (end_date, end_date2))
+        urls = (server + spec[1] + end_date.strftime("%Y/%m/%d/") for end_date in (end_date, end_date2))
 
         success = False
         match = None
 
         try:
-            for url1 in url:
-                r = session.get(url1, verify=False)
+            for url in urls:
+                r = session.get(url, verify=False)
                 r.raise_for_status()
-                parser = MyHTMLParser(satName, url1)
-                parser.feed(r.text + "\n")
+                parser = MyHTMLParser(satName, url)
+                parser.feed(r.text)
                 
                 for resulturl, result in parser.fileList:
                     if oType == 'precise':

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -166,10 +166,10 @@ if __name__ == '__main__':
             for resulturl, result in parser.fileList:
                 if oType == 'precise':
                     match = os.path.join(resulturl, result)
-                elif oType == 'restituted':
+                elif oType == "restituted":
                     tbef, taft, mission = fileToRange(os.path.basename(result))
                     if (tbef <= fileTSStart) and (taft >= fileTS):
-                        match = url + result
+                        match = os.path.join(resulturl, result)
 
             if match is not None:
                 success = True

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -146,7 +146,16 @@ if __name__ == '__main__':
     for spec in orbitMap:
         oType = spec[0]
 
-        url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
+        if oType == 'precise':
+            queryfmt3 = "%Y-%m-%d %H:%M:%S"
+            dt = datetime.datetime.strptime(str(fileTS), queryfmt3)
+            end_date = dt + datetime.timedelta(days=20)
+            fileTS1 = end_date.strftime(queryfmt3)   
+            url = server + spec[1] + str(fileTS1[0:4]) + '/' + str(fileTS1[5:7]) + \
+                               '/' + str(fileTS1[8:10]) + '/'
+            
+        elif oType == 'restituted':
+            url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
                                '/' + str(fileTS.day).zfill(2) + '/'
 
         success = False
@@ -162,12 +171,17 @@ if __name__ == '__main__':
                 match = os.path.join(resulturl, result)
                 if match is not None:
                     success = True
+            
         except:
             pass
-
-        if match is not None:
-            res = download_file(match, inps.outdir, session)
-            if res is False:
-                print('Failed to download URL: ', match)
-        else:
-            print('Failed to find {1} orbits for tref {0}'.format(fileTS, satName))
+        
+        if success:
+            break
+            
+    if match is not None:
+            
+        res = download_file(match, inps.outdir, session)
+        if res is False:
+            print('Failed to download URL: ', match)
+    else:
+        print('Failed to find {1} orbits for tref {0}'.format(fileTS, satName))

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -161,18 +161,20 @@ if __name__ == '__main__':
         match = None
 
         try:
+            
             for url1 in url:
                 r = session.get(url1, verify=False)
                 r.raise_for_status()
                 parser = MyHTMLParser(satName, url1)
-                parser.feed(r.text)
-            for resulturl, result in parser.fileList:
-                if oType == 'precise':
-                    match = os.path.join(resulturl, result)
-                elif oType == "restituted":
-                    tbef, taft, mission = fileToRange(os.path.basename(result))
-                    if (tbef <= fileTSStart) and (taft >= fileTS):
+                parser.feed(r.text + "\n")
+                
+                for resulturl, result in parser.fileList:
+                    if oType == 'precise':
                         match = os.path.join(resulturl, result)
+                    elif oType == "restituted":
+                        tbef, taft, mission = fileToRange(os.path.basename(result))
+                        if (tbef <= fileTSStart) and (taft >= fileTS):
+                            match = os.path.join(resulturl, result)
 
             if match is not None:
                 success = True

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+#!/usr/bin/env python3
+
 import numpy as np
 import re
 import requests
@@ -159,8 +161,7 @@ if __name__ == '__main__':
             timebef = (fileTS - delta).strftime(queryfmt)
             timeaft = (fileTS + delta).strftime(queryfmt)
             url = server + spec[1] + str(fileTS.year).zfill(2) + '/' + str(fileTS.month).zfill(2) + \
-                '/' + str(fileTS.day).zfill(2) + '/' + '?validity_start={0}..{1}&sentinel1__mission={2}'.\
-                format(timebef, timeaft,satName)
+                '/' + str(fileTS.day).zfill(2) +'/'
 
 
 
@@ -173,9 +174,16 @@ if __name__ == '__main__':
             parser = MyHTMLParser(satName, url)
             parser.feed(r.text)
             for resulturl, result in parser.fileList:
-                match = os.path.join(resulturl, result)
-                if match is not None:
-                    success = True
+                if oType == 'precise':
+                    match = os.path.join(resulturl, result)
+                elif oType == "restituted":
+                    tbef, taft, mission = fileToRange(os.path.basename(result))
+                    if (tbef <= fileTSStart) and (taft >= fileTS):
+                        datestr2 = FileToTimeStamp(result)[0].strftime(queryfmt2) 
+                        match = url + result
+
+            if match is not None:
+                success = True
         except:
             pass
 

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         elif oType == 'restituted':
             end_date = fileTS
         else:
-            throw ValueError("Unexpected orbit type: '" + oType + "'")
+            raise ValueError("Unexpected orbit type: '" + oType + "'")
         url = server + spec[1] + str(end_date.year).zfill(2) + '/' + str(end_date.month).zfill(2) + \
             '/' + str(end_date.day).zfill(2) + '/'
 

--- a/contrib/stack/topsStack/fetchOrbit.py
+++ b/contrib/stack/topsStack/fetchOrbit.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
         oType = spec[0]
 
         if oType == 'precise':
-            end_date = fileTS + datetime.timedelta(days=20)
+            end_date = fileTS + datetime.timedelta(days=19)
         elif oType == 'restituted':
             end_date = fileTS
         else:


### PR DESCRIPTION
After running the currently modified fetchOrbits.py, I've found out that the downloaded precise orbits were based on the date that they were processed instead of the date that they can be used. I've also modified the code to prevent downloading of restituted orbit if the precise orbit is available.

Pls. check if the changes I've made applies the orbit files to the Sentinel-1 SLC images properly.