### PR TITLE
StAMPS preprocessor and stackprocessors minor modification

### DIFF
--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -2,7 +2,7 @@
 
 #Author: Heresh Fattahi
 
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
 import datetime

--- a/contrib/stack/stripmapStack/invertMisreg.py
+++ b/contrib/stack/stripmapStack/invertMisreg.py
@@ -2,10 +2,10 @@
 
 # Author: Heresh Fattahi
 
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import time
 import numpy as np
 import shelve

--- a/contrib/stack/stripmapStack/invertOffsets.py
+++ b/contrib/stack/stripmapStack/invertOffsets.py
@@ -2,10 +2,10 @@
 
 #Author: Heresh Fattahi
 
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import time
 import numpy as np
 import shelve

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -2,7 +2,7 @@
 
 #Author: Heresh Fattahi
 
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
 import datetime

--- a/contrib/stack/topsStack/invertMisreg.py
+++ b/contrib/stack/topsStack/invertMisreg.py
@@ -3,7 +3,7 @@
 #Author: Heresh Fattahi
 #Copyright 2016
 ######################
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
 import  datetime

--- a/contrib/stack/topsStack/invertMisreg.py
+++ b/contrib/stack/topsStack/invertMisreg.py
@@ -6,7 +6,7 @@
 import os, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import time
 import numpy as np
 #################################################################

--- a/contrib/stack/topsStack/plotMisreg.py
+++ b/contrib/stack/topsStack/plotMisreg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 ########################
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
 import  datetime

--- a/contrib/stack/topsStack/plotMisreg.py
+++ b/contrib/stack/topsStack/plotMisreg.py
@@ -3,7 +3,7 @@
 import os, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import time
 import numpy as np
 import matplotlib.pyplot as plt

--- a/contrib/stack/topsStack/sentinelApp.py
+++ b/contrib/stack/topsStack/sentinelApp.py
@@ -6,7 +6,7 @@
 
 #######################
 
-import os, imp, sys, glob
+import os, sys, glob
 import argparse
 import configparser
 import  datetime

--- a/contrib/stack/topsStack/sentinelApp.py
+++ b/contrib/stack/topsStack/sentinelApp.py
@@ -9,7 +9,7 @@
 import os, sys, glob
 import argparse
 import configparser
-import  datetime
+import datetime
 import numpy as np
 import isce
 import isceobj

--- a/contrib/timeseries/prepStackToStaMPS/bin/make_single_reference_stack_isce
+++ b/contrib/timeseries/prepStackToStaMPS/bin/make_single_reference_stack_isce
@@ -89,7 +89,7 @@ if (( "$slc_stack_path" == "" ) || ( "$reference_date" == "" ) || ( "$lambda" ==
 endif
 
 # make sure the slash is added in case the variable is not empty
-set slc_stack_path = `echo ${slc_stack_path}/`
+set slc_stack_path = `echo ${slc_stack_path}`
 echo 
 echo -------------------------------                                                                                                             
 echo Stack path is: $slc_stack_path


### PR DESCRIPTION
- Removed excess backslash in make_single_reference_stack_isce which inhibited the generation of files needed for StAMPS
- Removed unused imp library in topsStack and stripmapStack
- Fixed spacing on the datetime library in topsStack and stripmapStack