### PR TITLE
fixImageXml: support multiple files w/ wildcards

### DIFF
--- a/applications/fixImageXml.py
+++ b/applications/fixImageXml.py
@@ -3,6 +3,7 @@
 
 import os
 import argparse
+import glob
 import isce
 import isceobj
 from isceobj.Util.ImageUtil import ImageLib as IML
@@ -14,7 +15,7 @@ def cmdLineParse():
     '''
 
     parser = argparse.ArgumentParser(description='Fixes pathnames in ISCE image XML files. Can be used to do more things in the future.')
-    parser.add_argument('-i', '--input', type=str, required=True, dest='infile',
+    parser.add_argument('-i', '--input', type=str, nargs='+', required=True, dest='infile',
             help = 'Input image for which the XML file needs to be fixed.')
 
     fname = parser.add_mutually_exclusive_group(required=True)
@@ -33,20 +34,19 @@ if __name__ == '__main__':
     '''
     inps = cmdLineParse()
 
-    if inps.infile.endswith('.xml'):
-        inps.infile = os.path.splitext(inps.infile)[0]
+    for fname in inps.infile:
+        if fname.endswith('.xml'):
+            fname = os.path.splitext(fname)[0]
+        print('fixing xml file path for file: {}'.format(fname))
 
-    dirname  = os.path.dirname(inps.infile)
+        if inps.full:
+            fdir = os.path.dirname(fname)
+            fname = os.path.abspath(os.path.join(fdir, os.path.basename(fname)))
+        else:
+            fname = os.path.basename(os.path.basename(fname))
 
-    img = IML.loadImage(inps.infile)[0]
-
-    if inps.full:
-        fname = os.path.abspath( os.path.join(dirname, os.path.basename(inps.infile)))
-    else:
-        fname = os.path.basename( os.path.basename(inps.infile))
-
-    img.filename = fname
-    img.setAccessMode('READ')
-    img.renderHdr()
-
+        img = IML.loadImage(fname)[0]
+        img.filename = fname
+        img.setAccessMode('READ')
+        img.renderHdr()
 

--- a/contrib/PyCuAmpcor/examples/cuDenseOffsets.py
+++ b/contrib/PyCuAmpcor/examples/cuDenseOffsets.py
@@ -42,7 +42,9 @@ def createParser():
     parser.add_argument('-s', '--secondary',type=str, dest='secondary', required=True,
                         help='Secondary image')
     parser.add_argument('--fix-xml','--fix-image-xml', dest='fixImageXml', action='store_true',
-                        help='Fix the image file path in the XML file. Enable this if input files havee been moved.')
+                        help='Fix the image file path in the XML file. Enable this if input files have been moved.')
+    parser.add_argument('--fix-vrt','--fix-image-vrt', dest='fixImageVrt', action='store_true',
+                        help='Fix the image file path in the VRT file. Enable this if input files have VRT pointing to non-existing burst files')
 
     parser.add_argument('--op','--outprefix','--output-prefix', type=str, dest='outprefix',
                         default='offset', required=True,
@@ -165,6 +167,12 @@ def estimateOffsetField(reference, secondary, inps=None):
             img.filename = fname
             img.setAccessMode('READ')
             img.renderHdr()
+
+    if inps.fixImageVrt:
+        for fname in [reference, secondary]:
+            fname = os.path.abspath(fname)
+            img = IML.loadImage(fname)[0]
+            img.renderVRT()
 
     ###Loading the secondary image object
     sim = isceobj.createSlcImage()

--- a/contrib/stack/stripmapStack/unwrap.py
+++ b/contrib/stack/stripmapStack/unwrap.py
@@ -29,18 +29,18 @@
 
 
 
+import os
+import sys
+import time
+import argparse
+import shelve
 
 import isce
-import sys
 import isceobj
-from contrib.Snaphu.Snaphu import Snaphu
 from isceobj.Constants import SPEED_OF_LIGHT
-import argparse
-import os
-import pickle
-import sys
-import shelve
+from contrib.Snaphu.Snaphu import Snaphu
 #from contrib.UnwrapComp.unwrapComponents import UnwrapComponents
+
 
 def createParser():
     '''
@@ -88,9 +88,6 @@ def extractInfoFromPickle(pckfile, inps):
     '''
     from isceobj.Planet.Planet import Planet
     from isceobj.Util.geo.ellipsoid import Ellipsoid
-
-   # with open(pckfile, 'rb') as f:
-   #    frame = pickle.load(f)
 
     with shelve.open(pckfile,flag='r') as db:
        # frame = db['swath']
@@ -292,6 +289,7 @@ def main(iargs=None):
     '''
     The main driver.
     '''
+    start_time = time.time()
 
     inps = cmdLineParse(iargs)
     print(inps.method)
@@ -337,6 +335,10 @@ def main(iargs=None):
 
     elif inps.method == 'icu':
         runUnwrapIcu(inps.intfile, inps.unwprefix + '_icu.unw')
+
+    # time usage
+    m, s = divmod(time.time() - start_time, 60)
+    print('time used: {:02.0f} mins {:02.1f} secs.'.format(m, s))
 
 
 if __name__ == '__main__':

--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -223,6 +223,7 @@ def get_dates(inps):
 
     if inps.bbox is not None:
         bbox = [float(val) for val in inps.bbox.split()]
+        bbox_poly = np.array([[bbox[2],bbox[0]],[bbox[3],bbox[0]],[bbox[3],bbox[1]],[bbox[2],bbox[1]]])
 
     if inps.exclude_dates is not None:
         excludeList = inps.exclude_dates.split(',')
@@ -271,7 +272,6 @@ def get_dates(inps):
     f = open('SAFE_files.txt','w')
     safe_count=0
     safe_dict={}
-    bbox_poly = np.array([[bbox[2],bbox[0]],[bbox[3],bbox[0]],[bbox[3],bbox[1]],[bbox[2],bbox[1]]])
 
     for safe in SAFE_files:
         safeObj=sentinelSLC(safe)

--- a/contrib/stack/topsStack/unwrap.py
+++ b/contrib/stack/topsStack/unwrap.py
@@ -30,19 +30,20 @@
 
 
 # giangi: taken Piyush code for snaphu and adapted
-import isce
-import sys
-import isceobj
-from contrib.Snaphu.Snaphu import Snaphu
-from isceobj.Constants import SPEED_OF_LIGHT
-import argparse
 import os
-import pickle
-from osgeo import gdal
+import sys
+import time
+import argparse
 import numpy as np
-#import shelve
-import s1a_isce_utils as ut
+from osgeo import gdal
+
+import isce
+import isceobj
+from isceobj.Constants import SPEED_OF_LIGHT
 from isceobj.Util.ImageUtil import ImageLib as IML
+from contrib.Snaphu.Snaphu import Snaphu
+import s1a_isce_utils as ut
+
 
 def createParser():
     '''
@@ -93,12 +94,6 @@ def extractInfo(xmlName, inps):
     '''
     from isceobj.Planet.Planet import Planet
     from isceobj.Util.geo.ellipsoid import Ellipsoid
-
-   # with open(pckfile, 'rb') as f:
-   #    frame = pickle.load(f)
-
-    #with shelve.open(pckfile,flag='r') as db:
-    #    frame = db['swath']
 
     frame = ut.loadProduct(xmlName)
 
@@ -319,23 +314,23 @@ def main(iargs=None):
     '''
     The main driver.
     '''
-
+    start_time = time.time()
     inps = cmdLineParse(iargs)
     print ('unwrapping method : ' , inps.method)
-    
+
     if inps.method == 'snaphu':
-       if inps.nomcf: 
-           fncall =  runUnwrap
-       else:
-           fncall = runUnwrapMcf
-       swathList = ut.getSwathList(inps.reference) 
-       #metadata = extractInfo(inps.reference+'.xml', inps)
-       xmlFile = os.path.join(inps.reference , 'IW{0}.xml'.format(swathList[0]))
-       metadata = extractInfo(xmlFile, inps)
-       fncall(inps.intfile, inps.unwfile, inps.cohfile, metadata, defomax=inps.defomax)
+        if inps.nomcf: 
+            fncall =  runUnwrap
+        else:
+            fncall = runUnwrapMcf
+        swathList = ut.getSwathList(inps.reference) 
+        #metadata = extractInfo(inps.reference+'.xml', inps)
+        xmlFile = os.path.join(inps.reference , 'IW{0}.xml'.format(swathList[0]))
+        metadata = extractInfo(xmlFile, inps)
+        fncall(inps.intfile, inps.unwfile, inps.cohfile, metadata, defomax=inps.defomax)
 
     elif inps.method == 'icu':
-       runUnwrapIcu(inps.intfile, inps.unwfile)
+        runUnwrapIcu(inps.intfile, inps.unwfile)
 
     if inps.rmfilter:
         filtfile = os.path.abspath(inps.intfile)
@@ -343,6 +338,10 @@ def main(iargs=None):
         intfile = intfile[0] + intfile[1]
 
         remove_filter(intfile, filtfile, inps.unwfile)
+
+    # time usage
+    m, s = divmod(time.time() - start_time, 60)
+    print('time used: {:02.0f} mins {:02.1f} secs.'.format(m, s))
 
 
 if __name__ == '__main__':

--- a/examples/input_files/topsApp.xml
+++ b/examples/input_files/topsApp.xml
@@ -156,8 +156,8 @@ By default, ESD is always performed.
 <!-- <<PHASE UNWRAPPING>>
              Phase unwrapping can be optionally turned off.
              Following unwrappers are currently available:
-             grass, icu, snaphu, snaphu_mcf-->
-<!--<property name="unwrap">True</property>-->
+             grass, icu, snaphu, snaphu_mcf, downsample_snaphu-->
+<!--<property name="do unwrap">True</property>-->
 <!--<property name="unwrapper name">snaphu_mcf</property>-->
 <!-- 2 Stage unwrapping option requires the following tags:-->
 <!--<property name="do unwrap">True</property> -->


### PR DESCRIPTION
This PR adds the support of multiple input files to `fixImageXml.py`, for easier usage.

I also attached a few other very minor changes, typo fixes to the following scripts:

+ `examples/input_files/topsApp.xml`: add `downsample_snaphu`
+ `topsStack/stackSentinel.py`: bugfix if `--bbox` is not specified in the command line
+ `{tops|stripmap}Stack/unwrap.py`: print out a message for the time used using `time.time()` for user's reference.
+ `cuDenseOffsets.py`: add `--fix-image-vrt` option, similar to the existing `--fix-image-xml` option
