### PR TITLE
topsStack ionosphere network: select and pair the SLCs with different starting ranges

### DIFF
--- a/contrib/stack/topsStack/s1_select_ion.py
+++ b/contrib/stack/topsStack/s1_select_ion.py
@@ -134,7 +134,7 @@ def get_group(dir0):
         fields = zips[i].split('_')
         tbef = datetime.datetime.strptime(fields[-5], datefmt)
         taft = datetime.datetime.strptime(fields[-4], datefmt)
-        
+
         if i == 0:
             #create new group
             tbef0 = tbef
@@ -225,7 +225,7 @@ def check_redundancy(group, threshold=1):
 def check_version(group):
     print('\nchecking different slice versions of an acquisition')
 
-    acquistion_removed_indices = [] 
+    acquistion_removed_indices = []
     ngroup = len(group)
     for i in range(ngroup):
         ngroupi = len(group[i])
@@ -367,7 +367,7 @@ def check_different_starting_ranges(group):
 def check_small_number_of_acquisitions_with_same_starting_ranges(group, threshold=1):
     '''
     for the same subswath starting ranges,
-    if the number of acquistions < threshold, remove these acquistions 
+    if the number of acquistions < threshold, remove these acquistions
     '''
 
     print('\nchecking small-number of acquistions with same starting ranges')
@@ -375,7 +375,7 @@ def check_small_number_of_acquisitions_with_same_starting_ranges(group, threshol
     ngroup = len(group)
 
     starting_ranges = [x[0].startingRanges for x in group]
-    
+
     #get unique starting_ranges
     starting_ranges_unique = []
     for i in range(ngroup):
@@ -418,14 +418,18 @@ def cmdLineParse():
     '''
     Command line parser.
     '''
-
-    parser = argparse.ArgumentParser( description='select Sentinel-1A/B acquistions good for ionosphere correction. not used slices are moved to folder: not_used')
+    EXAMPLE = """example:
+        s1_select_ion.py -dir data/slc -sn 33.55 37.12 -nr 10
+        s1_select_ion.py -dir data/slc -sn -36.0 -30.0 -nr 6
+    """
+    parser = argparse.ArgumentParser(description='Select Sentinel-1A/B acquistions good for ionosphere correction. Not used slices are moved to folder: not_used',
+                                     formatter_class=argparse.RawTextHelpFormatter, epilog=EXAMPLE)
     parser.add_argument('-dir', dest='dir', type=str, required=True,
             help = 'directory containing the "S1*_IW_SLC_*.zip" files')
-    parser.add_argument('-sn', dest='sn', type=str, required=True,
-            help='south/north bound of area of interest, format: south/north')
+    parser.add_argument('-sn', dest='sn', type=float, nargs=2, required=True,
+            help='south/north bound of area of interest. Input format: south north')
     parser.add_argument('-nr', dest='nr', type=int, default=10,
-            help = 'minimum number of acquisitions for same starting ranges. default: 10')
+            help = 'minimum number of acquisitions for same starting ranges. Default: %(default)s.')
 
     if len(sys.argv) <= 1:
         print('')
@@ -438,7 +442,9 @@ def cmdLineParse():
 if __name__ == '__main__':
 
     inps = cmdLineParse()
-    s,n=[float(x) for x in inps.sn.split('/')]
+    # s,n=[float(x) for x in inps.sn.split('/')]
+    s,n = inps.sn
+    print('south/north range: ', s, n)
 
     #group the slices
     group = get_group(inps.dir)

--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -534,16 +534,42 @@ def selectNeighborPairsIonosphere(safe_dict, num_connections):
                 pairs_same_starting_ranges.append((starting_ranges_unique_dates[k][i],starting_ranges_unique_dates[k][j]))
 
     #3. select pairs of diff starting ranges formed in 1 to connect the different starting ranges
+    cnt_both_ends = True
     pairs_diff_starting_ranges = []
-    for k in range(ndate_unique-1):
-        cnt = 0
+    cnt_dict = {}
+    for pair in pairs_diff_starting_ranges_0:
+        for k in range(ndate_unique):
+            if pair[0] in starting_ranges_unique_dates[k]: pair1_group=k+1
+            if pair[1] in starting_ranges_unique_dates[k]: pair2_group=k+1
+        if pair1_group != pair2_group:
+            idx = sorted([pair1_group, pair2_group])
+            if '{}-{}'.format(*idx) not in cnt_dict.keys():
+                cnt_dict['{}-{}'.format(*idx)] = 0
+            if cnt_dict['{}-{}'.format(*idx)] < num_connections:
+                cnt_dict['{}-{}'.format(*idx)] += 1
+                print('  adding from beginning {}({}) {}({})  (diff starting ranges group# {}--{}  cnt: {})'.format(
+                    pair[0], pair1_group, pair[1], pair2_group, *idx, cnt_dict['{}-{}'.format(*idx)]))
+                pairs_diff_starting_ranges.append(pair)
+    if cnt_both_ends:
+        cnt_dict = {}
+        pairs_diff_starting_ranges_0.reverse()
         for pair in pairs_diff_starting_ranges_0:
-            if (pair[0] in starting_ranges_unique_dates[k] and pair[1] in starting_ranges_unique_dates[k+1]) or \
-               (pair[1] in starting_ranges_unique_dates[k] and pair[0] in starting_ranges_unique_dates[k+1]):
-               pairs_diff_starting_ranges.append(pair)
-            cnt += 1
-            if cnt >= num_connections:
-                break
+            for k in range(ndate_unique):
+                if pair[0] in starting_ranges_unique_dates[k]: pair1_group=k+1
+                if pair[1] in starting_ranges_unique_dates[k]: pair2_group=k+1
+            if pair1_group != pair2_group:
+                idx = sorted([pair1_group, pair2_group])
+                if '{}-{}'.format(*idx) not in cnt_dict.keys():
+                    cnt_dict['{}-{}'.format(*idx)] = 0
+                if cnt_dict['{}-{}'.format(*idx)] < num_connections:
+                    cnt_dict['{}-{}'.format(*idx)] += 1
+                    print('  adding from end {}({}) {}({})  (diff starting ranges group# {}--{}  cnt: {})'.format(
+                        pair[0], pair1_group, pair[1], pair2_group, *idx, cnt_dict['{}-{}'.format(*idx)]))
+                    pairs_diff_starting_ranges.append(pair)
+        pairs_diff_starting_ranges = sorted(list(set(pairs_diff_starting_ranges)))
+
+    if pairs_diff_starting_ranges != []:
+        print(' number of connections across different starting ranges: {}\n'.format(len(pairs_diff_starting_ranges)))
 
     return pairs_same_starting_ranges, pairs_diff_starting_ranges
 

--- a/contrib/stack/topsStack/unwrap.py
+++ b/contrib/stack/topsStack/unwrap.py
@@ -2,19 +2,19 @@
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Copyright 2013 California Institute of Technology. ALL RIGHTS RESERVED.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # United States Government Sponsorship acknowledged. This software is subject to
 # U.S. export control laws and regulations and has been classified as 'EAR99 NLR'
 # (No [Export] License Required except when exporting to an embargoed country,
@@ -69,7 +69,7 @@ def createParser():
             help='Max cycles of deformation')
     parser.add_argument('-s', '--reference', dest='reference', type=str, default='reference',
             help='Reference directory')
-    
+
     parser.add_argument('-m', '--method', dest='method', type=str, default='icu',
             help='unwrapping method')
 
@@ -131,9 +131,9 @@ def extractInfo(xmlName, inps):
 
     #hdg = burst.orbit.getHeading()
     data['earthRadius'] = earthRadius  #elp.local_radius_of_curvature(llh.lat, hdg)
-    
+
     #azspacing  = burst.azimuthTimeInterval * sv.getScalarVelocity()
-    #azres = 20.0 
+    #azres = 20.0
 
     #corrfile  = os.path.join(self._insar.mergedDirname, self._insar.coherenceFilename)
     rangeLooks = inps.rglooks
@@ -153,16 +153,16 @@ def runUnwrap(infile, outfile, corfile, config, costMode = None,initMethod = Non
 
     if costMode is None:
         costMode   = 'DEFO'
-    
+
     if initMethod is None:
         initMethod = 'MST'
-    
+
     if  defomax is None:
         defomax = 4.0
-    
+
     if initOnly is None:
         initOnly = False
-    
+
     wrapName = infile
     unwrapName = outfile
 
@@ -173,7 +173,7 @@ def runUnwrap(infile, outfile, corfile, config, costMode = None,initMethod = Non
     wavelength = config['wavelength']
     width      = img.getWidth()
     length     = img.getLength()
-    earthRadius = config['earthRadius'] 
+    earthRadius = config['earthRadius']
     altitude   = config['altitude']
     rangeLooks = config['rglooks']
     azimuthLooks = config['azlooks']
@@ -249,7 +249,7 @@ def runUnwrapIcu(infile, outfile):
     intImage = isceobj.createIntImage()
     intImage.initImage(infile, 'read', width)
     intImage.createImage()
-   
+
 
     #unwImage
     unwImage = isceobj.Image.createImage()
@@ -261,10 +261,10 @@ def runUnwrapIcu(infile, outfile):
     unwImage.dataType = 'FLOAT'
     unwImage.setAccessMode('write')
     unwImage.createImage()
-    
+
     #unwrap with icu
     icuObj = Icu()
-    icuObj.filteringFlag = False      
+    icuObj.filteringFlag = False
     icuObj.useAmplitudeFlag = False
     icuObj.singlePatch = True
     icuObj.initCorrThreshold = 0.1
@@ -295,7 +295,7 @@ def remove_filter(intfile, filtfile, unwfile):
         integer_jumps = unw_phase[1, line, :] - np.angle(filt_phase[line, :])
         outfile[1, line, :] = integer_jumps + np.angle(int_phase[line, :])
         outfile[0, line, :] = unw_phase[0, line, :]
-    
+
     unwImage = isceobj.Image.createImage()
     unwImage.setFilename(outunw)
     unwImage.setWidth(width)
@@ -318,11 +318,11 @@ def main(iargs=None):
     print ('unwrapping method : ' , inps.method)
 
     if inps.method == 'snaphu':
-        if inps.nomcf: 
+        if inps.nomcf:
             fncall =  runUnwrap
         else:
             fncall = runUnwrapMcf
-        swathList = ut.getSwathList(inps.reference) 
+        swathList = ut.getSwathList(inps.reference)
         xmlFile = os.path.join(inps.reference , 'IW{0}.xml'.format(swathList[0]))
         metadata = extractInfo(xmlFile, inps)
         fncall(inps.intfile, inps.unwfile, inps.cohfile, metadata, defomax=inps.defomax)


### PR DESCRIPTION
Here are some proposed changes to the **ionospheric phase estimation module** for the `topsStack` processor under [contrib/stack/topsStack](https://github.com/isce-framework/isce2/tree/main/contrib/stack/topsStack)

### [s1_select_ion.py: -sn option](https://github.com/isce-framework/isce2/commit/01baf9e2ff8e560adb3bd4f6fa4ea96fcbf83bd5) 

+ make -sn as floats to accept negative values for the southern hemisphere

+ Add examples to --help message


### [stackSentinel.py: ion pairing between diff starting ranges](https://github.com/isce-framework/isce2/commit/276dedf81533cfa6c31fd275a63a98b56feeb5e6) 

The changes are applied to the section: Select pairs of diff starting ranges to connect groups of different starting ranges to eventually form a fully connected ionosphere network.

+ Fixed the indentation error on `cnt += 1`. It incremented even if we didn’t have pairs. This bug could cause the network to be disconnected. This was also brought up by @olliestephenson, and also in https://github.com/isce-framework/isce2/issues/499#issuecomment-1166623490).

+ Review and re-write the pairing logic in this section to connect groups of SLCs with different starting ranges.

+ Allow for pairing between diff starting range groups from both ends of the network. Such that, when pairing long S1A and S1B networks, beyond having a full rank matrix, we can have connections at both ends of the long S1A/B sequences. This was brought up in an offline discussion with @olliestephenson. The intuition/concern is that we could have some kind of divergence between the A and B ionosphere that we wouldn’t be able to notice without checking the consistency at both ends. But we are not entirely sure about this. 