### PR TITLE
Add CMake rules for optional Stanford-licensed components

### DIFF
--- a/.cmake/isce2_buildflags.cmake
+++ b/.cmake/isce2_buildflags.cmake
@@ -6,6 +6,7 @@
 add_definitions(-DNEEDS_F77_TRANSLATION -DF77EXTERNS_LOWERCASE_TRAILINGBAR)
 add_compile_options(
     $<$<COMPILE_LANGUAGE:Fortran>:-ffixed-line-length-none>
+    $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
     $<$<COMPILE_LANGUAGE:Fortran>:-fno-range-check>
     $<$<COMPILE_LANGUAGE:Fortran>:-fno-second-underscore>)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,10 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
     # override this to also test the resulting extension
     function(Python_add_library target)
         _Python_add_library(${target} ${ARGN})
+        set(name "$<TARGET_PROPERTY:${target},OUTPUT_NAME>")
         add_test(NAME import_${target}
                  COMMAND ${Python_EXECUTABLE} -c
-                     "import ${target}"
+                     "import $<IF:$<BOOL:${name}>,${name},${target}>"
                  )
     endfunction()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,11 @@ install(DIRECTORY DESTINATION ${ISCE2_PKG}/helper)
 # CMake will install a python package named "isce2",
 # but legacy scripts import it as simply "isce".
 # Make a symlink isce -> isce2 for compatibility.
-set(symsrc ${CMAKE_INSTALL_PREFIX}/${ISCE2_PKG})
-set(symdest ${symsrc}/../isce)
+set(symsrc isce2)
+if(IS_ABSOLUTE "${PYTHON_MODULE_DIR}")
+    set(symdest "${PYTHON_MODULE_DIR}/isce")
+else()
+    set(symdest "${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_DIR}/isce")
+endif()
 install(CODE "execute_process(COMMAND
     ${CMAKE_COMMAND} -E create_symlink ${symsrc} ${symdest})")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,21 @@ InstallSameDir(
     release_history.py
     )
 
+file(READ license.py LICENSE_TXT)
+string(FIND "${LICENSE_TXT}" "stanford_license = None" match)
+if(${match} EQUAL -1)
+    set(ISCE2_HAVE_LICENSE YES)
+else()
+    set(ISCE2_HAVE_LICENSE NO)
+endif()
+option(ISCE2_WITH_STANFORD "Build Stanford components" ${ISCE2_HAVE_LICENSE})
+if(ISCE2_WITH_STANFORD)
+    InstallSameDir(license.py)
+    message(STATUS "ISCE2's Stanford-licensed components will be built.")
+else()
+    message(STATUS "ISCE2's Stanford-licensed components will NOT be built.")
+endif()
+
 # We also need to create an empty directory for help
 install(DIRECTORY DESTINATION ${ISCE2_PKG}/helper)
 

--- a/components/stdproc/orbit/CMakeLists.txt
+++ b/components/stdproc/orbit/CMakeLists.txt
@@ -1,3 +1,12 @@
+add_subdirectory(orbitLib)
+
+add_subdirectory(fdmocomp)
+add_subdirectory(getpeg)
+add_subdirectory(mocompbaseline)
+add_subdirectory(orbit2sch)
+add_subdirectory(sch2orbit)
+add_subdirectory(setmocomppath)
+
 InstallSameDir(
     __init__.py
     pegManipulator.py

--- a/components/stdproc/orbit/fdmocomp/CMakeLists.txt
+++ b/components/stdproc/orbit/fdmocomp/CMakeLists.txt
@@ -1,0 +1,24 @@
+InstallSameDir(
+    __init__.py
+    Fdmocomp.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(fdmocomp MODULE
+    bindings/fdmocompmodule.cpp
+    src/fdmocomp.f90
+    src/fdmocompAllocateDeallocate.f
+    src/fdmocompGetState.f
+    src/fdmocompSetState.f
+    src/fdmocompState.f
+    )
+target_include_directories(fdmocomp PRIVATE include)
+target_link_libraries(fdmocomp PRIVATE
+    isce2::utilLib
+    )
+InstallSameDir(
+    fdmocomp
+    )

--- a/components/stdproc/orbit/getpeg/CMakeLists.txt
+++ b/components/stdproc/orbit/getpeg/CMakeLists.txt
@@ -1,0 +1,24 @@
+InstallSameDir(
+    Getpeg.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(getpeg MODULE
+    bindings/getpegmodule.cpp
+    src/getpeg.F
+    src/getpegAllocateDeallocate.F
+    src/getpegGetState.F
+    src/getpegSetState.F
+    src/getpegState.F
+    )
+target_include_directories(getpeg PRIVATE include)
+target_link_libraries(getpeg PRIVATE
+    isce2::orbitLib
+    isce2::stdoelLib
+    )
+InstallSameDir(
+    getpeg
+    )

--- a/components/stdproc/orbit/mocompbaseline/CMakeLists.txt
+++ b/components/stdproc/orbit/mocompbaseline/CMakeLists.txt
@@ -1,0 +1,25 @@
+InstallSameDir(
+    __init__.py
+    Mocompbaseline.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(mocompbaseline MODULE
+    bindings/mocompbaselinemodule.cpp
+    src/mocompbaselineSetState.F
+    src/mocompbaselineGetState.F
+    src/mocompbaselineState.F
+    src/mocompbaseline.f90
+    src/mocompbaselineAllocateDeallocate.F
+    )
+target_include_directories(mocompbaseline PRIVATE include)
+target_link_libraries(mocompbaseline PRIVATE
+    isce2::orbitLib
+    isce2::stdoelLib
+    )
+InstallSameDir(
+    mocompbaseline
+    )

--- a/components/stdproc/orbit/orbit2sch/CMakeLists.txt
+++ b/components/stdproc/orbit/orbit2sch/CMakeLists.txt
@@ -1,0 +1,25 @@
+InstallSameDir(
+    Orbit2sch.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(orbit2sch MODULE
+    bindings/orbit2schmodule.cpp
+    src/orbit2sch.F
+    src/orbit2schAllocateDeallocate.F
+    src/orbit2schGetState.F
+    src/orbit2schSetState.F
+    src/orbit2schState.F
+    )
+target_include_directories(orbit2sch PRIVATE include)
+target_link_libraries(orbit2sch PRIVATE
+    isce2::orbitLib
+    isce2::stdoelLib
+    isce2::utilLib
+    )
+InstallSameDir(
+    orbit2sch
+    )

--- a/components/stdproc/orbit/orbitLib/CMakeLists.txt
+++ b/components/stdproc/orbit/orbitLib/CMakeLists.txt
@@ -1,0 +1,26 @@
+InstallSameDir(
+    __init__.py
+    CalcSchHeightVel.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+isce2_add_staticlib(orbitLib
+    src/ave_tpsch.f90
+    src/convert_sch_to_xyz.F
+    src/convert_schdot_to_xyzdot.F
+    src/curvature.F
+    src/dot.f90
+    src/geo_hdg.F
+    src/get_tpsch.f90
+    src/latlon.F
+    src/lincomb.F
+    src/matmat.F
+    src/matvec.F
+    src/radar_to_xyz.F
+    src/schbasis.F
+    src/tranmat.F
+    src/unitvec.f90
+    )

--- a/components/stdproc/orbit/sch2orbit/CMakeLists.txt
+++ b/components/stdproc/orbit/sch2orbit/CMakeLists.txt
@@ -1,0 +1,26 @@
+InstallSameDir(
+    Sch2orbit.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(sch2orbit MODULE
+    bindings/sch2orbitmodule.cpp
+    src/sch2orbit.F
+    src/sch2orbitAllocateDeallocate.F
+    src/sch2orbitGetState.F
+    src/sch2orbitSetState.F
+    src/sch2orbitState.F
+    )
+target_include_directories(sch2orbit PRIVATE include)
+target_link_libraries(sch2orbit PRIVATE
+    isce2::orbitLib
+    isce2::stdoelLib
+    isce2::utilLib
+    )
+InstallSameDir(
+    sch2orbit
+    )
+

--- a/components/stdproc/orbit/setmocomppath/CMakeLists.txt
+++ b/components/stdproc/orbit/setmocomppath/CMakeLists.txt
@@ -1,0 +1,24 @@
+InstallSameDir(
+    Setmocomppath.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(setmocomppath MODULE
+    bindings/setmocomppathmodule.cpp
+    src/setmocomppath.F
+    src/setmocomppathAllocateDeallocate.F
+    src/setmocomppathState.F
+    src/setmocomppathSetState.F
+    src/setmocomppathGetState.F
+    )
+target_include_directories(setmocomppath PRIVATE include)
+target_link_libraries(setmocomppath PRIVATE
+    isce2::orbitLib
+    isce2::stdoelLib
+    )
+InstallSameDir(
+    setmocomppath
+    )

--- a/components/stdproc/rectify/CMakeLists.txt
+++ b/components/stdproc/rectify/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(dismphfile)
 add_subdirectory(geocode)
 
 InstallSameDir(__init__.py)

--- a/components/stdproc/rectify/dismphfile/CMakeLists.txt
+++ b/components/stdproc/rectify/dismphfile/CMakeLists.txt
@@ -1,0 +1,22 @@
+InstallSameDir(
+    __init__.py
+    Dismphfile.py
+    )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(dismphfile MODULE
+    bindings/dismphfilemodule.cpp
+    src/dismphfileSetState.F
+    src/dismphfileState.F
+    src/SConscript
+    src/dismphfile.F
+    src/writetiff.f
+    )
+target_include_directories(dismphfile PRIVATE include)
+target_link_libraries(dismphfile PRIVATE
+    isce2::DataAccessorLib
+    )
+InstallSameDir(dismphfile)

--- a/components/stdproc/stdproc/correct/CMakeLists.txt
+++ b/components/stdproc/stdproc/correct/CMakeLists.txt
@@ -2,3 +2,22 @@ InstallSameDir(
     __init__.py
     Correct.py
     )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(correct MODULE
+    bindings/correctmodule.cpp
+    src/correct.f
+    src/correctAllocateDeallocate.f
+    src/correctSetState.f
+    src/correctState.f
+    )
+target_include_directories(correct PRIVATE include)
+target_link_libraries(correct PRIVATE
+    isce2::DataAccessorLib
+    isce2::orbitLib
+    isce2::utilLib
+    OpenMP::OpenMP_Fortran
+    )

--- a/components/stdproc/stdproc/estamb/CMakeLists.txt
+++ b/components/stdproc/stdproc/estamb/CMakeLists.txt
@@ -2,3 +2,21 @@ InstallSameDir(
     __init__.py
     Estamb.py
     )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(estamb MODULE
+    bindings/estambmodule.cpp
+    src/estamb.f90
+    src/estambAllocateDeallocate.F
+    src/estambGetState.F
+    src/estambSetState.F
+    src/estambStateSoi.f90
+    )
+target_include_directories(estamb PRIVATE include)
+target_link_libraries(estamb PRIVATE
+    isce2::DataAccessorLib
+    isce2::formslcLib
+    )

--- a/components/stdproc/stdproc/formslc/CMakeLists.txt
+++ b/components/stdproc/stdproc/formslc/CMakeLists.txt
@@ -2,3 +2,27 @@ InstallSameDir(
     __init__.py
     Formslc.py
     )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(stdproc_formslc MODULE
+    bindings/formslcmodule.cpp
+    src/formslc.f90
+    src/formslcAllocateDeallocate.F
+    src/formslcGetState.F
+    src/formslcSetState.F
+    src/formslcStateSoi.f90
+    )
+target_include_directories(stdproc_formslc PRIVATE include)
+target_link_libraries(stdproc_formslc PRIVATE
+    isce2::DataAccessorLib
+    isce2::formslcLib
+    )
+set_target_properties(stdproc_formslc
+    PROPERTIES OUTPUT_NAME formslc
+    )
+InstallSameDir(
+    stdproc_formslc
+    )

--- a/components/stdproc/stdproc/formslcLib/CMakeLists.txt
+++ b/components/stdproc/stdproc/formslcLib/CMakeLists.txt
@@ -16,3 +16,19 @@ set_property(TARGET formslcLib PROPERTY Fortran_MODULE_DIRECTORY ${mdir})
 target_include_directories(formslcLib INTERFACE
     $<$<COMPILE_LANGUAGE:Fortran>:${mdir}>
     )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+target_sources(formslcLib PRIVATE
+    src/mocomp.f90
+    src/rciq.f90
+    src/rcov.f90
+    src/rmpatch.f90
+    src/tsxmocompIsce.f90
+    )
+target_link_libraries(formslcLib PRIVATE
+    isce2::combinedLib
+    isce2::stdoelLib
+    )

--- a/components/stdproc/stdproc/mocompTSX/CMakeLists.txt
+++ b/components/stdproc/stdproc/mocompTSX/CMakeLists.txt
@@ -2,3 +2,24 @@ InstallSameDir(
     __init__.py
     MocompTSX.py
     )
+
+if(NOT ISCE2_WITH_STANFORD)
+    return()
+endif()
+
+Python_add_library(mocompTSX MODULE
+    bindings/mocompTSXmodule.cpp
+    src/mocompTSXAllocateDeallocate.f
+    src/mocompTSXState.f
+    src/mocompTSX.f90
+    src/mocompTSXGetState.f
+    src/mocompTSXSetState.f
+    )
+target_include_directories(mocompTSX PRIVATE include)
+target_link_libraries(mocompTSX PRIVATE
+    isce2::formslcLib
+    isce2::DataAccessorLib
+    )
+InstallSameDir(
+    mocompTSX
+    )


### PR DESCRIPTION
CMake can be told to build the separate Stanford modules in stdproc via the ISCE2_WITH_STANFORD configuration option.

If not specified, it will be auto-enabled at configuration time if the `stanford_license` magic is not `None`.

I think this puts our CMake scripts at feature parity with the SCons scripts.

(Of course, the Stanford code itself still needs to be obtained separately. Enabling ISCE2_WITH_STANFORD without doing so will cause failures when CMake encounters the missing files.)

cc @parosen 