### PR TITLE
Fix ABC alias for Python 3.10

### DIFF
--- a/components/iscesys/Component/TraitSeq.py
+++ b/components/iscesys/Component/TraitSeq.py
@@ -30,7 +30,7 @@
 
 
 
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from iscesys.Component.Component import Component
 import numpy as N
 import re


### PR DESCRIPTION
Aliases in collections.* to collections.abc.* have been removed starting
with python 3.10, so we must use the fully qualified import here.

I think this is needed since https://github.com/python/cpython/pull/23754