### PR TITLE
UAVSAR_Stack: bugfix for line/sample num and dopplerFile path

### DIFF
--- a/components/isceobj/Sensor/UAVSAR_Stack.py
+++ b/components/isceobj/Sensor/UAVSAR_Stack.py
@@ -146,14 +146,11 @@ class UAVSAR_Stack(Component):
         frame.setSensingStart(tStart)
         frame.setSensingStop(tStop)
         frame.setSensingMid(tMid)
-        frame.setNumberOfLines(
-            int(self.metadata['slc_1_1x1_mag.set_rows']))
-        frame.setNumberOfSamples(
-            int(self.metadata['slc_1_1x1_mag.set_cols']))
+        frame.setNumberOfLines(int(self.metadata['slc_{}_1x1_mag.set_rows'.format(self.segment_index)]))
+        frame.setNumberOfSamples(int(self.metadata['slc_{}_1x1_mag.set_cols'.format(self.segment_index)]))
         frame.setPolarization(self.metadata['Polarization'])
-        frame.C0 = self.metadata['slc_1_1x1_mag.col_addr']
-        frame.S0 = self.metadata[
-            'Segment {} Data Starting Azimuth'.format(self.segment_index)]
+        frame.C0 = self.metadata['slc_{}_1x1_mag.col_addr'.format(self.segment_index)]
+        frame.S0 = self.metadata['Segment {} Data Starting Azimuth'.format(self.segment_index)]
         frame.nearLookAngle = self.metadata['Minimum Look Angle']
         frame.farLookAngle = self.metadata['Maximum Look Angle']
         frame.setStartingRange(self.startingRange)
@@ -175,8 +172,7 @@ class UAVSAR_Stack(Component):
         #of values in degrees at each corner (without rdf unit specified)
         llC = []
         for ic in range(1,5):
-            key = 'Segment {0} Data Approximate Corner {1}'.format(
-                      self.segment_index, ic)
+            key = 'Segment {0} Data Approximate Corner {1}'.format(self.segment_index, ic)
             self.logger.info("key = {}".format(key))
             self.logger.info("metadata[key] = {}".format(self.metadata[key], type(self.metadata[key])))
             llC.append(list(map(float, self.metadata[key].split(','))))
@@ -316,9 +312,9 @@ class UAVSAR_Stack(Component):
         drho = instrument.getRangePixelSize()  #full res value, not spacing in the dop file
         prf = instrument.getPulseRepetitionFrequency()
         self.logger.info("extractDoppler: rho0, drho, prf = {}, {}, {}".format(rho0, drho, prf))
-        dopfile = self.metadata['dop']
-        f = open(dopfile,'r')
-        x = f.readlines()  #first line is a header
+        dopfile = self.dopplerFile if hasattr(self, 'dopplerFile') else self.metadata['dop']
+        with open(dopfile,'r') as f:
+            x = f.readlines()  #first line is a header
 
         import numpy
         z = numpy.array(
@@ -337,21 +333,20 @@ class UAVSAR_Stack(Component):
         res2 = fit[1][0]  #sum of squared residuals
         self.logger.info("coeffs = {}".format(coefs))
         self.logger.info("rms residual = {}".format(numpy.sqrt(res2/len(dop))))
-        o = open("dop.txt", 'w')
-        for i, d in zip(rhoi, dop):
-            val = polyval(coefs,i)
-            res = d-val
-            o.write("{0} {1} {2} {3}\n".format(i, d, val, res))
-            dopfile = self.metadata['dop']
+        with open("dop.txt", 'w') as o:
+            for i, d in zip(rhoi, dop):
+                val = polyval(coefs,i)
+                res = d-val
+                o.write("{0} {1} {2} {3}\n".format(i, d, val, res))
 
         self.dopplerVals = {'Near':polyval(coefs, 0)}  #need this temporarily in this module
 
         self.logger.info("UAVSAR_Stack.extractDoppler: self.dopplerVals = {}".format(self.dopplerVals))
         self.logger.info("UAVSAR_Stack.extractDoppler: prf = {}".format(prf))
 
-#The doppler file values are in units rad/m.  divide by 2*pi rad/cycle to convert
-#to cycle/m.  Then multiply by velocity to get Hz and divide by prf for dimensionless
-#doppler coefficients
+        #The doppler file values are in units rad/m.  divide by 2*pi rad/cycle to convert
+        #to cycle/m.  Then multiply by velocity to get Hz and divide by prf for dimensionless
+        #doppler coefficients
         dop_scale = self.velocity/2.0/math.pi
         coefs =  [x*dop_scale for x in coefs]
         #Set the coefs in frame._dopplerVsPixel because that is where DefaultDopp looks for them
@@ -361,14 +356,14 @@ class UAVSAR_Stack(Component):
 
     @property
     def terrainHeight(self):
-#The peg point incorporates the actual terrainHeight
+        #The peg point incorporates the actual terrainHeight
         return 0.0
 
     @property
     def platformHeight(self):
         h = self.metadata['Global Average Altitude']
-#Reduce the platform height by the terrain height because the
-#peg radius of curvature includes the terrain height
+        #Reduce the platform height by the terrain height because the
+        #peg radius of curvature includes the terrain height
         h -= self.metadata['Global Average Terrain Height']
         return h
 

--- a/components/isceobj/Sensor/UAVSAR_Stack.py
+++ b/components/isceobj/Sensor/UAVSAR_Stack.py
@@ -312,7 +312,7 @@ class UAVSAR_Stack(Component):
         drho = instrument.getRangePixelSize()  #full res value, not spacing in the dop file
         prf = instrument.getPulseRepetitionFrequency()
         self.logger.info("extractDoppler: rho0, drho, prf = {}, {}, {}".format(rho0, drho, prf))
-        dopfile = self.dopplerFile if hasattr(self, 'dopplerFile') else self.metadata['dop']
+        dopfile = getattr(self, 'dopplerFile', self.metadata['dop'])
         with open(dopfile,'r') as f:
             x = f.readlines()  #first line is a header
 

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
@@ -47,8 +47,6 @@ def unpack(metaFile, slcDir, dopFile, stackSegment, parse=False):
     with shelve.open(pickName) as db:
         db['frame'] = obj.frame
 
-    return
-
 
 if __name__ == '__main__':
     '''

--- a/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
+++ b/contrib/stack/stripmapStack/unpackFrame_UAVSAR.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 # modified to pass the segment number to UAVSAR_STACK sensor EJF 2020/08/02
 
+import os
+import glob
+import argparse
+import shelve
 import isce
 from isceobj.Sensor import createSensor
-import shelve
-import argparse
-import glob
 from isceobj.Util import Poly1D
 from isceobj.Planet.AstronomicalHandbook import Const
-import os
+
 
 def cmdLineParse():
     '''
@@ -16,35 +17,38 @@ def cmdLineParse():
     '''
 
     parser = argparse.ArgumentParser(description='Unpack UAVSAR SLC data and store metadata in pickle file.')
-    parser.add_argument('-i','--input', dest='h5dir', type=str,
-            required=True, help='Input UAVSAR directory')
+    parser.add_argument('-i','--input', dest='metaFile', type=str,
+            required=True, help='metadata file')
     parser.add_argument('-d','--dop_file', dest='dopFile', type=str,
             default=None, help='Doppler file')
     parser.add_argument('-s','--segment', dest='stackSegment', type=int,
             default=1, help='stack segment')
-    parser.add_argument('-o', '--output', dest='slcdir', type=str,
+    parser.add_argument('-o', '--output', dest='slcDir', type=str,
             required=True, help='Output SLC directory')
     return parser.parse_args()
 
 
-def unpack(hdf5, slcname, dopFile, stackSegment, parse=False):
+def unpack(metaFile, slcDir, dopFile, stackSegment, parse=False):
     '''
-    Unpack HDF5 to binary SLC file.
+    Prepare shelve/pickle file for the binary SLC file.
     '''
 
     obj = createSensor('UAVSAR_STACK')
     obj.configure()
-    obj.metadataFile = hdf5
+    obj.metadataFile = metaFile
     obj.dopplerFile = dopFile
     obj.segment_index = stackSegment
     obj.parse()
 
-    if not os.path.isdir(slcname):
-        os.mkdir(slcname)
+    if not os.path.isdir(slcDir):
+        os.mkdir(slcDir)
 
-    pickName = os.path.join(slcname, 'data')
+    pickName = os.path.join(slcDir, 'data')
     with shelve.open(pickName) as db:
         db['frame'] = obj.frame
+
+    return
+
 
 if __name__ == '__main__':
     '''
@@ -52,10 +56,9 @@ if __name__ == '__main__':
     '''
 
     inps = cmdLineParse()
-    if inps.slcdir.endswith('/'):
-        inps.slcdir = inps.slcdir[:-1]
+    inps.slcDir = inps.slcDir.rstrip('/')
+    inps.metaFile = os.path.abspath(inps.metaFile)
+    inps.dopFile = os.path.abspath(inps.dopFile)
+    inps.slcDir = os.path.abspath(inps.slcDir)
 
-    if inps.h5dir.endswith('/'):
-        inps.h5dir = inps.h5dir[:-1]
-
-    unpack(inps.h5dir, inps.slcdir, inps.dopFile, inps.stackSegment)
+    unpack(inps.metaFile, inps.slcDir, inps.dopFile, inps.stackSegment)


### PR DESCRIPTION
This PR fixes the following two bugs in UAVSAR_Stack.py:

+ `UAVSAR_Stack`: use segment index while setting the number of lines / samples
+ `UAVSAR_Stack`: use self.dopplerFile if it exists, otherwise use the path from *.ann file, to support unpackFrame_UAVSAR.py when dop file is not in the current directory
+ `unpackFrame_UAVSAR`: rename variables and comments to improve code readability