### PR TITLE
Added missing DemStitcherND.py in CMakeLists.txt

### DIFF
--- a/contrib/demUtils/CMakeLists.txt
+++ b/contrib/demUtils/CMakeLists.txt
@@ -50,6 +50,7 @@ InstallSameDir(
     correct_geoid_i2_srtm/egm96geoid.dat
     demstitcher/DemStitcher.py
     demstitcher/DemStitcherV3.py
+    demstitcher/DemStitcherND.py
     swbdstitcher/SWBDStitcher.py
     upsampledem/UpsampleDem.py
     watermask/WaterMask.py


### PR DESCRIPTION
- Added missing DemStitcherND.py in CMakeLists.txt to enable downloading of NASA DEM if ISCE2 is complied through CMake.