### PR TITLE
Proposed changes to CMakeLists.txt and relaxIVdriver.cpp

### DIFF
--- a/contrib/UnwrapComp/CMakeLists.txt
+++ b/contrib/UnwrapComp/CMakeLists.txt
@@ -1,7 +1,20 @@
-# TODO check for RelaxIV
-
-InstallSameDir(
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/RelaxIV)
+    Python_add_library(unwcomp MODULE
+        bindings/unwcompmodule.cpp
+        src/RelaxIV/RelaxIV.C
+        src/relaxIVdriver.cpp
+        )
+    target_include_directories(unwcomp PUBLIC include)
+    InstallSameDir(
+    __init__.py
+    phaseUnwrap.py
+    unwrapComponents.py
+    unwcomp
+    )
+else()
+    InstallSameDir(
     __init__.py
     phaseUnwrap.py
     unwrapComponents.py
     )
+endif()

--- a/contrib/UnwrapComp/src/relaxIVdriver.cpp
+++ b/contrib/UnwrapComp/src/relaxIVdriver.cpp
@@ -2,7 +2,7 @@
 #include <sstream>
 #include <RelaxIV.h>
 #include <relaxIVdriver.h>
-#include <MCFClass.h>
+
 
 using namespace MCFClass_di_unipi_it;
 
@@ -13,7 +13,72 @@ inline T ABS( const T x )
 }
 
 using namespace std;
-extern void SetParam( MCFClass *mcf );
+//extern void SetParam( MCFClass *mcf );
+
+template<class T>
+static inline void str2val( const char* const str , T &sthg )
+{
+ istringstream( str ) >> sthg;
+ }
+
+/*--------------------------------------------------------------------------*/
+// This function skips comment line in a input stream, where comment line is 
+// // marked by an initial '#' character
+//
+void SkipComments( ifstream &iParam , string &buf )
+ {
+  do {
+    iParam >> ws;
+      getline( iParam , buf );
+       }
+        while( buf[ 0 ] == '#' );
+        }
+
+
+
+
+void SetParam( MCFClass *mcf )
+{
+ ifstream iParam( "config.txt" ); 
+ if( ! iParam.is_open() )
+  return;
+
+ string buf;
+ int num;
+ SkipComments( iParam , buf );
+ str2val( buf.c_str(), num );        // get number of int parameters
+
+ for( int i = 0 ; i < num ; i++ ) {  // read all int parameters
+  int param , val;
+  
+  SkipComments( iParam , buf );
+  str2val( buf.c_str(), param );     // parameter name
+  
+  SkipComments( iParam , buf );
+  str2val( buf.c_str(), val );       // parameter value
+
+  mcf->SetPar( param , val );
+
+  }  // end( for( i ) )
+
+ SkipComments( iParam , buf );
+ str2val( buf.c_str() , num );       // get number of double parameters
+
+ for( int i = 0 ; i < num ; i++ ) {  // read all double parameters
+  int param;
+  double val;
+  SkipComments( iParam , buf );
+  str2val( buf.c_str(), param );     // parameter name
+  
+  SkipComments( iParam , buf );
+  str2val( buf.c_str() , val );      // parameter value
+  
+  mcf->SetPar( param , val );
+
+  }  // end( for( i ) )
+ }  // end( SetParam )
+
+
 vector<int> driver(char *fileName)
 {
  ifstream iFile(fileName);

--- a/contrib/UnwrapComp/src/relaxIVdriver.cpp
+++ b/contrib/UnwrapComp/src/relaxIVdriver.cpp
@@ -95,7 +95,7 @@ vector<int> driver(char *fileName)
 
   // load the network - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  cout << "Loading Network :" << fileName  << endl;
+  cout << "Loading Network: " << fileName  << endl;
   mcf->LoadDMX( iFile );
 
   // set "reasonable" values for the epsilons, if any - - - - - - - - - - - -


### PR DESCRIPTION
- Changes are made to CMakeLists.txt to compile RelaxIV if available  #286 
- Changes to relaxIVdriver.cpp for it to compile and run properly. The changes to relaxIVdriver.cpp are credited to Wilson Acero (http://earthdef.caltech.edu/boards/4/topics/2698?r=3099#message-3099)

Output from my terminal after running unwrap2stage incorporating the changes above.
```
(isce2expe) bryanmarfito@Bryans-MacBook-Pro 20170701_20170707_des_S1 % topsApp.py --dostep=unwrap2stage
This is the Open Source version of ISCE.
Some of the workflows depend on a separate licensed package.
To obtain the licensed package, please make a request for ISCE
through the website: https://download.jpl.nasa.gov/ops/request/index.cfm.
Alternatively, if you are a member, or can become a member of WinSAR
you may be able to obtain access to a version of the licensed sofware at
https://winsar.unavco.org/software/isce
2021-07-26 20:38:31,949 - isce.insar - INFO - ISCE VERSION = 2.5.2, RELEASE_SVN_REVISION = ,RELEASE_DATE = 20210528, CURRENT_SVN_REVISION =
ISCE VERSION = 2.5.2, RELEASE_SVN_REVISION = ,RELEASE_DATE = 20210528, CURRENT_SVN_REVISION =

/Users/bryanmarfito/miniconda3/envs/isce2expe/bin/topsApp.py:768: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  logger.warn((
2021-07-26 20:38:39,282 - isce.insar - WARNING - Some filenames in insarApp.geocode_list configuration are different from those in InsarProc. Using names given to insarApp.
insarApp.geocode_list = ['merged/phsig.cor', 'merged/filt_topophase.unw', 'merged/los.rdr', 'merged/topophase.flat', 'merged/filt_topophase.flat', 'merged/topophase.cor', 'merged/filt_topophase.unw.conncomp', 'merged/filt_topophase_2stage.unw', 'merged/filt_topophase.msk']
InsarProc.geocode_list = ['merged/phsig.cor', 'merged/topophase.cor', 'merged/filt_topophase.unw', 'merged/los.rdr', 'merged/topophase.flat', 'merged/filt_topophase.flat', 'merged/filt_topophase_2stage.unw']
Step processing
Running step unwrap2stage
Unwrap 2 Stage Settings:
Name: MCF
Solver: pulp
2021-07-26 20:38:39,368 - root - DEBUG - Creating readonly ISCE mmap with
file = merged/filt_topophase.unw
bands = 2
width = 2256
length = 1961
scheme = BIL
dtype = FLOAT

2021-07-26 20:38:39,517 - root - DEBUG - Creating readonly ISCE mmap with
file = merged/filt_topophase.unw.conncomp
bands = 1
width = 2256
length = 1961
scheme = BIP
dtype = BYTE

GDAL using merged/filt_topophase.unw.conncomp.vrt
Number of connected components: 20
Estimating neighbors of component : 1
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 2
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 3
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 4
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 5
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 6
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 7
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 8
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 9
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 10
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 11
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 12
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 13
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 14
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 15
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 16
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 17
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 18
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 19
0...10...20...30...40...50...60...70...80...90...100 - done.
Estimating neighbors of component : 20
0...10...20...30...40...50...60...70...80...90...100 - done.
Number of unique vertices: 208
/Users/bryanmarfito/miniconda3/envs/isce2expe/lib/python3.8/site-packages/pulp/pulp.py:1199: UserWarning: Spaces are not permitted in the name. Converted to '_'
  warnings.warn("Spaces are not permitted in the name. Converted to '_'")
Loading Network :network.dmx
Running Relax IV
Optimal Objective Function value = 39
Solution time (s): user 0.001011, system 0
This is the Open Source version of ISCE.
Some of the workflows depend on a separate licensed package.
To obtain the licensed package, please make a request for ISCE
through the website: https://download.jpl.nasa.gov/ops/request/index.cfm.
Alternatively, if you are a member, or can become a member of WinSAR
you may be able to obtain access to a version of the licensed sofware at
https://winsar.unavco.org/software/isce
args:  Namespace(debug=False, dtype='float', equation='a_0;b_0', hh=None, noxml=False, out='/Volumes/BJM_WD_Red/InSAR/LeyteEQ2017/processed_data/ISCE/20170701_20170707_des_S1/merged/filt_topophase_2stage.unw', scheme='BIL')
files:  ['--a=merged/filt_topophase.unw', '--b=merged/filt_topophase_2stage.unw_temp']
GDAL open (R): /Volumes/BJM_WD_Red/InSAR/LeyteEQ2017/processed_data/ISCE/20170701_20170707_des_S1/merged/filt_topophase_2stage.unw.vrt
GDAL close: /Volumes/BJM_WD_Red/InSAR/LeyteEQ2017/processed_data/ISCE/20170701_20170707_des_S1/merged/filt_topophase_2stage.unw.vrt
Dumping the application's pickle object _insar to file  PICKLE/unwrap2stage
The remaining steps are (in order):  ['geocode', 'denseoffsets', 'filteroffsets', 'geocodeoffsets']
```