### PR TITLE
add "unpack" and "prepare" UAVSAR_HDF5 scripts for stripmap stack

### DIFF
--- a/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
@@ -103,8 +103,11 @@ def main():
         slcFile = os.path.join(imgDir, imgDate + ".slc")
 
         # Now extract the correct pol SLC from the HDF5 file
-        subdataset = "/science/LSAR/SLC/swaths/frequencyA/{}".format(inps.polarization)
-        cmd = 'gdal_translate -of ISCE HDF5:"{}":"/{}" {}'.format(h5_file, subdataset, slcFile)
+        subdataset = "/science/LSAR/SLC/swaths"
+        subdataset += "/frequency{}/{}".format(inps.frequency, inps.polarization)
+        cmd = 'gdal_translate -of ISCE HDF5:"{fname}":"/{sds}" {out}'.format(
+            fname=h5_file, sds=subdataset, out=slcFile
+        )
 
         print(cmd)
         subprocess.check_call(cmd, shell=True)

--- a/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
@@ -106,14 +106,8 @@ def main():
         subdataset = "/science/LSAR/SLC/swaths/frequencyA/{}".format(inps.polarization)
         cmd = 'gdal_translate -of ISCE HDF5:"{}":"/{}" {}'.format(h5_file, subdataset, slcFile)
 
-        # cmd = "ln -s " + h5_file + " " + slcFile
         print(cmd)
         subprocess.check_call(cmd, shell=True)
-
-        # cmd = "mv " + annFile + " " + imgDir
-        # print(cmd)
-        # os.system(cmd)
-        # subprocess.check_call(cmd, shell=True)
 
         shelveFile = os.path.join(imgDir, "data")
         write_xml(shelveFile, slcFile)

--- a/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_HDF5Stack.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os
+import glob
+import argparse
+
+import isce  # noqa
+import isceobj
+import subprocess
+import shelve
+
+
+def get_cli_args():
+    """
+    Create command line parser.
+    """
+
+    parser = argparse.ArgumentParser(description="Prepare UAVSAR HDF5 SLC Stack files.")
+    parser.add_argument(
+        "-i",
+        "--input-dir",
+        dest="input_dir",
+        required=True,
+        help="Input UAVSAR HDF5 file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output SLC directory",
+    )
+    parser.add_argument(
+        "-p",
+        "--polarization",
+        dest="polarization",
+        default="VV",
+        help="SLC polarization (default=%(default)s ) ",
+    )
+    parser.add_argument(
+        "-f",
+        "--frequency",
+        default="A",
+        choices=("A", "B"),
+        help="NISAR frequency choices (choices = %(choices)s , default=%(default)s )",
+    )
+    return parser.parse_args()
+
+
+def write_xml(shelveFile, slcFile):
+    with shelve.open(shelveFile, flag="r") as db:
+        frame = db["frame"]
+
+    length = frame.numberOfLines
+    width = frame.numberOfSamples
+    print(width, length)
+
+    slc = isceobj.createSlcImage()
+    slc.setWidth(width)
+    slc.setLength(length)
+    slc.filename = slcFile
+    slc.setAccessMode("write")
+    slc.renderHdr()
+    slc.renderVRT()
+
+
+def get_date(file):
+    yyyymmdd = "20" + file.split("_")[4]
+    return yyyymmdd
+
+
+def main():
+    """
+    The main driver.
+    """
+
+    inps = get_cli_args()
+
+    outputDir = os.path.abspath(inps.output)
+
+    #######################################
+    slc_files = glob.glob(os.path.join(inps.input_dir, "*.h5"))
+
+    for h5_file in slc_files:
+        imgDate = get_date(h5_file)
+        print(imgDate)
+        print(h5_file)
+        imgDir = os.path.join(outputDir, imgDate)
+        os.makedirs(imgDir, exist_ok=True)
+
+        cmd = (
+            "unpackFrame_UAVSAR_HDF5_SLC.py -i "
+            + h5_file
+            + " -p "
+            + inps.polarization
+            + " -f "
+            + inps.frequency
+            + " -o "
+            + imgDir
+        )
+        print(cmd)
+        subprocess.check_call(cmd, shell=True)
+
+        slcFile = os.path.join(imgDir, imgDate + ".slc")
+
+        # Now extract the correct pol SLC from the HDF5 file
+        subdataset = "/science/LSAR/SLC/swaths/frequencyA/{}".format(inps.polarization)
+        cmd = 'gdal_translate -of ISCE HDF5:"{}":"/{}" {}'.format(h5_file, subdataset, slcFile)
+
+        # cmd = "ln -s " + h5_file + " " + slcFile
+        print(cmd)
+        subprocess.check_call(cmd, shell=True)
+
+        # cmd = "mv " + annFile + " " + imgDir
+        # print(cmd)
+        # os.system(cmd)
+        # subprocess.check_call(cmd, shell=True)
+
+        shelveFile = os.path.join(imgDir, "data")
+        write_xml(shelveFile, slcFile)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -117,7 +117,7 @@ def cmdLineParse(iargs = None):
 def get_dates(inps):
 
     dirs = glob.glob(inps.slcDir+'/*')
-    acuisitionDates = []
+    acquisitionDates = []
     for dirf in dirs:
         if inps.nofocus:
             expectedRaw = os.path.join(dirf,os.path.basename(dirf) + '.slc')
@@ -125,18 +125,18 @@ def get_dates(inps):
             expectedRaw = os.path.join(dirf, os.path.basename(dirf) + '.raw')
 
         if os.path.exists(expectedRaw):
-             acuisitionDates.append(os.path.basename(dirf))
+            acquisitionDates.append(os.path.basename(dirf))
 
-    acuisitionDates.sort()
-    print (dirs)
-    print (acuisitionDates)
-    if inps.referenceDate not in acuisitionDates:
-        print ('reference date was not found. The first acquisition will be considered as the stack reference date.')
-    if inps.referenceDate is None or inps.referenceDate not in acuisitionDates:
-        inps.referenceDate = acuisitionDates[0]
-    secondaryDates = acuisitionDates.copy()
+    acquisitionDates.sort()
+    print("dirs = ", dirs)
+    print("acquisitionDates = ", acquisitionDates)
+    if inps.referenceDate not in acquisitionDates:
+        print('reference date was not found. The first acquisition will be considered as the stack reference date.')
+    if inps.referenceDate is None or inps.referenceDate not in acquisitionDates:
+        inps.referenceDate = acquisitionDates[0]
+    secondaryDates = acquisitionDates.copy()
     secondaryDates.remove(inps.referenceDate)
-    return acuisitionDates, inps.referenceDate, secondaryDates
+    return acquisitionDates, inps.referenceDate, secondaryDates
 
 
 def slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, pairs, splitFlag=False, rubberSheet=False):
@@ -334,7 +334,7 @@ def main(iargs=None):
     runDir = os.path.join(inps.workDir,'run_files')
     os.makedirs(runDir, exist_ok=True)
 
-    if inps.sensor and inps.sensor.lower() == 'uavsar_stack':    # don't try to calculate baselines for UAVSAR_STACK data
+    if inps.sensor and inps.sensor.lower().startswith('uavsar'):    # don't try to calculate baselines for UAVSAR_STACK data
         pairs = selectPairs(inps,stackReferenceDate, secondaryDates, acquisitionDates,doBaselines=False)
     else:
         pairs = selectPairs(inps,stackReferenceDate, secondaryDates, acquisitionDates,doBaselines=True)

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR_HDF5_SLC.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR_HDF5_SLC.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# modified to pass the segment number to UAVSAR_STACK sensor EJF 2020/08/02
+
+import isce  # noqa
+from isceobj.Sensor import createSensor
+import shelve
+import argparse
+import os
+
+
+def cmdLineParse():
+    """
+    Command line parser.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Unpack UAVSAR SLC data and store metadata in pickle file."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        dest="h5_file",
+        required=True,
+        help="Input UAVSAR HDF5 file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="slc_dir",
+        required=True,
+        help="Output SLC directory",
+    )
+    parser.add_argument(
+        "-p",
+        "--polarization",
+        dest="polarization",
+        default="VV",
+        help="SLC polarization (default=%(default)s ) ",
+    )
+    parser.add_argument(
+        "-f",
+        "--frequency",
+        default="A",
+        choices=("A", "B"),
+        help="NISAR frequency choices (choices = %(choices)s , default=%(default)s )",
+    )
+    return parser.parse_args()
+
+
+def unpack(h5_file, slc_dir, frequency="A", polarization="VV"):
+    """
+    Unpack HDF5 to binary SLC file.
+    """
+
+    obj = createSensor("UAVSAR_HDF5_SLC")
+    obj.configure()
+    obj.hdf5 = h5_file
+    obj.frequency = "frequency" + frequency
+    obj.polarization = polarization
+
+    if not os.path.isdir(slc_dir):
+        os.mkdir(slc_dir)
+
+    # obj.parse()
+    date = os.path.basename(slc_dir)
+    obj.output = os.path.join(slc_dir, date + ".slc")
+
+    obj.extractImage()
+    obj.frame.getImage().renderHdr()
+
+    obj.extractDoppler()
+
+    pickName = os.path.join(slc_dir, "data")
+    with shelve.open(pickName) as db:
+        db["frame"] = obj.frame
+
+
+if __name__ == "__main__":
+    """
+    Main driver.
+    """
+
+    inps = cmdLineParse()
+    inps.slc_dir.rstrip("/")
+    inps.h5_file.rstrip("/")
+
+    unpack(inps.h5_file, inps.slc_dir, inps.frequency, inps.polarization)

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR_HDF5_SLC.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR_HDF5_SLC.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# modified to pass the segment number to UAVSAR_STACK sensor EJF 2020/08/02
 
 import isce  # noqa
 from isceobj.Sensor import createSensor


### PR DESCRIPTION
Adds the two scripts needed for [Step 4](https://github.com/isce-framework/isce2/tree/main/contrib/stack/stripmapStack#4-prepare-sar-data ) of `stackStripMap.py` to process the NISAR-simulated HDF5 products from UAVSAR. Since the `UAVSAR_HDF5_SLC` sensor was already created, I just added the prepare/extract parts so that you can do

`prepareUAVSAR_HDF5Stack.py --polarization VV --frequency A --input-dir . --output ../SLC`

I'm not sure if there's much interest in heavily adding on to ISCE2 for NISAR-like data, since that's what ISCE3 is being built for; I'm just submitting this because I've done some processing here. If it's not wanted in ISCE2, feel free to close.