### PR TITLE
topsStack/correlation: replace undefined `burstIgram_mergeBurst()`

### DIFF
--- a/contrib/stack/topsStack/stackSentinel.py
+++ b/contrib/stack/topsStack/stackSentinel.py
@@ -727,8 +727,14 @@ def correlationStack(inps, acquisitionDates, stackReferenceDate, secondaryDates,
 
     i+=1
     runObj = run()
+    runObj.configure(inps, 'run_{:02d}_generate_burst_igram'.format(i))
+    runObj.generate_burstIgram(acquisitionDates, safe_dict, pairs)
+    runObj.finalize()
+
+    i += 1
+    runObj = run()
     runObj.configure(inps, 'run_{:02d}_merge_burst_igram'.format(i))
-    runObj.burstIgram_mergeBurst(acquisitionDates, safe_dict, pairs)
+    runObj.igram_mergeBurst(acquisitionDates, safe_dict, pairs)
     runObj.finalize()
 
     i+=1


### PR DESCRIPTION
This PR fixes the issue reported in #630 by @svenborgstrom on the `correlation` workflow in `topsStack`, by replacing the undefined `runObj.burstIgram_mergeBurst()` with `runObj.generate_burstIgram()` and `runObj.igram_mergeBurst()`.