### PR TITLE
Proposed changes to compile RelaxIV using CMake

### DIFF
--- a/contrib/UnwrapComp/CMakeLists.txt
+++ b/contrib/UnwrapComp/CMakeLists.txt
@@ -1,7 +1,20 @@
-# TODO check for RelaxIV
-
-InstallSameDir(
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/RelaxIV)
+    Python_add_library(unwcomp MODULE
+        bindings/unwcompmodule.cpp
+        src/RelaxIV/RelaxIV.C
+        src/relaxIVdriver.cpp
+        )
+    target_include_directories(unwcomp PUBLIC include)
+    InstallSameDir(
+    __init__.py
+    phaseUnwrap.py
+    unwrapComponents.py
+    unwcomp
+    )
+else()
+    InstallSameDir(
     __init__.py
     phaseUnwrap.py
     unwrapComponents.py
     )
+endif()


### PR DESCRIPTION
- Compiles RelaxIV files using CMake
*Though it compiles properly, the output named unwcomp.so was not properly imported so someone might check if I've missed something.

This is the output from my terminal once I've imported it using Python.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: dlopen(/Users/bryanmarfito/miniconda3/envs/isce2expe/lib/python3.8/site-packages/isce2/components/contrib/UnwrapComp/unwcomp.so, 2): Symbol not found: __Z8SetParamPN20MCFClass_di_unipi_it8MCFClassE
  Referenced from: /Users/bryanmarfito/miniconda3/envs/isce2expe/lib/python3.8/site-packages/isce2/components/contrib/UnwrapComp/unwcomp.so
  Expected in: flat namespace
 in /Users/bryanmarfito/miniconda3/envs/isce2expe/lib/python3.8/site-packages/isce2/components/contrib/UnwrapComp/unwcomp.so
```