### PR TITLE
GPU geo2rdr and topo memory allocation fix

### DIFF
--- a/components/zerodop/GPUtopozero/cuda/gpuTopo.cu
+++ b/components/zerodop/GPUtopozero/cuda/gpuTopo.cu
@@ -73,7 +73,7 @@ __device__ int interpolateOrbit(struct Orbit *orb, double t, double *xyz, double
     double h[4], hdot[4], f0[4], f1[4], g0[4], g1[4];
     double sum = 0.0;
     int v0 = -1;
-   
+
     if ((t < orb->svs[0].t) || (t > orb->svs[orb->nVec-1].t)) return 1;
     for (int i=0; i<orb->nVec; i++) {
         if ((orb->svs[i].t >= t) && (v0 == -1)) {
@@ -95,44 +95,44 @@ __device__ int interpolateOrbit(struct Orbit *orb, double t, double *xyz, double
     sum = (1.0 / (orb->svs[v0+3].t - orb->svs[v0].t)) + (1.0 / (orb->svs[v0+3].t - orb->svs[v0+1].t)) + (1.0 / (orb->svs[v0+3].t - orb->svs[v0+2].t));
     f0[3] = 1.0 - (2.0 * (t - orb->svs[v0+3].t) * sum);
 
-    h[0] = ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) * 
+    h[0] = ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) *
                 ((t - orb->svs[v0+3].t) / (orb->svs[v0].t - orb->svs[v0+3].t));
-    h[1] = ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+1].t - orb->svs[v0+2].t)) * 
+    h[1] = ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+1].t - orb->svs[v0+2].t)) *
                 ((t - orb->svs[v0+3].t) / (orb->svs[v0+1].t - orb->svs[v0+3].t));
     h[2] = ((t - orb->svs[v0].t) / (orb->svs[v0+2].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+2].t - orb->svs[v0+1].t)) *
                 ((t - orb->svs[v0+3].t) / (orb->svs[v0+2].t - orb->svs[v0+3].t));
-    h[3] = ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) * 
+    h[3] = ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) *
                 ((t - orb->svs[v0+2].t) / (orb->svs[v0+3].t - orb->svs[v0+2].t));
 
-    sum = ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0].t - orb->svs[v0+3].t)) * 
+    sum = ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0].t - orb->svs[v0+1].t));
-    sum += ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0].t - orb->svs[v0+3].t)) * 
+    sum += ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0].t - orb->svs[v0+2].t));
-    sum += ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) * 
+    sum += ((t - orb->svs[v0+1].t) / (orb->svs[v0].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0].t - orb->svs[v0+2].t)) *
             (1.0 / (orb->svs[v0].t - orb->svs[v0+3].t));
     hdot[0] = sum;
 
     sum = ((t - orb->svs[v0+2].t) / (orb->svs[v0+1].t - orb->svs[v0+2].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+1].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0+1].t - orb->svs[v0].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+1].t - orb->svs[v0+3].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+1].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0+1].t - orb->svs[v0+2].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+1].t - orb->svs[v0+2].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+1].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+1].t - orb->svs[v0+2].t)) *
             (1.0 / (orb->svs[v0+1].t - orb->svs[v0+3].t));
     hdot[1] = sum;
 
-    sum = ((t - orb->svs[v0+1].t) / (orb->svs[v0+2].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+2].t - orb->svs[v0+3].t)) * 
+    sum = ((t - orb->svs[v0+1].t) / (orb->svs[v0+2].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+2].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0+2].t - orb->svs[v0].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+2].t - orb->svs[v0].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+2].t - orb->svs[v0+3].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+2].t - orb->svs[v0].t)) * ((t - orb->svs[v0+3].t) / (orb->svs[v0+2].t - orb->svs[v0+3].t)) *
             (1.0 / (orb->svs[v0+2].t - orb->svs[v0+1].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+2].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+2].t - orb->svs[v0+1].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+2].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+2].t - orb->svs[v0+1].t)) *
             (1.0 / (orb->svs[v0+2].t - orb->svs[v0+3].t));
     hdot[2] = sum;
 
-    sum = ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+3].t - orb->svs[v0+2].t)) * 
+    sum = ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+3].t - orb->svs[v0+2].t)) *
             (1.0 / (orb->svs[v0+3].t - orb->svs[v0].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+3].t - orb->svs[v0+2].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+2].t) / (orb->svs[v0+3].t - orb->svs[v0+2].t)) *
             (1.0 / (orb->svs[v0+3].t - orb->svs[v0+1].t));
-    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) * 
+    sum += ((t - orb->svs[v0].t) / (orb->svs[v0+3].t - orb->svs[v0].t)) * ((t - orb->svs[v0+1].t) / (orb->svs[v0+3].t - orb->svs[v0+1].t)) *
             (1.0 / (orb->svs[v0+3].t - orb->svs[v0+2].t));
     hdot[3] = sum;
 
@@ -152,12 +152,12 @@ __device__ int interpolateOrbit(struct Orbit *orb, double t, double *xyz, double
 
     xyz[0] = (((orb->svs[v0].px * f0[0]) + (orb->svs[v0].vx * f1[0])) * h[0] * h[0]) + (((orb->svs[v0+1].px * f0[1]) + (orb->svs[v0+1].vx * f1[1])) * h[1] * h[1]) +
                 (((orb->svs[v0+2].px * f0[2]) + (orb->svs[v0+2].vx * f1[2])) * h[2] * h[2]) + (((orb->svs[v0+3].px * f0[3]) + (orb->svs[v0+3].vx * f1[3])) * h[3] * h[3]);
-    xyz[1] = (((orb->svs[v0].py * f0[0]) + (orb->svs[v0].vy * f1[0])) * h[0] * h[0]) + (((orb->svs[v0+1].py * f0[1]) + (orb->svs[v0+1].vy * f1[1])) * h[1] * h[1]) + 
+    xyz[1] = (((orb->svs[v0].py * f0[0]) + (orb->svs[v0].vy * f1[0])) * h[0] * h[0]) + (((orb->svs[v0+1].py * f0[1]) + (orb->svs[v0+1].vy * f1[1])) * h[1] * h[1]) +
                 (((orb->svs[v0+2].py * f0[2]) + (orb->svs[v0+2].vy * f1[2])) * h[2] * h[2]) + (((orb->svs[v0+3].py * f0[3]) + (orb->svs[v0+3].vy * f1[3])) * h[3] * h[3]);
     xyz[2] = (((orb->svs[v0].pz * f0[0]) + (orb->svs[v0].vz * f1[0])) * h[0] * h[0]) + (((orb->svs[v0+1].pz * f0[1]) + (orb->svs[v0+1].vz * f1[1])) * h[1] * h[1]) +
                 (((orb->svs[v0+2].pz * f0[2]) + (orb->svs[v0+2].vz * f1[2])) * h[2] * h[2]) + (((orb->svs[v0+3].pz * f0[3]) + (orb->svs[v0+3].vz * f1[3])) * h[3] * h[3]);
 
-    vel[0] = (((orb->svs[v0].px * g0[0]) + (orb->svs[v0].vx * g1[0])) * h[0]) + (((orb->svs[v0+1].px * g0[1]) + (orb->svs[v0+1].vx * g1[1])) * h[1]) + 
+    vel[0] = (((orb->svs[v0].px * g0[0]) + (orb->svs[v0].vx * g1[0])) * h[0]) + (((orb->svs[v0+1].px * g0[1]) + (orb->svs[v0+1].vx * g1[1])) * h[1]) +
                 (((orb->svs[v0+2].px * g0[2]) + (orb->svs[v0+2].vx * g1[2])) * h[2]) + (((orb->svs[v0+3].px * g0[3]) + (orb->svs[v0+3].vx * g1[3])) * h[3]);
     vel[1] = (((orb->svs[v0].py * g0[0]) + (orb->svs[v0].vy * g1[0])) * h[0]) + (((orb->svs[v0+1].py * g0[1]) + (orb->svs[v0+1].vy * g1[1])) * h[1]) +
                 (((orb->svs[v0+2].py * g0[2]) + (orb->svs[v0+2].vy * g1[2])) * h[2]) + (((orb->svs[v0+3].py * g0[3]) + (orb->svs[v0+3].vy * g1[3])) * h[3]);
@@ -212,7 +212,7 @@ __device__ double interpolateDEM(float *DEM, double lon, double lat, int width, 
 
     i0 = int(lon) - 2;
     j0 = int(lat) - 2;
-    
+
     indi = min((i0+1), width); // bound by out_of_bounds, so this isn't a concern
     spline(indi, j0, length, A, DEM);
     initSpline(A,R,Q);
@@ -328,7 +328,7 @@ __device__ void radar2xyz(struct Peg *peg, struct Ellipsoid *elp, struct PegTran
     ptm->mat[2][0] = sin(peg->lat);
     ptm->mat[2][1] = cos(peg->lat) * cos(peg->hdg);
     ptm->mat[2][2] = cos(peg->lat) * sin(peg->hdg);
-    
+
     re = elp->a / sqrt(1.0 - (elp->e2 * pow(sin(peg->lat),2)));
     rn = (elp->a * (1.0 - elp->e2)) / pow((1.0 - (elp->e2 * pow(sin(peg->lat),2))),1.5);
     ptm->radcur = (re * rn) / ((re * pow(cos(peg->hdg),2)) + (rn * pow(sin(peg->hdg),2)));
@@ -337,7 +337,7 @@ __device__ void radar2xyz(struct Peg *peg, struct Ellipsoid *elp, struct PegTran
     llh[1] = peg->lon;
     llh[2] = 0.0;
     llh2xyz(temp,llh,elp);
-   
+
     ptm->ov[0] = temp[0] - (ptm->radcur * cos(peg->lat) * cos(peg->lon));
     ptm->ov[1] = temp[1] - (ptm->radcur * cos(peg->lat) * sin(peg->lon));
     ptm->ov[2] = temp[2] - (ptm->radcur * sin(peg->lat));
@@ -370,7 +370,7 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
     long pixel = (blockDim.x * blockIdx.x) + threadIdx.x;
 
     if (pixel < NPIXELS) { // Make sure we're not operating on a non-existent pixel
-        
+
         double enumat[3][3];
         double xyzsat[3], velsat[3], llhsat[3], vhat[3], that[3], chat[3], nhat[3];
         double llh[3], llh_prev[3], xyz[3], xyz_prev[3], sch[3], enu[3], delta[3];
@@ -381,11 +381,11 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
         double thrd_z, thrd_zsch, thrd_lat, thrd_lon, thrd_distance, thrd_losang0, thrd_losang1;
         double thrd_incang0, thrd_incang1;
         int thrd_converge;
-    
+
         struct Ellipsoid elp;
         struct Peg peg;
         struct PegTrans ptm;
-    
+
         /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
         *   double t0 = inpts_dbl[0];
         *   double prf = inpts_dbl[1];
@@ -412,7 +412,7 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
         *   int extraiter = inpts_int[5];
         *   int length = inpts_int[6];      NOT USED IN THIS KERNEL
         * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-    
+
         line = (pixel + OFFSET) / d_inpts_int[1];
         tline = d_inpts_dbl[0] + (d_inpts_int[0] * (line / d_inpts_dbl[1]));
         if (interpolateOrbit(&orbit,tline,xyzsat,velsat) != 0) {
@@ -427,28 +427,28 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
         peg.lat = llhsat[0];
         peg.lon = llhsat[1];
         radar2xyz(&peg,&elp,&ptm);
-   
+
         thrd_converge = 0;
         thrd_z = 0.0;
         thrd_zsch = 0.0;
         thrd_lat = d_inpts_dbl[7] + (0.5 * d_inpts_dbl[9] * d_inpts_int[2]);
         thrd_lon = d_inpts_dbl[8] + (0.5 * d_inpts_dbl[10] * d_inpts_int[3]);
-    
+
         dopfact = (0.5 * d_inpts_dbl[11] * (inImgArrs.dopline[pixel] / vmag)) * inImgArrs.rho[pixel];
-    
+
         // START THE ITERATIONS
         for (iter=0; iter<=(d_inpts_int[4]+d_inpts_int[5]); iter++) {
             if (thrd_converge == 0) { // Designing this way helps prevent thread divergence as much as possible
                 llh_prev[0] = thrd_lat / (180. / M_PI);
                 llh_prev[1] = thrd_lon / (180. / M_PI);
                 llh_prev[2] = thrd_z;
-               
-                costheta = 0.5 * (((height + ptm.radcur) / inImgArrs.rho[pixel]) + (inImgArrs.rho[pixel] / (height + ptm.radcur)) - 
+
+                costheta = 0.5 * (((height + ptm.radcur) / inImgArrs.rho[pixel]) + (inImgArrs.rho[pixel] / (height + ptm.radcur)) -
                                     (((ptm.radcur + thrd_zsch) / (height + ptm.radcur)) * ((ptm.radcur + thrd_zsch) / inImgArrs.rho[pixel])));
                 sintheta = sqrt(1.0 - pow(costheta,2));
                 alpha = (dopfact - (costheta * inImgArrs.rho[pixel] * dot(nhat,vhat))) / dot(vhat,that);
                 beta = -d_inpts_dbl[12] * sqrt((pow(inImgArrs.rho[pixel],2) * pow(sintheta,2)) - pow(alpha,2));
-   
+
                 delta[0] = (costheta * inImgArrs.rho[pixel] * nhat[0]) + (alpha * that[0]) + (beta * chat[0]);
                 delta[1] = (costheta * inImgArrs.rho[pixel] * nhat[1]) + (alpha * that[1]) + (beta * chat[1]);
                 delta[2] = (costheta * inImgArrs.rho[pixel] * nhat[2]) + (alpha * that[2]) + (beta * chat[2]);
@@ -457,7 +457,7 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
                 xyz[1] = xyzsat[1] + delta[1];
                 xyz[2] = xyzsat[2] + delta[2];
                 xyz2llh(xyz,llh,&elp);
-   
+
                 thrd_lat = llh[0] * (180. / M_PI);
                 thrd_lon = llh[1] * (180. / M_PI);
                 demlat = ((thrd_lat - d_inpts_dbl[7]) / d_inpts_dbl[9]) + 1;
@@ -468,7 +468,7 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
                 demlon = fmin(demlon,(d_inpts_int[3]-1.));
                 thrd_z = interpolateDEM(inImgArrs.DEM,demlon,demlat,d_inpts_int[3],d_inpts_int[2]);
                 thrd_z = fmax(thrd_z,-500.);
-   
+
                 llh[0] = thrd_lat / (180. / M_PI);
                 llh[1] = thrd_lon / (180. / M_PI);
                 llh[2] = thrd_z;
@@ -494,23 +494,23 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
                 }
             }
         }
-   
+
         // Final computation
         costheta = 0.5 * (((height + ptm.radcur) / inImgArrs.rho[pixel]) + (inImgArrs.rho[pixel] / (height + ptm.radcur)) -
                             (((ptm.radcur + thrd_zsch) / (height + ptm.radcur)) * ((ptm.radcur + thrd_zsch) / inImgArrs.rho[pixel])));
         sintheta = sqrt(1.0 - pow(costheta,2));
         alpha = (dopfact - (costheta * inImgArrs.rho[pixel] * dot(nhat,vhat))) / dot(vhat,that);
         beta = -d_inpts_dbl[12] * sqrt((pow(inImgArrs.rho[pixel],2) * pow(sintheta,2)) - pow(alpha,2));
-        
+
         delta[0] = (costheta * inImgArrs.rho[pixel] * nhat[0]) + (alpha * that[0]) + (beta * chat[0]);
         delta[1] = (costheta * inImgArrs.rho[pixel] * nhat[1]) + (alpha * that[1]) + (beta * chat[1]);
         delta[2] = (costheta * inImgArrs.rho[pixel] * nhat[2]) + (alpha * that[2]) + (beta * chat[2]);
-        
+
         xyz[0] = xyzsat[0] + delta[0];
         xyz[1] = xyzsat[1] + delta[1];
         xyz[2] = xyzsat[2] + delta[2];
         xyz2llh(xyz,llh,&elp);
-    
+
         thrd_lat = llh[0] * (180. / M_PI);
         thrd_lon = llh[1] * (180. / M_PI);
         thrd_z = llh[2];
@@ -526,42 +526,42 @@ __global__ void runTopo(struct Orbit orbit, struct OutputImgArrs outImgArrs, str
         enumat[0][2] = 0.0;
         enumat[1][2] = cos(llh[0]);
         enumat[2][2] = sin(llh[0]);
-   
+
         // Expanded from Linalg::matvec
         enu[0] = (enumat[0][0] * delta[0]) + (enumat[0][1] * delta[1]) + (enumat[0][2] * delta[2]);
         enu[1] = (enumat[1][0] * delta[0]) + (enumat[1][1] * delta[1]) + (enumat[1][2] * delta[2]);
         enu[2] = (enumat[2][0] * delta[0]) + (enumat[2][1] * delta[1]) + (enumat[2][2] * delta[2]);
-        
+
         cosalpha = fabs(enu[2]) / norm(3,enu);
         thrd_losang0 = acos(cosalpha) * (180. / M_PI);
         thrd_losang1 = (atan2(-enu[1],-enu[0]) - (0.5*M_PI)) * (180. / M_PI);
         thrd_incang0 = acos(costheta) * (180. / M_PI);
         thrd_zsch = inImgArrs.rho[pixel] * sintheta;
-    
+
         demlat = ((thrd_lat - d_inpts_dbl[7]) / d_inpts_dbl[9]) + 1;
         demlat = fmax(demlat,2.);
         demlat = fmin(demlat,(d_inpts_int[2]-1.));
         demlon = ((thrd_lon - d_inpts_dbl[8]) / d_inpts_dbl[10]) + 1;
         demlon = fmax(demlon,2.);
         demlon = fmin(demlon,(d_inpts_int[3]-1.));
-    
+
         aa = interpolateDEM(inImgArrs.DEM,(demlon-1.),demlat,d_inpts_int[3],d_inpts_int[2]);
         bb = interpolateDEM(inImgArrs.DEM,(demlon+1.),demlat,d_inpts_int[3],d_inpts_int[2]);
         alpha = ((bb - aa) * (180. / M_PI)) / (2.0 * (elp.a / sqrt(1.0 - (elp.e2 * pow(sin(thrd_lat / (180. / M_PI)),2)))) * d_inpts_dbl[10]);
-    
+
         aa = interpolateDEM(inImgArrs.DEM,demlon,(demlat-1.),d_inpts_int[3],d_inpts_int[2]);
         bb = interpolateDEM(inImgArrs.DEM,demlon,(demlat+1.),d_inpts_int[3],d_inpts_int[2]);
         beta = ((bb - aa) * (180. / M_PI)) / (2.0 * ((elp.a * (1.0 - elp.e2)) / pow((1.0 - (elp.e2 * pow(sin(thrd_lat / (180. / M_PI)),2))),1.5)) * d_inpts_dbl[9]);
-    
+
         enunorm = norm(3,enu);
         enu[0] = enu[0] / enunorm;
         enu[1] = enu[1] / enunorm;
         enu[2] = enu[2] / enunorm;
         costheta = ((enu[0] * alpha) + (enu[1] * beta) - enu[2]) / sqrt(1.0 + pow(alpha,2) + pow(beta,2));
         thrd_incang1 = acos(costheta) * (180. / M_PI);
-    
+
         // Leave out masking stuff for now (though it's doable)
-    
+
         // Finally write to reference arrays
         outImgArrs.lat[pixel] = thrd_lat;
         outImgArrs.lon[pixel] = thrd_lon;
@@ -590,11 +590,10 @@ void freeOrbit(struct Orbit *orb) {
     free(orb->svs);
 }
 
-size_t getDeviceMem() {
+size_t getDeviceFreeMem() {
     size_t freeByte, totalByte;
     cudaMemGetInfo(&freeByte, &totalByte);
-    totalByte = (totalByte / 1e9) * 1e9; // Round down to nearest GB
-    return totalByte;
+    return freeByte;
 }
 
 // --------------- C FUNCTIONS ----------------
@@ -616,10 +615,10 @@ void runGPUTopo(long nBlock, long numPix, double *h_inpts_dbl, int *h_inpts_int,
     cudaSetDevice(0);
 
     printf("    Allocating host and general GPU memory...\n");
-    
+
     size_t nb_pixels = numPix * sizeof(double);    // size of rho/dopline/lat/lon/z/zsch/incang/losang
     size_t nb_DEM = h_inpts_int[3] * h_inpts_int[2] * sizeof(float);    // size of DEM
-    
+
     /*
     h_lat = (double *)malloc(nb_pixels);
     h_lon = (double *)malloc(nb_pixels);
@@ -655,21 +654,21 @@ void runGPUTopo(long nBlock, long numPix, double *h_inpts_dbl, int *h_inpts_int,
     cudaMemcpyToSymbol(d_inpts_dbl, h_inpts_dbl, (14*sizeof(double)));
     cudaMemcpyToSymbol(d_inpts_int, h_inpts_int, (7*sizeof(int)));
     freeOrbit(&orbit);
-    
+
     orbit.svs = d_svs;
     inImgArrs.DEM = d_DEM;
     inImgArrs.rho = d_rho;
     inImgArrs.dopline = d_dopline;
 
     printf("    Allocating block memory (%d pixels per image)...\n", numPix);
-    
+
     cudaMalloc((double**)&d_lat, nb_pixels);
     cudaMalloc((double**)&d_lon, nb_pixels);
     cudaMalloc((double**)&d_z, nb_pixels);
     //cudaMalloc((double**)&d_zsch, nb_pixels);
     cudaMalloc((double**)&d_incang, (2*nb_pixels));
     cudaMalloc((double**)&d_losang, (2*nb_pixels));
-    
+
     outImgArrs.lat = d_lat;
     outImgArrs.lon = d_lon;
     outImgArrs.z = d_z;
@@ -702,7 +701,7 @@ void runGPUTopo(long nBlock, long numPix, double *h_inpts_dbl, int *h_inpts_int,
     iEndRun = cpuSecond();
     if (nBlock > -1) printf("    GPU finished block %d in %f s.\n", nBlock, (iEndRun-iStartRun));
     else printf("    GPU finished remaining lines in %f s.\n", (iEndRun-iStartRun));
-    
+
     printf("    Copying memory back to host...\n");
 
     cudaMemcpy(accArr[0], outImgArrs.lat, nb_pixels, cudaMemcpyDeviceToHost); // Copy memory from device to host with offset

--- a/components/zerodop/GPUtopozero/include/gpuTopo.h
+++ b/components/zerodop/GPUtopozero/include/gpuTopo.h
@@ -6,7 +6,7 @@
 #ifndef GPU_TOPO_H
 #define GPU_TOPO_H
 
-size_t getDeviceMem();
+size_t getDeviceFreeMem();
 void runGPUTopo(long,long,double*,int*,float*,double*,double*,int,double*,double**);
 
 #endif


### PR DESCRIPTION
This PR fixes the memory allocation error for geo2rdr and topo GPU modules, when the GPU has a small memory size (e.g., gaming cards), see Issues #331 and #392. 

N.B.: these GPU modules are designed for GPUs with sufficient double precision support (e.g., K40/P100/V100/A100). However, they still run reasonably faster on gaming cards than CPU modules, even though the speedup is limited.   