### PR TITLE
Changed 'is' to '==' to the SentinelWrapper.py to remove warning

### DIFF
--- a/contrib/stack/topsStack/SentinelWrapper.py
+++ b/contrib/stack/topsStack/SentinelWrapper.py
@@ -110,7 +110,7 @@ class ConfigParser:
 
   # Looks for string between $ sysmbols in the common subheading in config file
   def __parseString(self, iString):
-    if iString is '':
+    if iString == '':
       return iString
     elif isinstance(self.common, (dict)):
       # Case when "common" parameters are read from the configuration file


### PR DESCRIPTION
- Changed 'is' to '==' in line no. 113 of the SentinelWrapper.py to remove the warning issued by Python.