### PR TITLE
logging.conf: avoid empty file creation

### DIFF
--- a/defaults/logging/logging.conf
+++ b/defaults/logging/logging.conf
@@ -20,8 +20,8 @@ propagate=0
 [handler_fileHandler]
 class=handlers.RotatingFileHandler
 formatter=simpleFormatter
-# Filename, file mode, maximum file size in bytes,number of backups to keep
-args=('isce.log','a',1000048576,5)
+# Filename, file mode, maximum file size in bytes,number of backups to keep, encoding, delay creation
+args=('isce.log','a',1000048576,5,None,True)
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
Keeps the larger size from previous commit, but sets `delay=True` in `RotatingFileHandler`
https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler

Arguments are:
`RotatingFileHandler(filename, mode='a', maxBytes=0, backupCount=0, encoding=None, delay=False, errors=None)`