### PR TITLE
Replaced logger.warn to logger.warning, changed *.hgt* to *.hgt and updated RelaxIV download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ you want to try the unwrap 2 stage option:
 
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
-based on the Fortran code developed by Dimitri Bertsekas (while
-at MIT) which is available at https://github.com/frangio68/Min-Cost-Flow-Class.
+based on the Fortran code developed by Dimitri Bertsekas while
+at MIT) is available at https://github.com/frangio68/Min-Cost-Flow-Class.
 The RelaxIV files should be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV' so that ISCE will compile it properly.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ you want to try the unwrap 2 stage option:
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
 based on the Fortran code developed by by Dimitri Bertsekas while
-at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. The RelaxIV files should
-be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
+at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. 
+The RelaxIV files should be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,
 https://github.com/coin-or/pulp.  Make sure the path to the installed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ you want to try the unwrap 2 stage option:
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
 based on the Fortran code developed by by Dimitri Bertsekas while
-at MIT) available by request at http://www.di.unipi.it/~frangio.
+at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class.
 So that ISCE will compile it properly, the RelaxIV files should
 be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ you want to try the unwrap 2 stage option:
 
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
-based on the Fortran code developed by by Dimitri Bertsekas while
-at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. 
+based on the Fortran code developed by Dimitri Bertsekas (while
+at MIT) which is available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. 
 The RelaxIV files should be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,

--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ you want to try the unwrap 2 stage option:
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
 based on the Fortran code developed by by Dimitri Bertsekas while
-at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class.
-So that ISCE will compile it properly, the RelaxIV files should
+at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly, the RelaxIV files should
 be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ you want to try the unwrap 2 stage option:
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
 based on the Fortran code developed by Dimitri Bertsekas (while
-at MIT) which is available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. 
-The RelaxIV files should be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
+at MIT) which is available at https://github.com/frangio68/Min-Cost-Flow-Class.
+The RelaxIV files should be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV' so that ISCE will compile it properly.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,
 https://github.com/coin-or/pulp.  Make sure the path to the installed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ you want to try the unwrap 2 stage option:
 * RelaxIV (a minimum cost flow relaxation algorithm coded in C++ by
 Antonio Frangioni and Claudio Gentile at the University of Pisa,
 based on the Fortran code developed by by Dimitri Bertsekas while
-at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly, the RelaxIV files should
+at MIT) available at https://github.com/frangio68/Min-Cost-Flow-Class so that ISCE will compile it properly. The RelaxIV files should
 be placed in the directory: 'contrib/UnwrapComp/src/RelaxIV'.
 
 * PULP: Use easy\_install or pip to install it or else clone it from,

--- a/applications/insarApp.py
+++ b/applications/insarApp.py
@@ -754,19 +754,19 @@ class _InsarBase(Application, FrameMixin):
                 if self.geocode_bbox:
                     ####Adjust bbox according to dem
                     if self.geocode_bbox[0] < dem_snwe[0]:
-                        logger.warn('Geocoding southern extent changed to match DEM')
+                        logger.warning('Geocoding southern extent changed to match DEM')
                         self.geocode_bbox[0] = dem_snwe[0]
 
                     if self.geocode_bbox[1] > dem_snwe[1]:
-                        logger.warn('Geocoding northern extent changed to match DEM')
+                        logger.warning('Geocoding northern extent changed to match DEM')
                         self.geocode_bbox[1] = dem_snwe[1]
 
                     if self.geocode_bbox[2] < dem_snwe[2]:
-                        logger.warn('Geocoding western extent changed to match DEM')
+                        logger.warning('Geocoding western extent changed to match DEM')
                         self.geocode_bbox[2] = dem_snwe[2]
 
                     if self.geocode_bbox[3] > dem_snwe[3]:
-                        logger.warn('Geocoding eastern extent changed to match DEM')
+                        logger.warning('Geocoding eastern extent changed to match DEM')
                         self.geocode_bbox[3] = dem_snwe[3]
 
         #Ensure consistency in geocode_list maintained by insarApp and

--- a/applications/isceApp.py
+++ b/applications/isceApp.py
@@ -1170,19 +1170,19 @@ class IsceApp(Application, FrameMixin):
                 if self.geocode_bbox:
                     ####Adjust bbox according to dem
                     if self.geocode_bbox[0] < dem_snwe[0]:
-                        logger.warn('Geocoding southern extent changed to match DEM')
+                        logger.warning('Geocoding southern extent changed to match DEM')
                         self.geocode_bbox[0] = dem_snwe[0]
 
                     if self.geocode_bbox[1] > dem_snwe[1]:
-                        logger.warn('Geocoding northern extent changed to match DEM')
+                        logger.warning('Geocoding northern extent changed to match DEM')
                         self.geocode_bbox[1] = dem_snwe[1]
 
                     if self.geocode_bbox[2] < dem_snwe[2]:
-                        logger.warn('Geocoding western extent changed to match DEM')
+                        logger.warning('Geocoding western extent changed to match DEM')
                         self.geocode_bbox[2] = dem_snwe[2]
 
                     if self.geocode_bbox[3] > dem_snwe[3]:
-                        logger.warn('Geocoding eastern extent changed to match DEM')
+                        logger.warning('Geocoding eastern extent changed to match DEM')
                         self.geocode_bbox[3] = dem_snwe[3]
 
         #Ensure consistency in geocode_list maintained by isceApp and

--- a/applications/rtcApp.py
+++ b/applications/rtcApp.py
@@ -320,7 +320,7 @@ class GRDSAR(Application):
             #warn if there are any differences in content
             if g_count > 0:
                 print()
-                logger.warn((
+                logger.warning((
                     "Some filenames in rtcApp.geocode_list configuration "+
                     "are different from those in rtcProc. Using names given"+
                     " to grdApp."))

--- a/applications/stripmapApp.py
+++ b/applications/stripmapApp.py
@@ -646,7 +646,7 @@ class _RoiBase(Application, FrameMixin):
             #warn if there are any differences in content
             if g_count > 0:
                 print()
-                logger.warn((
+                logger.warning((
                     "Some filenames in stripmapApp.geocode_list configuration "+
                     "are different from those in StripmapProc. Using names given"+
                     " to stripmapApp."))

--- a/applications/topsApp.py
+++ b/applications/topsApp.py
@@ -782,7 +782,7 @@ class TopsInSAR(Application):
             #warn if there are any differences in content
             if g_count > 0:
                 print()
-                logger.warn((
+                logger.warning((
                     "Some filenames in insarApp.geocode_list configuration "+
                     "are different from those in InsarProc. Using names given"+
                     " to insarApp."))

--- a/components/isceobj/InsarProc/runOffoutliers.py
+++ b/components/isceobj/InsarProc/runOffoutliers.py
@@ -72,6 +72,6 @@ def runOffoutliers(self, distance, errorLimit=100):
         logger.error('Small number of output Offsets after culling: %d .\n Increase number of windows (or) window sizes (or) provide gross offset manually.'%(lenOut))
         raise Exception('Offset estimation Failed.')
     elif lenOut < warnLimit:
-        logger.warn('Number of output offsets after culling are low: %d. Might be ok to continue.'%(lenOut))
+        logger.warning('Number of output offsets after culling are low: %d. Might be ok to continue.'%(lenOut))
 
     self._insar.setRefinedOffsetField(refinedOffsets)

--- a/components/isceobj/InsarProc/runPrepareResamps.py
+++ b/components/isceobj/InsarProc/runPrepareResamps.py
@@ -82,10 +82,10 @@ def runPrepareResamps(self, rangeLooks=None, azLooks=None):
         looksaz=int(round(posting/(s2_2 - s2)))
     
     if (looksrange < 1):
-        logger.warn("Number range looks less than zero, setting to 1")
+        logger.warning("Number range looks less than zero, setting to 1")
         looksrange = 1
     if (looksaz < 1):
-        logger.warn("Number azimuth looks less than zero, setting to 1")
+        logger.warning("Number azimuth looks less than zero, setting to 1")
         looksaz = 1
 
     self._insar.setNumberAzimuthLooks(looksaz) 

--- a/components/isceobj/IsceProc/runPrepareResamps.py
+++ b/components/isceobj/IsceProc/runPrepareResamps.py
@@ -82,10 +82,10 @@ def runPrepareResamps(self, rgLooks=None, azLooks=None):
         looksaz = int(round(posting/(s2_2 - s2)))
 
     if (looksrange < 1):
-        logger.warn("Number range looks less than zero, setting to 1")
+        logger.warning("Number range looks less than zero, setting to 1")
         looksrange = 1
     if (looksaz < 1):
-        logger.warn("Number azimuth looks less than zero, setting to 1")
+        logger.warning("Number azimuth looks less than zero, setting to 1")
         looksaz = 1
 
     self._isce.numberAzimuthLooks = looksaz

--- a/components/isceobj/Sensor/ALOS.py
+++ b/components/isceobj/Sensor/ALOS.py
@@ -283,7 +283,7 @@ class ALOS(Sensor):
                 self.imageFile.width*rangePixelSize
                 )
         except TypeError as strerr:
-            self.logger.warn(strerr)
+            self.logger.warning(strerr)
 
         self.frame.frameNumber = frame
         self.frame.setOrbitNumber(

--- a/components/isceobj/Sensor/ERS.py
+++ b/components/isceobj/Sensor/ERS.py
@@ -221,7 +221,7 @@ class ERS(Sensor):
             # Sometimes, the ICU on board clock is corrupt, if the time suggested by the on board clock is more than
             # 5 days from the satellite clock time, assume its bogus and use the low-precision scene centre time
             if (math.fabs(deltaSeconds) > 5*86400):
-                        self.logger.warn("ICU on board time appears to be corrupt, resorting to low precision clock")
+                        self.logger.warning("ICU on board time appears to be corrupt, resorting to low precision clock")
                         first_line_utc = centerLineTime - datetime.timedelta(microseconds=pulseInterval*(self.imageFile.length/2.0)*1e6)
             else:
                 satelliteClockTime = datetime.datetime.strptime(self.leaderFile.sceneHeaderRecord.metadata['Satellite clock time'],"%Y%m%d%H%M%S%f")
@@ -568,7 +568,7 @@ class ImageFile(object):
             lineCounter = imageData.metadata['Image format counter']
 
             if (lineCounter == 0):
-                self.logger.warn("Zero line counter at line %s" % (line+1))
+                self.logger.warning("Zero line counter at line %s" % (line+1))
                 lastLineCounter += 1
                 continue
 

--- a/components/isceobj/Util/decorators.py
+++ b/components/isceobj/Util/decorators.py
@@ -56,7 +56,7 @@ def force(type_):
                     self.__class__.__name__,
                     setter.__name__)
                 if hasattr(self, "logger"):
-                    self.logger.warn(message)
+                    self.logger.warning(message)
                 else:
                     raise ValueError(message)
                 pass

--- a/components/mroipac/grass/grass.py
+++ b/components/mroipac/grass/grass.py
@@ -163,7 +163,7 @@ class Grass(Component):
         #####Old files need to be cleaned out
         #####Otherwise will use old result
         if os.path.exists(flagFilename):
-            self.logger.warn('Old Mask File found. Will be deleted.')
+            self.logger.warning('Old Mask File found. Will be deleted.')
             os.remove(flagFilename)
     
         intFile_C = ctypes.c_char_p(self.interferogram.getFilename().encode('utf-8'))

--- a/contrib/stack/alosStack/alosStack.xml
+++ b/contrib/stack/alosStack/alosStack.xml
@@ -88,7 +88,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_3_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 3 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL3.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #1 arcsec for creating differential interferogram
@@ -96,7 +96,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_1_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 1 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #water body

--- a/examples/input_files/alos2/alos2App.xml
+++ b/examples/input_files/alos2/alos2App.xml
@@ -100,7 +100,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_3_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 3 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL3.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #1 arcsec for creating differential interferogram
@@ -108,7 +108,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_1_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 1 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #water body

--- a/examples/input_files/alos2/alos2burstApp.xml
+++ b/examples/input_files/alos2/alos2burstApp.xml
@@ -95,7 +95,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_3_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 3 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL3.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #1 arcsec for creating differential interferogram
@@ -103,7 +103,7 @@ IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-450
     cd dem_1_arcsec
     dem.py -a stitch -b 29 37 125 133 -k -s 1 -c -f -u http://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/2000.02.11
     fixImageXml.py -i demLat_*_*_Lon_*_*.dem.wgs84 -f
-    rm *.hgt* *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
+    rm *.hgt *.log demLat_*_*_Lon_*_*.dem demLat_*_*_Lon_*_*.dem.vrt demLat_*_*_Lon_*_*.dem.xml
     cd ../
 
     #water body


### PR DESCRIPTION
- Replaced `logger.warn to logger.warning` to remove deprecated warning
- Changed `*.hgt* to *.hgt` on alos2App sample xml files to be able to delete .hgt files properly
- Updated the RelaxIV download link since the code is publicly available on Github