### PR TITLE
Speed up baselineGrid.py and cut prints

### DIFF
--- a/components/isceobj/Orbit/Orbit.py
+++ b/components/isceobj/Orbit/Orbit.py
@@ -1003,7 +1003,6 @@ class Orbit(Component):
         Takes a lat, lon, height triplet and returns azimuth time and range.
         Assumes zero doppler for now.
         '''
-
         from isceobj.Planet.Planet import Planet
         from isceobj.Util.Poly2D import Poly2D
         if doppler is None:
@@ -1021,6 +1020,8 @@ class Orbit(Component):
         delta = (self.maxTime - self.minTime).total_seconds() * 0.5
         tguess = self.minTime + datetime.timedelta(seconds = delta)
         outOfBounds = False
+        # Start the previous guess tracking with dummy value
+        t_prev_guess = tguess + datetime.timedelta(seconds=10)
         for ii in range(51):
             try:
                 sv = self.interpolateOrbit(tguess, method='hermite')
@@ -1045,10 +1046,13 @@ class Orbit(Component):
             fnprime = c1 + c2 * dopfact
 
             tguess = tguess - datetime.timedelta(seconds = fn/fnprime)
+            if abs(tguess - t_prev_guess).total_seconds() < 5e-9:
+                break
+            else:
+                t_prev_guess = tguess
 
         if outOfBounds:
             raise Exception('Interpolation time out of bounds')
-
 
         return tguess, rng
 

--- a/contrib/stack/stripmapStack/baselineGrid.py
+++ b/contrib/stack/stripmapStack/baselineGrid.py
@@ -52,6 +52,7 @@ def main(iargs=None):
     '''
     inps=cmdLineParse(iargs)
     from isceobj.Planet.Planet import Planet
+    from isceobj.Util.Poly2D import Poly2D
     import numpy as np
     import shelve
 
@@ -101,6 +102,8 @@ def main(iargs=None):
     nAzimuth = int(np.max([30,int(np.ceil(azimuthLimits))]))
     azimuthTime = [mSensingStart + datetime.timedelta(seconds= x * azimuthLimits/(nAzimuth-1.0))  for x in range(nAzimuth)]
 
+    doppler = Poly2D()
+    doppler.initPoly(azimuthOrder=0, rangeOrder=0, coeffs=[[0.]])
     
     Bperp = np.zeros((nAzimuth,nRange), dtype=np.float32)
     Bpar = np.zeros((nAzimuth,nRange), dtype=np.float32)
@@ -123,7 +126,7 @@ def main(iargs=None):
                 target = mOrb.rdr2geo(taz, rng)
     
                 targxyz = np.array(refElp.LLH(target[0], target[1], target[2]).ecef().tolist())
-                slvTime,slvrng = sOrb.geo2rdr(target)
+                slvTime, slvrng = sOrb.geo2rdr(target, doppler=doppler, wvl=0)
     
                 secondarySV = sOrb.interpolateOrbit(slvTime, method='hermite')
     


### PR DESCRIPTION
In the original form, the `geo2rdr` method of Orbit.py took a couple hundred milliseconds to run, and it also printed `Polynomial Order: 0 - by - 0` each time.
For my stripmap stack run, this would print out ~20k times per SLC.

```python
In [60]: %time orb.geo2rdr(target)
Polynomial Order: 0 - by - 0
0
CPU times: user 181 ms, sys: 11.8 ms, total: 193 ms
Wall time: 192 ms
```
It also meant that each `baselineGrid.py` run would take over an hour, and the entire step would take about a day for my stack of 25.

I had initially just changed the `run_07_grid_baseline` to kick off a bunch of them in parallel, since they are only using one CPU core to run. But I noticed two quick fixes for the python `geo2rdr`:

1. Each time, a `Poly2D` object is created, because we were calling `sOrb.geo2rdr(target)`, and `geo2rdr` had this
```python
        if doppler is None:
            doppler = Poly2D()
            doppler.initPoly(azimuthOrder=0, rangeOrder=0, coeffs=[[0.]])
            wvl = 0.
```


Creating that once and passing it through saved ~20% on it, but it also cuts out the 1000s of "Polynomial Order 0" prints
```python
In [65]: %time orb.geo2rdr(target, doppler=doppler, wvl=0)
CPU times: user 164 ms, sys: 4.99 ms, total: 169 ms
Wall time: 168 ms
```

2. adding a check for convergence in the loop at the bottom, like the fortran version has https://github.com/isce-framework/isce2/blob/main/components/zerodop/geo2rdr/src/geo2rdr.f90#L300-L304 

```python
    # Start the previous guess tracking with dummy value
    t_prev_guess = tguess + datetime.timedelta(seconds=10)
...
            if abs(tguess - t_prev_guess).total_seconds() < 5e-9:
                break
            else:
                t_prev_guess = tguess
```
makes it break after a few iterations (for the testing i added a print with the total iterations):
```python
In [76]: %time orb.geo2rdr(target, doppler=doppler, wvl=0)
Total iters: 3
CPU times: user 11.1 ms, sys: 1.02 ms, total: 12.1 ms
Wall time: 11.3 ms
```

