### PR TITLE
UAVSAR cropping fixes for stackStripmapApp

### DIFF
--- a/contrib/stack/stripmapStack/cropFrame.py
+++ b/contrib/stack/stripmapStack/cropFrame.py
@@ -161,18 +161,18 @@ def cropFrame(frame, limits, outdir, israw=False):
     ####sensing start
     ymin = np.floor( (limits[0] - frame.sensingStart).total_seconds() * frame.PRF)
     print('Line start: ', ymin)
-    ymin = np.int( np.clip(ymin, 0, frame.numberOfLines-1))
+    ymin = int( np.clip(ymin, 0, frame.numberOfLines-1))
 
 
     ####sensing stop 
     ymax = np.ceil( (limits[1] - frame.sensingStart).total_seconds() * frame.PRF) + 1
     print('Line stop: ', ymax)
-    ymax = np.int( np.clip(ymax, 1, frame.numberOfLines)) 
+    ymax = int( np.clip(ymax, 1, frame.numberOfLines)) 
 
     print('Line limits: ', ymin, ymax)
     print('Original Line Limits: ', 0, frame.numberOfLines)
 
-    if (ymax-ymin) <= 1:
+    if (ymax-ymin) < 0:
         raise Exception('Azimuth limits appear to not overlap with the scene')
 
 
@@ -185,18 +185,18 @@ def cropFrame(frame, limits, outdir, israw=False):
     ####starting range
     xmin = np.floor( (limits[2] - frame.startingRange)/frame.instrument.rangePixelSize)
     print('Pixel start: ', xmin)
-    xmin = np.int(np.clip(xmin, 0, (frame.image.width//factor)-1))
+    xmin = int(np.clip(xmin, 0, (frame.image.filename//factor)-1))
 
     ####far range
     xmax = np.ceil( (limits[3] - frame.startingRange)/frame.instrument.rangePixelSize)+1
     print('Pixel stop: ', xmax)
 
-    xmax = np.int(np.clip(xmax, 1, frame.image.width//factor))
+    xmax = int(np.clip(xmax, 1, frame.image.filename//factor))
 
     print('Pixel limits: ', xmin, xmax)
-    print('Original Pixel Limits: ', 0, frame.image.width//factor)
+    print('Original Pixel Limits: ', 0, frame.image.filename//factor)
 
-    if (xmax - xmin) <= 1:
+    if (xmax - xmin) < 0:
         raise Exception('Range limits appear to not overlap with the scene')
 
     outframe.startingRange = frame.startingRange + xmin * frame.instrument.rangePixelSize

--- a/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
+++ b/contrib/stack/stripmapStack/prepareUAVSAR_coregStack.py
@@ -55,6 +55,12 @@ def write_xml(shelveFile, slcFile):
     slc.renderHdr()
     slc.renderVRT()
 
+    # set filename in shelvefile
+    frame.image.filename = os.path.join(os.path.dirname(shelveFile), slcFile)
+    frame.image.width = width
+    with shelve.open(shelveFile) as db:
+        db['frame'] = frame
+
 
 def get_Date(file):
     yyyymmdd='20'+file.split('_')[4]


### PR DESCRIPTION
Hello team, I am working to process UAVSAR data with `stackStripmapApp.py` and ran into a few issues when attempting to crop my scenes. Below I detail the simple changes I have made to address them:

1. `frame.image.filename` and `frame.image.width` were empty in ‘cropFrames.py’, which led to crashes. Thus ‘prepareUAVSAR_coregStack.py’ was updated to populate these fields in the shelve file.

2. In `cropFrames.py`, `numpy.int` is depreciated so I replaced all `np.int` calls with `int`

3. Finally in `cropFrames.py`, I adjusted the min/max check for each dimension so only <0 differences are flagged… Important because with long inclined swaths like UAVSAR, the user may want to only crop in one dimension, and the check fails if the other isn’t cropped.


Please let me know if any further clarification/information is needed.