### PR TITLE
Add lookside check to geozero, fixes #294

### DIFF
--- a/components/zerodop/geozero/Geozero.py
+++ b/components/zerodop/geozero/Geozero.py
@@ -247,7 +247,7 @@ class Geocode(Component):
             demCropAcc = 0
             geozero.geozero_Py(demAccessor, inputAccessor, demCropAcc,
                     self.geoAccessor, inband, outband,
-                    int(complexFlag), int(self.interp_methods[self.method]))
+                    int(complexFlag), int(self.interp_methods[self.method]), int(self.lookSide))
 
         combinedlibmodule.freeCOrbit(cOrbit)
         self.getState()

--- a/components/zerodop/geozero/bindings/geozeromodule.cpp
+++ b/components/zerodop/geozero/bindings/geozeromodule.cpp
@@ -75,15 +75,15 @@ PyObject * geozero_C(PyObject* self, PyObject* args)
     uint64_t var1;
     uint64_t var2;
     uint64_t var3;
-    int b1, b2, b3,b4;
-    if(!PyArg_ParseTuple(args, "KKKKiiii", &var0, &var1, &var2, &var3,
-        &b1,&b2,&b3,&b4))
+    int b1, b2, b3, b4, b5;
+    if(!PyArg_ParseTuple(args, "KKKKiiiii", &var0, &var1, &var2, &var3,
+        &b1,&b2,&b3,&b4,&b5))
     {
         return NULL;
     }
     b1++;    //Python bandnumber to Fortran bandnumber
     b2++;    //Python bandnumber to Fortran bandnumber
-    geozero_f(&var0,&var1,&var2,&var3,&b1,&b2,&b3,&b4);
+    geozero_f(&var0,&var1,&var2,&var3,&b1,&b2,&b3,&b4,&b5);
     return Py_BuildValue("i", 0);
 }
 PyObject * setEllipsoidMajorSemiAxis_C(PyObject* self, PyObject* args)

--- a/components/zerodop/geozero/include/geozeromodule.h
+++ b/components/zerodop/geozero/include/geozeromodule.h
@@ -41,7 +41,7 @@ extern "C"
     #include "poly1d.h"
 
     void geozero_f(uint64_t *, uint64_t *, uint64_t *, uint64_t *, 
-        int*, int*, int*, int*);
+        int*, int*, int*, int*, int*);
     PyObject * geozero_C(PyObject *, PyObject *);
     void setEllipsoidMajorSemiAxis_f(double *);
     PyObject * setEllipsoidMajorSemiAxis_C(PyObject *, PyObject *);


### PR DESCRIPTION
comparison is based on https://github.com/isce-framework/isce3/blob/0eb175f86f6c74d86c19ba9623f23054513fc657/cxx/isce3/geometry/detail/Geo2Rdr.icc#L83-L89

This gets rid of the duplicate image for UAVSAR geocoding with diagonal heading