### PR TITLE
Replace deprecated `normed` with `density` in numpy.histogram()

### DIFF
--- a/components/isceobj/TopsProc/runESD.py
+++ b/components/isceobj/TopsProc/runESD.py
@@ -93,7 +93,7 @@ def runESD(self, debugPlot=True):
             vali = off[mask]
             val = np.hstack((val, vali))
 
-    
+
 
         img = isceobj.createIntImage()
         img.filename = combIntName
@@ -114,13 +114,13 @@ def runESD(self, debugPlot=True):
             img.renderHdr()
 
     if val.size == 0 :
-        raise Exception('Coherence threshold too strict. No points left for reliable ESD estimate') 
+        raise Exception('Coherence threshold too strict. No points left for reliable ESD estimate')
 
     medianval = np.median(val)
     meanval = np.mean(val)
     stdval = np.std(val)
 
-    hist, bins = np.histogram(val, 50, normed=1)
+    hist, bins = np.histogram(val, 50, density=True)
     center = 0.5*(bins[:-1] + bins[1:])
 
 
@@ -156,7 +156,7 @@ def runESD(self, debugPlot=True):
     catalog.printToLog(logger, "runESD")
     self._insar.procDoc.addAllFromCatalog(catalog)
 
-    self._insar.secondaryTimingCorrection = medianval * reference.bursts[0].azimuthTimeInterval 
+    self._insar.secondaryTimingCorrection = medianval * reference.bursts[0].azimuthTimeInterval
 
     return
 

--- a/components/isceobj/TopsProc/runRangeCoreg.py
+++ b/components/isceobj/TopsProc/runRangeCoreg.py
@@ -4,7 +4,7 @@
 #
 
 
-import numpy as np 
+import numpy as np
 import os
 import isceobj
 import logging
@@ -108,7 +108,7 @@ def runRangeCoreg(self, debugPlot=True):
     '''
 
     if not self.doESD:
-        return 
+        return
 
     catalog = isceobj.Catalog.createCatalog(self._insar.procDoc.name)
 
@@ -125,8 +125,8 @@ def runRangeCoreg(self, debugPlot=True):
 
         minBurst, maxBurst = self._insar.commonReferenceBurstLimits(swath-1)
 
-        maxBurst = maxBurst - 1  ###For overlaps 
-    
+        maxBurst = maxBurst - 1  ###For overlaps
+
         referenceTop = self._insar.loadProduct( os.path.join(self._insar.referenceSlcOverlapProduct, 'top_IW{0}.xml'.format(swath)))
         referenceBottom  = self._insar.loadProduct( os.path.join(self._insar.referenceSlcOverlapProduct , 'bottom_IW{0}.xml'.format(swath)))
 
@@ -137,14 +137,14 @@ def runRangeCoreg(self, debugPlot=True):
             for ii in range(minBurst,maxBurst):
                 mFile = pair[0].bursts[ii-minBurst].image.filename
                 sFile = pair[1].bursts[ii-minBurst].image.filename
-            
+
                 field = runAmpcor(mFile, sFile)
 
                 for offset in field:
                     rangeOffsets.append(offset.dx)
                     snr.append(offset.snr)
 
-    ###Cull 
+    ###Cull
     mask = np.logical_and(np.array(snr) >  self.offsetSNRThreshold, np.abs(rangeOffsets) < 1.2)
     val = np.array(rangeOffsets)[mask]
 
@@ -152,7 +152,7 @@ def runRangeCoreg(self, debugPlot=True):
     meanval = np.mean(val)
     stdval = np.std(val)
 
-    hist, bins = np.histogram(val, 50, normed=1)
+    hist, bins = np.histogram(val, 50, density=True)
     center = 0.5*(bins[:-1] + bins[1:])
 
 

--- a/contrib/stack/topsStack/estimateAzimuthMisreg.py
+++ b/contrib/stack/topsStack/estimateAzimuthMisreg.py
@@ -141,7 +141,7 @@ def main(iargs=None):
     meanval = np.mean(val)
     stdval = np.std(val)
 
-    hist, bins = np.histogram(val, 50, normed=1)
+    hist, bins = np.histogram(val, 50, density=True)
     center = 0.5*(bins[:-1] + bins[1:])
 
 
@@ -190,7 +190,7 @@ if __name__ == '__main__':
     The main driver.
     '''
 
-    main()    
+    main()
 
 
 

--- a/contrib/stack/topsStack/estimateRangeMisreg.py
+++ b/contrib/stack/topsStack/estimateRangeMisreg.py
@@ -6,7 +6,7 @@
 # Heresh Fattahi: Adopted for stack processing
 
 import argparse
-import numpy as np 
+import numpy as np
 import os
 import isce
 import isceobj
@@ -20,7 +20,7 @@ import s1a_isce_utils as ut
 
 def createParser():
     parser = argparse.ArgumentParser( description='Estimate range misregistration using overlap bursts')
-    
+
     parser.add_argument('-o', '--out_range', type=str, dest='output', default='misreg.txt',
             help='Output textfile with the constant range offset')
     parser.add_argument('-t', '--snr_threshold', type=float, dest='offsetSNRThreshold', default=6.0,
@@ -139,7 +139,7 @@ def main(iargs=None):
     '''
 
     #if not self.doESD:
-    #    return 
+    #    return
 
     #catalog = isceobj.Catalog.createCatalog(self._insar.procDoc.name)
 
@@ -158,9 +158,9 @@ def main(iargs=None):
         #    continue
 
         #minBurst, maxBurst = self._insar.commonReferenceBurstLimits(swath-1)
-        
-        #maxBurst = maxBurst - 1  ###For overlaps 
-    
+
+        #maxBurst = maxBurst - 1  ###For overlaps
+
         #referenceTop = self._insar.loadProduct( os.path.join(self._insar.referenceSlcOverlapProduct, 'top_IW{0}.xml'.format(swath)))
         #referenceBottom  = self._insar.loadProduct( os.path.join(self._insar.referenceSlcOverlapProduct , 'bottom_IW{0}.xml'.format(swath)))
         referenceTop = ut.loadProduct(os.path.join(inps.reference , 'overlap','IW{0}_top.xml'.format(swath)))
@@ -185,14 +185,14 @@ def main(iargs=None):
             for ii in range(minBurst,maxBurst):
                 mFile = pair[0].bursts[ii-minReference].image.filename
                 sFile = pair[1].bursts[ii-minSecondary].image.filename
-            
+
                 field = runAmpcor(mFile, sFile)
 
                 for offset in field:
                     rangeOffsets.append(offset.dx)
                     snr.append(offset.snr)
 
-    ###Cull 
+    ###Cull
     mask = np.logical_and(np.array(snr) >  inps.offsetSNRThreshold, np.abs(rangeOffsets) < 1.2)
     val = np.array(rangeOffsets)[mask]
 
@@ -200,12 +200,12 @@ def main(iargs=None):
     meanval = np.mean(val)
     stdval = np.std(val)
 
-    # convert the estimations to meters 
+    # convert the estimations to meters
     medianval = medianval * referenceTop.bursts[0].rangePixelSize
     meanval = meanval * referenceTop.bursts[0].rangePixelSize
     stdval = stdval * referenceTop.bursts[0].rangePixelSize
 
-    hist, bins = np.histogram(val, 50, normed=1)
+    hist, bins = np.histogram(val, 50, density=True)
     center = 0.5*(bins[:-1] + bins[1:])
 
     outputDir = os.path.dirname(inps.output)


### PR DESCRIPTION
Related to #661, expired deprecations from numpy 1.24.

The normed keyword argument has been removed from np.histogram, np.histogram2d, and np.histogramdd. Use density instead. If normed was passed by position, density is now used.

Here is the change log:
https://numpy.org/devdocs/release/2.24.1-notes.html#expired-deprecations