### PR TITLE
Print that restituted or precise orbits already exists

### DIFF
--- a/contrib/stack/topsStack/Stack.py
+++ b/contrib/stack/topsStack/Stack.py
@@ -1033,7 +1033,7 @@ class sentinelSLC(object):
               orbit_start_date_time = datetime.datetime.strptime(fields[6].replace('V',''), datefmt)
               orbit_stop_date_time = datetime.datetime.strptime(fields[7].replace('.EOF',''), datefmt)
               if self.start_date_time >= orbit_start_date_time and self.stop_date_time < orbit_stop_date_time:
-                  print ("restituted orbit already exists.")
+                  print ("restituted or precise orbit already exists.")
                   self.orbit =  orbitFile
                   self.orbitType = 'restituted'
 


### PR DESCRIPTION
- Edited Stack.py to reflect that either restituted or precise orbit exists. Prior to this PR, Stack.py only prints out restituted orbit exists even though the precise orbits is the one that exists.