### PR TITLE
add an option for masking out islands in ionosphere computation

### DIFF
--- a/applications/topsApp.py
+++ b/applications/topsApp.py
@@ -519,6 +519,14 @@ ION_AZSHIFT_FLAG = Application.Parameter('ION_azshiftFlag',
     mandatory=False,
     doc='')
 
+#seperated islands or areas usually affect ionosphere estimation and it's better to mask them
+#out. check ion/ion_cal/raw_no_projection.ion for areas to be masked out.
+#The parameter is a 2-D list. Each element in the 2-D list is a four-element list: [firstLine,
+#lastLine, firstColumn, lastColumn], with line/column numbers starting with 1. If one of the
+#four elements is specified as -1, the program will use firstLine/lastLine/firstColumn/
+#lastColumn instead. For exmple, if you want to mask the following two areas out, you can
+#specify a 2-D list like:
+#[[100, 200, 100, 200],[1000, 1200, 500, 600]]
 ION_MASKED_AREAS = Application.Parameter('ION_maskedAreas',
     public_name = 'areas masked out in ionospheric phase estimation',
     default = None,

--- a/applications/topsApp.py
+++ b/applications/topsApp.py
@@ -519,6 +519,14 @@ ION_AZSHIFT_FLAG = Application.Parameter('ION_azshiftFlag',
     mandatory=False,
     doc='')
 
+ION_MASKED_AREAS = Application.Parameter('ION_maskedAreas',
+    public_name = 'areas masked out in ionospheric phase estimation',
+    default = None,
+    type = int,
+    mandatory = False,
+    container = list,
+    doc = 'areas masked out in ionospheric phase estimation')
+
 ION_NUMBER_AZIMUTH_LOOKS = Application.Parameter('ION_numberAzimuthLooks',
     public_name='total number of azimuth looks in the ionosphere processing',
     default=50,
@@ -674,6 +682,7 @@ class TopsInSAR(Application):
                       ION_IONSHIFT_FILTERING_WINSIZE_MAX,
                       ION_IONSHIFT_FILTERING_WINSIZE_MIN,
                       ION_AZSHIFT_FLAG,
+                      ION_MASKED_AREAS,
                       ION_NUMBER_AZIMUTH_LOOKS,
                       ION_NUMBER_RANGE_LOOKS,
                       ION_NUMBER_AZIMUTH_LOOKS0,

--- a/examples/input_files/topsApp.xml
+++ b/examples/input_files/topsApp.xml
@@ -200,6 +200,16 @@ By default, ESD is always performed.
 #2: use full burst
 <property name="correct phase error caused by ionosphere azimuth shift">1</property>
 
+#seperated islands or areas usually affect ionosphere estimation and it's better to mask them
+#out. check ion/ion_cal/raw_no_projection.ion for areas to be masked out.
+#The parameter is a 2-D list. Each element in the 2-D list is a four-element list: [firstLine,
+#lastLine, firstColumn, lastColumn], with line/column numbers starting with 1. If one of the
+#four elements is specified as -1, the program will use firstLine/lastLine/firstColumn/
+#lastColumn instead. For exmple, if you want to mask the following two areas out, you can
+#specify a 2-D list like:
+#[[100, 200, 100, 200],[1000, 1200, 500, 600]]
+<property name="areas masked out in ionospheric phase estimation">None</property>
+
 #better NOT try changing the following two parameters, since they are related
 #to the filtering parameters above
 <property name="total number of azimuth looks in the ionosphere processing">50</property>


### PR DESCRIPTION
Islands are not connected with lands, and thus lead to phase unwrapping errors. This might be a big issue in ionosphere computation. This pull request add an option for masking out the islands in topsApp.py.

A comparison of ionosphere computation results before filtering with and without using this option is shown in the attached figure.

![Screen Shot 2021-06-25 at 7 13 05 AM](https://user-images.githubusercontent.com/56097947/123354103-839ed500-d595-11eb-9986-a7eb9eaa00f0.jpg)
