### PR TITLE
gdal2isce_xml.py: correct gdal multilook scheme for los

### DIFF
--- a/applications/gdal2isce_xml.py
+++ b/applications/gdal2isce_xml.py
@@ -105,8 +105,12 @@ def gdal2isce_xml(fname):
         img.scheme = 'BSQ'
     else:
         print('Unrecognized interleaving scheme, {}'.format(sch))
-        print('Assuming default, BIP')
-        img.scheme = 'BIP'
+        if bands < 2:
+            print('Assuming default, BIP')
+            img.scheme = 'BIP'
+        else:
+            print('Assuming default, BSQ')
+            img.scheme = 'BSQ'
 
     img.firstLongitude = transform[0]
     img.firstLatitude = transform[3] 


### PR DESCRIPTION
For CSK images, multi-looking of the geometry data is fine for all except los. The scheme written in .xml file does not match with what it should be. I have modified the default so that for 2 band products (like los.rdr), the default is BSQ instead of BIP.
