### PR TITLE
absolute module import in `stackSentinel/StripMap.py`

### DIFF
--- a/contrib/stack/README.md
+++ b/contrib/stack/README.md
@@ -1,37 +1,76 @@
-## Stack Processors
+## ISCE-2 Stack Processors
 
 Read the document for each stack processor for details.
 
-+ [stripmapStack](./stripmapStack/README.md)
 + [topsStack](./topsStack/README.md)
++ [stripmapStack](./stripmapStack/README.md)
 + [alosStack](./alosStack/alosStack_tutorial.txt)
 
 ### Installation
 
 To use a stack processor you need to:
 
-1. Install ISCE as usual
+#### 1. Install ISCE as usual
 
-2. Depending on which stack processor you need to try, add the path of the folder containing the python scripts to your `$PATH` environment variable as follows:
-   - add the full path of your **contrib/stack/topsStack** to `$PATH` to use the topsStack for processing a stack of Sentinel-1 TOPS data
-   - add the full path of your **contrib/stack/stripmapStack** to `$PATH` to use the stripmapStack for processing a stack of StripMap data
-   - set environment variable `$PATH_ALOSSTACK` by doing: export PATH_ALOSSTACK=CODE_DIR/contrib/stack/alosStack to use the alosStack for processing a stack of ALOS-2 data
+#### 2. Setup paths for stack processors
 
-Note: The stack processors do not show up in the install directory of your isce software. They can be found in the isce source directory. 
+The stack processors do not show up in the install directory of your isce software. They can be found in the isce source directory. Thus, extra path setup is needed.
+
+2.1 Add the following path to your `${PYTHON_PATH}` environment vavriable:
+
+```bash
+export ISCE_STACK={full_path_to_your_contrib/stack}
+export PYTHONPATH=${PYTHONPATH}:${ISCE_STACK}
+```
+
+2.2 Depending on which stack processor you want to use, add the following path to your `${PATH}` environment variable:
+
++ For Sentinel-1 TOPS data
+
+```bash
+export PATH=${PATH}:${ISCE_STACK}/topsStack
+```
+
++ For StripMap data
+
+```bash
+export PATH=${PATH}:${ISCE_STACK}/stripmapStack
+```
+
++ For ALOS-2 data
+
+```bash
+export PATH=${PATH}:${ISCE_STACK}/alosStack
+```
 
 #### Important Note: ####
 
-There might be conflicts between topsStack and stripmapStack scripts (due to comman names of different scripts). Therefore users **MUST only** have the path of **one stack processor in their $PATH environment at a time**, to avoid conflicts between the two stack processors.
+There are naming conflicts between topsStack and stripmapStack scripts. Therefore users **MUST** have the path of **ONLY ONE stack processor in their $PATH at a time**, to avoid the naming conflicts.
 
 ### References
 
 Users who use the stack processors may refer to the following literatures:
 
+For TOPS stack processing:
+
++ H. Fattahi, P. Agram, and M. Simons, “A network-based enhanced spectral diversity approach for TOPS time-series analysis,” IEEE Trans. Geosci. Remote Sens., vol. 55, no. 2, pp. 777–786, Feb. 2017. (https://ieeexplore.ieee.org/abstract/document/7637021/)
+
 For StripMap stack processor and ionospheric phase estimation:
 
 + H. Fattahi, M. Simons, and P. Agram, "InSAR Time-Series Estimation of the Ionospheric Phase Delay: An Extension of the Split Range-Spectrum Technique", IEEE Trans. Geosci. Remote Sens., vol. 55, no. 10, 5984-5996, 2017. (https://ieeexplore.ieee.org/abstract/document/7987747/)
 
-For TOPS stack processing:
+For ALOS and ALOS-2 stack processing:
 
-+ H. Fattahi, P. Agram, and M. Simons, “A network-based enhanced spectral diversity approach for TOPS time-series analysis,” IEEE Trans. Geosci. Remote Sens., vol. 55, no. 2, pp. 777–786, Feb. 2017. (https://ieeexplore.ieee.org/abstract/document/7637021/)
+1. ScanSAR or multi-mode InSAR processing
+
++ C. Liang and E. J. Fielding, "Interferometry with ALOS-2 full-aperture ScanSAR data," IEEE Transactions on Geoscience and Remote Sensing, vol. 55, no. 5, pp. 2739-2750, May 2017.
+
+2. Ionospheric correction, burst-by-burst ScanSAR processing, and burst-mode spectral diversity (SD) or 
+multi-aperture InSAR (MAI) processing
+
++ C. Liang and E. J. Fielding, "Measuring azimuth deformation with L-band ALOS-2 ScanSAR interferometry," IEEE Transactions on Geoscience and Remote Sensing, vol. 55, no. 5, pp. 2725-2738, May 2017.
+
+3. Ionospheric correction
+
++ C. Liang, Z. Liu, E. J. Fielding, and R. Bürgmann, "InSAR time series analysis of L-band wide-swath SAR data acquired by ALOS-2," IEEE Transactions on Geoscience and Remote Sensing, vol. 56, no. 8, pp. 4492-4506, Aug. 2018.
 

--- a/contrib/stack/alosStack/alosStack_tutorial.txt
+++ b/contrib/stack/alosStack/alosStack_tutorial.txt
@@ -10,8 +10,8 @@ This is the tutorial of alosStack processor.
 #        0. SET ENVIRONMENT VARIABLE
 ###########################################
 
-Set environment variable 'PATH_ALOSSTACK'
-export PATH_ALOSSTACK=CODE_DIR/contrib/stack/alosStack
+Set environment variable 'ISCE_STACK'
+export ISCE_STACK=CODE_DIR/contrib/stack
 
 where CODE_DIR is the directory of your isce code. Note that alosStack is not installed when you install
 the software, so CODE_DIR is your code directory rather than installation directory.
@@ -81,10 +81,10 @@ cd saf_d169_proc
 
 2. Input xml file alosStack.xml can be found in code directory. Copy it to current folder and simply set 
 the parameters.
-cp ${PATH_ALOSSTACK}/alosStack.xml ./
+cp ${ISCE_STACK}/alosStack/alosStack.xml ./
 
 3. Create command files for processing data. Run
-${PATH_ALOSSTACK}/create_cmds.py -stack_par alosStack.xml
+${ISCE_STACK}/alosStack/create_cmds.py -stack_par alosStack.xml
 
 4. Do most of the single date processing. Run
 ./cmd_1.sh
@@ -130,7 +130,7 @@ some pairs with ionosphere estimation anomalies, specify them by adding argument
 Make sure all dates are still connected after excluding these pairs, and then run ion_ls.py.
 
 You can plot baselines to see if the pairs are fully connected, e.g.
-${PATH_ALOSSTACK}/plot_baseline.py -baseline baseline/baseline_center.txt -pairs_dir pairs_ion -pairs_exc 150520-150701 -output baselines.pdf
+${ISCE_STACK}/alosStack/plot_baseline.py -baseline baseline/baseline_center.txt -pairs_dir pairs_ion -pairs_exc 150520-150701 -output baselines.pdf
 
 If the following parameters of the input xml file are True (default)
 

--- a/contrib/stack/alosStack/create_cmds.py
+++ b/contrib/stack/alosStack/create_cmds.py
@@ -277,7 +277,7 @@ def createCmds(stack, datesProcess, pairsProcess, pairsProcessIon, mode):
         return hdr
 
 
-    stackScriptPath = os.environ['PATH_ALOSSTACK']
+    stackScriptPath = os.path.join(os.environ['ISCE_STACK'], 'alosStack')
 
     def parallelSettings(array):
         settings = '''

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -18,7 +18,7 @@ mpl_logger.setLevel(logging.WARNING)
 import isce
 import isceobj
 from mroipac.baseline.Baseline import Baseline
-from Stack import config, run, selectPairs
+from stripmapStack.Stack import config, run, selectPairs
 
 
 filtStrength = '0.8'

--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -14,7 +14,7 @@ import numpy as np
 import isce
 import isceobj
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
-from Stack import config, run, sentinelSLC
+from topsStack.Stack import config, run, sentinelSLC
 
 
 helpstr = """
@@ -103,7 +103,7 @@ def createParser():
                         help='Working directory (default: %(default)s).')
 
     parser.add_argument('-d', '--dem', dest='dem', type=str, required=True,
-                        help='Directory with the DEM')
+                        help='Path of the DEM file')
 
     parser.add_argument('-m', '--reference_date', dest='reference_date', type=str, default=None,
                         help='Directory with reference acquisition')


### PR DESCRIPTION
This PR replaces the `from Stack import *` line in `stackSentinel.py` and `stackStripMap.py` with the absolute module import below, to allow for pythonic calls to their `main()`. 

```
from topsStack.Stack import *
from stripmapStack.Stack import *
```

This change requires adding `$ISCE_STACK` to `$PYTHONPATH`, thus, would break the previous default setup for stack processors. But it enables a more programmable workflow/recipe for the downstream developers. So I think it's a good change at a small cost: updating the stack processor path setup, which is updated in the README file.

The PR also includes a small change on `alosStack`: use $ISCE_STACK/alosStack to replace $PATH_ALOSSTACK for style consistency