### PR TITLE
Fix denseoffsetsRead for modern gfortran

### DIFF
--- a/.cmake/isce2_buildflags.cmake
+++ b/.cmake/isce2_buildflags.cmake
@@ -9,11 +9,6 @@ add_compile_options(
     $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
     $<$<COMPILE_LANGUAGE:Fortran>:-fno-range-check>
     $<$<COMPILE_LANGUAGE:Fortran>:-fno-second-underscore>)
-if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND
-   CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-    add_compile_options(
-        $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
-endif()
 
 # Set up build flags for C++ and Fortran.
 set(CMAKE_CXX_STANDARD 11)

--- a/components/iscesys/ImageApi/DataAccessor/src/DataAccessorF.cpp
+++ b/components/iscesys/ImageApi/DataAccessor/src/DataAccessorF.cpp
@@ -4,7 +4,8 @@
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
+
+extern "C" {
 
 void rewindAccessor_f(uint64_t * ptDataAccessor)
 {
@@ -24,15 +25,47 @@ void setLineSequential_f(uint64_t * ptDataAccessor,  char * dataLine)
 {
     ((DataAccessor * ) (* ptDataAccessor))->setLineSequential(dataLine);
 }
+void setlinesequential_c_(uint64_t* acc, char* data)
+{
+    setLineSequential_f(acc, data);
+}
+void setlinesequential_r4_(uint64_t* acc, char* data)
+{
+    setLineSequential_f(acc, data);
+}
+void setlinesequential_r8_(uint64_t* acc, char* data)
+{
+    setLineSequential_f(acc, data);
+}
 void setLineSequentialBand_f(uint64_t * ptDataAccessor, char * dataLine, int * band)
 {
     (*band) -=1;
     ((DataAccessor * ) (* ptDataAccessor))->setLineSequentialBand(dataLine, (*band));
     (*band) +=1;
 }
+void setlinesequentialband_c_(uint64_t* acc, char* data, int* band)
+{
+    setLineSequentialBand_f(acc, data, band);
+}
+void setlinesequentialband_r4_(uint64_t* acc, char* data, int* band)
+{
+    setLineSequentialBand_f(acc, data, band);
+}
 void getLineSequential_f(uint64_t * ptDataAccessor,  char * dataLine, int * ptFlag) 
 {
     (*ptFlag) =  ((DataAccessor * ) (* ptDataAccessor))->getLineSequential(dataLine);
+}
+void getlinesequential_c_(uint64_t* acc,  char* data, int* flag)
+{
+    getLineSequential_f(acc, data, flag);
+}
+void getlinesequential_r4_(uint64_t* acc,  char* data, int* flag)
+{
+    getLineSequential_f(acc, data, flag);
+}
+void getlinesequential_r8_(uint64_t* acc,  char* data, int* flag)
+{
+    getLineSequential_f(acc, data, flag);
 }
 void getLineSequentialBand_f(uint64_t * ptDataAccessor, char * dataLine, int *band, int *ptFlag)
 {
@@ -41,12 +74,28 @@ void getLineSequentialBand_f(uint64_t * ptDataAccessor, char * dataLine, int *ba
     (*band) +=1;
     (*ptFlag) = flag;
 }
+void getlinesequentialband_c_(uint64_t* acc, char* data, int *band, int* flag)
+{
+    getLineSequentialBand_f(acc, data, band, flag);
+}
+void getlinesequentialband_r4_(uint64_t* acc, char* data, int *band, int* flag)
+{
+    getLineSequentialBand_f(acc, data, band, flag);
+}
 void setLine_f(uint64_t * ptDataAccessor,  char * dataLine, int * ptLine) 
 {
     // fortran is one based
     (*ptLine) -= 1;
     ((DataAccessor * ) (* ptDataAccessor))->setLine(dataLine, (*ptLine));
     (*ptLine) += 1;
+}
+void setline_c_(uint64_t* acc,  char* data, int* line)
+{
+    setLine_f(acc, data, line);
+}
+void setline_r4_(uint64_t* acc,  char* data, int* line)
+{
+    setLine_f(acc, data, line);
 }
 void setLineBand_f(uint64_t * ptDataAccessor, char * dataLine, int * ptLine, int * band)
 {
@@ -55,6 +104,10 @@ void setLineBand_f(uint64_t * ptDataAccessor, char * dataLine, int * ptLine, int
     ((DataAccessor * ) (* ptDataAccessor))->setLineBand(dataLine, (*ptLine), (*band));
     (*ptLine) += 1;
     (*band) +=1;
+}
+void setlineband_r4_(uint64_t* acc, char* data, int* line, int* band)
+{
+    setLineBand_f(acc, data, line, band);
 }
 void getLine_f(uint64_t * ptDataAccessor,  char * dataLine, int * ptLine) 
 {
@@ -70,6 +123,14 @@ void getLine_f(uint64_t * ptDataAccessor,  char * dataLine, int * ptLine)
         (*ptLine) += 1;
     }
 }
+void getline_r4_(uint64_t* acc,  char* data, int* line)
+{
+    getLine_f(acc, data, line);
+}
+void getline_r8_(uint64_t* acc,  char* data, int* line)
+{
+    getLine_f(acc, data, line);
+}
 void getLineBand_f(uint64_t * ptDataAccessor, char * dataLine, int *band, int *ptLine)
 {
     int ptLine1, band1;
@@ -84,6 +145,14 @@ void getLineBand_f(uint64_t * ptDataAccessor, char * dataLine, int *band, int *p
 //    {
 //        (*ptLine) +=1;
 //    }
+}
+void getlineband_c_(uint64_t* acc, char* data, int* band, int* line)
+{
+    getLineBand_f(acc, data, band, line);
+}
+void getlineband_r4_(uint64_t* acc, char* data, int* band, int* line)
+{
+    getLineBand_f(acc, data, band, line);
 }
 
 void setSequentialElements_f(uint64_t * ptDataAccessor,  char * dataLine, int * ptRow, int * ptCol, int * ptNumEl) 
@@ -159,4 +228,6 @@ void setLineOffset_f(uint64_t * ptDataAccessor,int * lineoff)
 int getLineOffset_f(uint64_t * ptDataAccessor)
 {
   return ((DataAccessor * ) (* ptDataAccessor))->getLineOffset();
+}
+
 }

--- a/components/mroipac/ampcor/src/ampcor.F
+++ b/components/mroipac/ampcor/src/ampcor.F
@@ -480,7 +480,7 @@
                if ((i_lineno .lt. 1).or.(i_lineno .gt. i_lines(1))) then
                     c_refimg(:,i_yy) = cmplx(0.,0.)
                else
-                    call getLineBand(imgAccessor1, c_refimg(:,i_yy), i_xx, i_lineno)
+                    call getLineBand_c(imgAccessor1, c_refimg(:,i_yy), i_xx, i_lineno)
                endif
 
                if(i_mag1 .ne. 0) then
@@ -500,7 +500,7 @@
                if ((i_lineno .lt. 1).or.(i_lineno .gt. i_lines(1))) then
                     r_refimg(:,i_yy) = 0.0
                else
-                   call getLineBand(imgAccessor1, r_refimg(:,i_yy), i_xx, i_lineno)
+                   call getLineBand_r4(imgAccessor1, r_refimg(:,i_yy), i_xx, i_lineno)
                endif
 
                do i_xx=1,i_samples(1)
@@ -522,7 +522,7 @@
                if ((i_lineno .lt. 1).or.(i_lineno .gt. i_lines(2))) then
                     c_srchimg(:,i_yy) = cmplx(0.,0.)
                else
-                    call getLineBand(imgAccessor2, c_srchimg(:,i_yy), i_xx, i_lineno)
+                    call getLineBand_c(imgAccessor2, c_srchimg(:,i_yy), i_xx, i_lineno)
                endif
 
                 if(i_mag2 .ne. 0) then
@@ -544,7 +544,7 @@
                if ((i_lineno .lt. 1).or.(i_lineno .gt. i_lines(2))) then
                     r_srchimg(:,i_yy) = 0.0
                else
-                   call getLineBand(imgAccessor2, r_srchimg(:,i_yy), i_xx, i_lineno)
+                   call getLineBand_r4(imgAccessor2, r_srchimg(:,i_yy), i_xx, i_lineno)
                endif
 
                do i_xx=1,i_samples(2)

--- a/components/mroipac/icu/src/icu.F
+++ b/components/mroipac/icu/src/icu.F
@@ -226,7 +226,7 @@
              if(corrAcc.gt.0)then
                 do l=i_sl, i_el
 !c             write(CCUNIT,rec=j+l+1) (r_cc(k,l,1), k=0, infp%i_rsamps-1)
-                    call setLine(corrAcc,r_cc(0,l,1),j+l+1)
+                    call setLine_r4(corrAcc,r_cc(0,l,1),j+l+1)
                 end do 
             end if
          end if
@@ -235,7 +235,7 @@
              if(gccAcc .gt. 0)then
                 do l=i_sl, i_el
 !c             write(GCCUNIT,rec=j+l+1) (r_cc(k,l,2), k=0, infp%i_rsamps-1)
-                    call setLine(gccAcc,r_cc(0,l,2),j+l+1)
+                    call setLine_r4(gccAcc,r_cc(0,l,2),j+l+1)
                 end do 
             end if
          end if
@@ -244,10 +244,10 @@
              if(phsigcorrAcc .gt. 0) then
                 do l=i_sl, i_el
 !c             write(SIGMAUNIT,rec=j+l+1)(r_sigma(k,l), k=0, infp%i_rsamps-1)
-!c            setLine(sigmaAcc,r_sigma(0,l),j+l+1)
+!c            setLine_r4(sigmaAcc,r_sigma(0,l),j+l+1)
 
 !c             write(SIGMACCUNIT,rec=j+l+1)(r_cc(k,l,3), k=0, infp%i_rsamps-1)
-                    call setLine(phsigcorrAcc,r_cc(0,l,3),j+l+1)
+                    call setLine_r4(phsigcorrAcc,r_cc(0,l,3),j+l+1)
                 end do 
             end if
          end if
@@ -287,8 +287,8 @@
            do ia = i_sl, i_el
 !c              write(UNWUNIT,rec=(j+ia)+1)(r_unw(k,ia), k=0, infp
 !c     $             %i_rsamps-1)
-                call setLineBand(unwAcc, r_amp(0,ia),j+ia+1, b1)
-                call setLineBand(unwAcc, r_unw(0,ia),j+ia+1, b2)
+                call setLineBand_r4(unwAcc, r_amp(0,ia),j+ia+1, b1)
+                call setLineBand_r4(unwAcc, r_unw(0,ia),j+ia+1, b2)
            end do           
 
            if (conncompAcc.gt.0) then

--- a/components/stdproc/rectify/geocode/src/geocode.f90
+++ b/components/stdproc/rectify/geocode/src/geocode.f90
@@ -168,7 +168,7 @@ subroutine geocode(demAccessor,topophaseAccessor,demCropAccessor,losAccessor,geo
   !allocate(demi2(demwidth))
   lineNum = 1
   do i = 1,demlength
-      call getLineSequential(demAccessor,dem(:,i),lineNum)
+      call getLineSequential_r4(demAccessor,dem(:,i),lineNum)
       !do j=1,demwidth
       !   dem(j,i) = demi2(j)
       !enddo
@@ -454,7 +454,7 @@ subroutine geocode(demAccessor,topophaseAccessor,demCropAccessor,losAccessor,geo
 
      if(losAccessor.gt.0) then
          do i=1,plen
-            call setLineSequential(losAccessor, losang(:,i))
+            call setLineSequential_r4(losAccessor, losang(:,i))
          enddo
      endif
 

--- a/components/stdproc/rectify/geocode/src/geocodeReadWrite.F
+++ b/components/stdproc/rectify/geocode/src/geocodeReadWrite.F
@@ -57,7 +57,7 @@
                         integer*8 :: acc
                         integer :: irow,band,n,i
 
-                        call getLineSequentialBand(acc,rarr,band,irow)
+                        call getLineSequentialBand_r4(acc,rarr,band,irow)
                         do i=1,n
                             carr(i) = cmplx(rarr(i), 0.)
                         end do
@@ -80,7 +80,7 @@
                             rarr(i) = real(carr(i))
                         enddo
                         
-                        call setLineSequentialBand(acc,rarr,band)
+                        call setLineSequentialBand_r4(acc,rarr,band)
                     end subroutine writeRealLine
 
                 end module geocodeReadWrite

--- a/components/stdproc/stdproc/resamp_slc/src/resamp_slc.f90
+++ b/components/stdproc/stdproc/resamp_slc/src/resamp_slc.f90
@@ -128,7 +128,7 @@
 
         !!!!All carriers are removed from the data up front
         do j = 1,inlength
-            call getLineSequential(slcInAccessor,cline,lineNum)
+            call getLineSequential_c(slcInAccessor,cline,lineNum)
             r_at = j
 
             !$OMP PARALLEL DO private(i,r_rt,r_ph)&
@@ -150,7 +150,7 @@
       else
         lineNum=1
         do j = 1,inlength
-            call getLineSequential(slcInAccessor, rin(:,j), lineNum)
+            call getLineSequential_r4(slcInAccessor, rin(:,j), lineNum)
 
             if (mod(j,1000).eq.0) then
                 print *, 'At line ',j
@@ -172,11 +172,11 @@
             end if
 
             if(residazAccessor .ne. 0) then
-              call getLineSequential(residAzAccessor, residaz, lineNum)
+              call getLineSequential_r8(residAzAccessor, residaz, lineNum)
             endif
 
             if(residRgAccessor .ne. 0) then
-              call getLineSequential(residRgAccessor, residrg, lineNum)
+              call getLineSequential_r8(residRgAccessor, residrg, lineNum)
             endif
 
             cout=cmplx(0.,0.)
@@ -255,7 +255,7 @@
             end do
             !$OMP END PARALLEL DO
 
-            call setLineSequential(slcOutAccessor,cout)
+            call setLineSequential_c(slcOutAccessor,cout)
         enddo
 
      !!!!!Interpolation of real images

--- a/components/zerodop/geozero/src/geozeroReadWrite.F
+++ b/components/zerodop/geozero/src/geozeroReadWrite.F
@@ -57,7 +57,7 @@
                         integer*8 :: acc
                         integer :: irow,band,n,i
 
-                        call getLineSequentialBand(acc,rarr,band,irow)
+                        call getLineSequentialBand_r4(acc,rarr,band,irow)
                         do i=1,n
                             carr(i) = cmplx(rarr(i), 0.)
                         end do
@@ -68,7 +68,7 @@
                         integer*8 :: acc
                         integer :: band,n,i
 
-                        call setLineSequentialBand(acc,carr,band)
+                        call setLineSequentialBand_c(acc,carr,band)
                     end subroutine writeCpxLine
 
                     subroutine writeRealLine(acc,carr,band,n)
@@ -80,7 +80,7 @@
                             rarr(i) = real(carr(i))
                         enddo
                         
-                        call setLineSequentialBand(acc,rarr,band)
+                        call setLineSequentialBand_r4(acc,rarr,band)
                     end subroutine writeRealLine
 
                 end module geozeroReadWrite

--- a/components/zerodop/topozero/src/topozero.f90
+++ b/components/zerodop/topozero/src/topozero.f90
@@ -193,7 +193,7 @@
         !!!For detailed explanation of steps - see main loop below
         line=1
         !!!Doppler for geometry (not carrier) is const / range variant only
-        call getLine(dopAccessor, dopline, line)
+        call getLine_r8(dopAccessor, dopline, line)
         call getLine(slrngAccessor, rho, line)
 
         !!!First line
@@ -337,7 +337,7 @@
         do j=1,udemlength
             lineFile = j + ustarty - 1
 !            print *, 'Line: ', lineFile
-            call getLine(demAccessor,demline,lineFile)
+            call getLine_r4(demAccessor,demline,lineFile)
             dem(:,j) = demline(ustartx:uendx)
         enddo
 
@@ -714,15 +714,15 @@
          min_lon = min(minval(lon), min_lon)
          max_lon = max(maxval(lon), max_lon)
 !!         write(31,rec=line)(distance(j),j=1,width)
-         call setLineSequential(latAccessor, lat)
-         call setLineSequential(lonAccessor, lon)
-         call setLineSequential(heightAccessor, z)
+         call setLineSequential_r8(latAccessor, lat)
+         call setLineSequential_r8(lonAccessor, lon)
+         call setLineSequential_r8(heightAccessor, z)
          if(losAccessor.gt.0) then
-             call setLineSequential(losAccessor,losang)
+             call setLineSequential_r4(losAccessor,losang)
          endif
 
          if (incAccessor.gt.0) then
-             call setLineSequential(incAccessor, incang)
+             call setLineSequential_r4(incAccessor, incang)
          endif
 
 


### PR DESCRIPTION
Allows compilation without need for -fallow-argument-mismatch

My intent here is to declare getLineBand's `arr` argument as `type(*)`, which as far as I can tell is the fortran equivalent of a `void*` and allows passing any data. I'm a fortran newbie so I would appreciate a look from someone more experienced.