### PR TITLE
stackSentinel: expose virtual merge via -V / --virtual_merge option

### DIFF
--- a/contrib/stack/topsStack/README.md
+++ b/contrib/stack/topsStack/README.md
@@ -37,7 +37,7 @@ The following calibration auxliary (AUX_CAL) file is used for **antenna pattern 
 Run the command below to download the AUX_CAL file once and store it somewhere (_i.e._ ~/aux/aux_cal) so that you can use it all the time, for `stackSentinel.py -a` or `auxiliary data directory` in `topsApp.py`.
 
 ```
-wget https://aux.sentinel1.eo.esa.int/AUX_CAL/2014/09/08/S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE/ --no-check-certificate --recursive --level=1 --cut-dirs=4 -nH
+wget https://qc.sentinel1.groupcls.com/product/S1A/AUX_CAL/2014/09/08/S1A_AUX_CAL_V20140908T000000_G20190626T100201.SAFE.TGZ
 ```
 
 #### 1. Create your project folder somewhere ####
@@ -53,7 +53,7 @@ Download of DEM (need to use wgs84 version) using the ISCE DEM download script.
 
 ```
 mkdir DEM; cd DEM
-dem.py -a stitch -b 18 20 -100 -97 -r -s 1 –c
+dem.py -a stitch -b 18 20 -100 -97 -r -s 1 -c
 rm demLat*.dem demLat*.dem.xml demLat*.dem.vrt
 cd ..
 ```

--- a/contrib/stack/topsStack/s1a_isce_utils.py
+++ b/contrib/stack/topsStack/s1a_isce_utils.py
@@ -5,11 +5,11 @@ import os
 #from isceobj.Sensor.TOPS.coregSwathSLCProduct import coregSwathSLCProduct
 
 class catalog(object):
-      def __init__(self):
-         pass
+    def __init__(self):
+        pass
 
-      def addItem(self,*args):
-          print(' '.join([str(x) for x in args]))
+    def addItem(self,*args):
+        print(' '.join([str(x) for x in args]))
           
 
 
@@ -29,22 +29,23 @@ def loadProduct(xmlname):
 
 
 def saveProduct( obj, xmlname):
-        '''
-        Save the product to an XML file using Product Manager.
-        '''
-       # import shelve
-       # import os
-       # with shelve.open(os.path.dirname(xmlname) + '/'+ os.path.basename(xmlname)  +'.data') as db:
-       #     db['data'] = obj
+    '''
+    Save the product to an XML file using Product Manager.
+    '''
+    import shelve
+    import os
+    with shelve.open(os.path.dirname(xmlname) + '/'+ os.path.basename(xmlname)  +'.data') as db:
+        db['data'] = obj
 
-        from iscesys.Component.ProductManager import ProductManager as PM
+    from iscesys.Component.ProductManager import ProductManager as PM
 
-        pm = PM()
-        pm.configure()
+    pm = PM()
+    pm.configure()
 
-        pm.dumpProduct(obj, xmlname)
+    pm.dumpProduct(obj, xmlname)
 
-        return None
+    return None
+
 
 def getRelativeShifts(mFrame, sFrame, minBurst, maxBurst, secondaryBurstStart):
     '''
@@ -152,30 +153,31 @@ def adjustValidSampleLine_V2(reference, secondary, minAz=0, maxAz=0, minRng=0, m
 
     if (minAz > 0) and (maxAz > 0):
 
-            reference.firstValidLine = secondary.firstValidLine - int(np.floor(maxAz) - 4)
-            lastValidLine = reference.firstValidLine - 8  + secondary.numValidLines
-            if lastValidLine < reference.numberOfLines:
-               reference.numValidLines = secondary.numValidLines - 8
-            else:
-               reference.numValidLines = reference.numberOfLines - reference.firstValidLine
+        reference.firstValidLine = secondary.firstValidLine - int(np.floor(maxAz) - 4)
+        lastValidLine = reference.firstValidLine - 8  + secondary.numValidLines
+        if lastValidLine < reference.numberOfLines:
+            reference.numValidLines = secondary.numValidLines - 8
+        else:
+            reference.numValidLines = reference.numberOfLines - reference.firstValidLine
 
     elif (minAz < 0) and  (maxAz < 0):
-            reference.firstValidLine = secondary.firstValidLine - int(np.floor(minAz) - 4)
-            lastValidLine = reference.firstValidLine + secondary.numValidLines  - 8
-            if lastValidLine < reference.numberOfLines:
-               reference.numValidLines = secondary.numValidLines - 8
-            else:
-               reference.numValidLines = reference.numberOfLines - reference.firstValidLine
+        reference.firstValidLine = secondary.firstValidLine - int(np.floor(minAz) - 4)
+        lastValidLine = reference.firstValidLine + secondary.numValidLines  - 8
+        if lastValidLine < reference.numberOfLines:
+            reference.numValidLines = secondary.numValidLines - 8
+        else:
+            reference.numValidLines = reference.numberOfLines - reference.firstValidLine
 
     elif (minAz < 0) and (maxAz > 0):
-            reference.firstValidLine = secondary.firstValidLine - int(np.floor(minAz) - 4)
-            lastValidLine = reference.firstValidLine + secondary.numValidLines + int(np.floor(minAz) - 8) - int(np.ceil(maxAz))
-            if lastValidLine < reference.numberOfLines:
-               reference.numValidLines = secondary.numValidLines + int(np.floor(minAz) - 8) - int(np.ceil(maxAz))
-            else:
-               reference.numValidLines = reference.numberOfLines - reference.firstValidLine
+        reference.firstValidLine = secondary.firstValidLine - int(np.floor(minAz) - 4)
+        lastValidLine = reference.firstValidLine + secondary.numValidLines + int(np.floor(minAz) - 8) - int(np.ceil(maxAz))
+        if lastValidLine < reference.numberOfLines:
+            reference.numValidLines = secondary.numValidLines + int(np.floor(minAz) - 8) - int(np.ceil(maxAz))
+        else:
+            reference.numValidLines = reference.numberOfLines - reference.firstValidLine
 
     return reference
+
 
 def adjustCommonValidRegion(reference,secondary):
     # valid lines between reference and secondary
@@ -264,13 +266,14 @@ def asBaseClass(inobj):
     else:
         raise Exception('Cannot be converted to TOPSSwathSLCProduct')
 
+
 def getSwathList(indir):
 
     swathList = []
     for x in [1,2,3]:
-       SW = os.path.join(indir,'IW{0}'.format(x))
-       if os.path.exists(SW):
-          swathList.append(x)
+        SW = os.path.join(indir,'IW{0}'.format(x))
+        if os.path.exists(SW):
+            swathList.append(x)
 
     return swathList
 

--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -160,8 +160,14 @@ def createParser():
     parser.add_argument('-e', '--esd_coherence_threshold', dest='esdCoherenceThreshold', type=str, default='0.85', 
                         help='Coherence threshold for estimating azimuth misregistration using enhanced spectral diversity (default: %(default)s).')
 
-    parser.add_argument('-W', '--workflow', dest='workflow', type=str, default='interferogram', choices=['slc', 'correlation', 'interferogram', 'offset'],
+    parser.add_argument('-W', '--workflow', dest='workflow', type=str, default='interferogram',
+                        choices=['slc', 'correlation', 'interferogram', 'offset'],
                         help='The InSAR processing workflow (default: %(default)s).')
+
+    parser.add_argument('-V', '--virtual_merge', dest='virtualMerge', type=str, default=None, choices=['True', 'False'],
+                        help='Use virtual files for the merged SLCs and geometry files.\n'
+                             'Default: True  for correlation / interferogram workflow\n'
+                             '         False for slc / offset workflow')
 
     parser.add_argument('-useGPU', '--useGPU', dest='useGPU',action='store_true', default=False,
                         help='Allow App to use GPU when available')
@@ -531,15 +537,16 @@ def slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe_di
 
 def correlationStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe_dict, pairs, updateStack):
 
-    #############################
     i = slcStack(inps, acquisitionDates,stackReferenceDate, secondaryDates, safe_dict, updateStack)
 
+    # default value of virtual_merge
+    virtual_merge = 'True' if not inps.virtualMerge else inps.virtualMerge
 
     i+=1
     runObj = run()
     runObj.configure(inps, 'run_{:02d}_merge_reference_secondary_slc'.format(i))
-    runObj.mergeReference(stackReferenceDate, virtual = 'True')
-    runObj.mergeSecondarySLC(secondaryDates, virtual = 'True')
+    runObj.mergeReference(stackReferenceDate, virtual = virtual_merge)
+    runObj.mergeSecondarySLC(secondaryDates, virtual = virtual_merge)
     runObj.finalize()
 
     i+=1
@@ -559,11 +566,14 @@ def interferogramStack(inps, acquisitionDates, stackReferenceDate, secondaryDate
 
     i = slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe_dict, updateStack)
 
+    # default value of virtual_merge
+    virtual_merge = 'True' if not inps.virtualMerge else inps.virtualMerge
+
     i+=1
     runObj = run()
     runObj.configure(inps, 'run_{:02d}_merge_reference_secondary_slc'.format(i))
-    runObj.mergeReference(stackReferenceDate, virtual = 'True')
-    runObj.mergeSecondarySLC(secondaryDates, virtual = 'True')
+    runObj.mergeReference(stackReferenceDate, virtual = virtual_merge)
+    runObj.mergeSecondarySLC(secondaryDates, virtual = virtual_merge)
     runObj.finalize()
 
     i+=1
@@ -595,11 +605,14 @@ def offsetStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe
 
     i = slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, safe_dict, updateStack)
 
+    # default value of virtual_merge
+    virtual_merge = 'False' if not inps.virtualMerge else inps.virtualMerge
+
     i+=1
     runObj = run()
     runObj.configure(inps, 'run_{:02d}_merge_reference_secondary_slc'.format(i))
-    runObj.mergeReference(stackReferenceDate, virtual = 'False')
-    runObj.mergeSecondarySLC(secondaryDates, virtual = 'False')
+    runObj.mergeReference(stackReferenceDate, virtual = virtual_merge)
+    runObj.mergeSecondarySLC(secondaryDates, virtual = virtual_merge)
     runObj.finalize()
 
     i+=1


### PR DESCRIPTION
This PR adds `stackSentinel.py --virtual_merge` option to be able to change the default virtual file merge behavior. Default values are retained to not affect existing behavior.

There are a few more minor changes:
+ README: update wget cmd to download the aux_cal file due to the ESA link change
+ README: + fix typo in the dem.py command
+ mergeBursts/s1a_isce_utils.py: Adjust indentations in the following scripts following pep8 style for improved readability.