### PR TITLE
Added os.chdir('../') after line no. 71

### DIFF
--- a/components/isceobj/Alos2burstProc/runCoregCc.py
+++ b/components/isceobj/Alos2burstProc/runCoregCc.py
@@ -69,6 +69,7 @@ def runCoregCc(self):
                     self._insar.rangeResidualOffsetCc[i].append(0.0)
                     self._insar.azimuthResidualOffsetCc[i].append(0.0)
                     catalog.addItem('warning message', 'land area too small for estimating offsets between reference and secondary magnitudes at frame {}, swath {}'.format(frameNumber, swathNumber), 'runCoregCc')
+                    os.chdir('../')
                     continue
                 #total number of offsets to use
                 numberOfOffsets /= landRatio


### PR DESCRIPTION
Added os.chdir('../') after line no. 71 so it can change directory to the next swath after printing the warning message (pls. see this issue https://github.com/isce-framework/isce2/issues/581).