### PR TITLE
Proposed fix on a bug in create_cmds.py

### DIFF
--- a/contrib/stack/alosStack/create_cmds.py
+++ b/contrib/stack/alosStack/create_cmds.py
@@ -162,9 +162,7 @@ def formPairs(idir, numberOfSubsequentDates, pairTimeSpanMinimum=None, pairTimeS
         for pair in pairsProcess:
             rdate = pair.split('-')[0]
             sdate = pair.split('-')[1]
-            if (rdate in datesExcluded) or (sdate in datesExcluded):
-                pass
-            else:
+            if (rdate not in datesExcluded) and (sdate not in datesExcluded):
                 pairsProcess2.append(pair)
         pairsProcess = pairsProcess2
 

--- a/contrib/stack/alosStack/create_cmds.py
+++ b/contrib/stack/alosStack/create_cmds.py
@@ -162,7 +162,9 @@ def formPairs(idir, numberOfSubsequentDates, pairTimeSpanMinimum=None, pairTimeS
         for pair in pairsProcess:
             rdate = pair.split('-')[0]
             sdate = pair.split('-')[1]
-            if (rdate not in datesIncluded) and (sdate not in datesIncluded):
+            if (rdate in datesExcluded) or (sdate in datesExcluded):
+                pass
+            else:
                 pairsProcess2.append(pair)
         pairsProcess = pairsProcess2
 


### PR DESCRIPTION
I'm proposing a fix to create_cmds.py since I found a minor bug in line 165 which doesn't remove the excluded dates during image stacking. Instead line 165 removes dates based on the dates not included from the parameter `dates to be included` on the alosStack.xml.

The image folder contains the ALOS-2 images with dates 191005, 191019, 191102, 191214, 191228. I've excluded the date 191102 from the processing using the parameter `dates to be excluded` on the alosStack.xml.

Output from the terminal before applying the fix:

```
(isce2expe) abscissa@ABSCISSA:/mnt/f/Mindanao/time-series_test2$ create_cmds.py -stack_par alosStack.xml
This is the Open Source version of ISCE.
Some of the workflows depend on a separate licensed package.
To obtain the licensed package, please make a request for ISCE
through the website: https://download.jpl.nasa.gov/ops/request/index.cfm.
Alternatively, if you are a member, or can become a member of WinSAR
you may be able to obtain access to a version of the licensed sofware at
https://winsar.unavco.org/software/isce

get dates and pairs from user input
Traceback (most recent call last):
  File "/home/abscissa/isce2/contrib/stack/alosStack/create_cmds.py", line 1368, in <module>
    pairsProcess = formPairs(stack.dataDir, stack.numberOfSubsequentDates,
  File "/home/abscissa/isce2/contrib/stack/alosStack/create_cmds.py", line 165, in formPairs
    if (rdate not in datesIncluded) and (sdate not in datesIncluded):
TypeError: argument of type 'NoneType' is not iterable
```

Output from the terminal after applying the fix:

```
(isce2expe) abscissa@ABSCISSA:/mnt/f/Mindanao/time-series_test2$ create_cmds.py -stack_par alosStack.xml
This is the Open Source version of ISCE.
Some of the workflows depend on a separate licensed package.
To obtain the licensed package, please make a request for ISCE
through the website: https://download.jpl.nasa.gov/ops/request/index.cfm.
Alternatively, if you are a member, or can become a member of WinSAR
you may be able to obtain access to a version of the licensed sofware at
https://winsar.unavco.org/software/isce

get dates and pairs from user input
InSAR processing:
dates: 191005 191019 191214 191228
pairs: 191005-191019 191005-191214 191005-191228 191019-191214 191019-191228 191214-191228

ionospheric phase estimation:
dates: 191005 191019 191102 191214 191228
pairs: 191005-191019 191005-191102 191005-191214 191005-191228 191019-191102 191019-191214 191019-191228 191102-191214 191102-191228 191214-191228


acquisition mode of stack: WBD



dates and pairs to be processed:
dates: 191005 191019 191102 191214 191228
pairs (for InSAR processing): 191005-191019 191005-191214 191005-191228 191019-191214 191019-191228 191214-191228
pairs (for estimating ionospheric phase): 191005-191019 191005-191102 191005-191214 191005-191228 191019-191102 191019-191214 191019-191228 191102-191214 191102-191228 191214-191228


                       * * *
reference date of stack in date list to be processed.
reference date of stack not processed previously.
implement reference-date-related processing this time.
                       * * *
```

I've tested the changes and it worked properly. Though, the ionospheric corrections will still include 191102 since the code doesn't take into account the excluded date on estimation of ionospheric corrections. Based from create_cmds.py, the user may need to define the dates to be excluded from ionospheric correction using the parameter `dates to be excluded for estimating ionosphere` on the alosStack.xml. 