### PR TITLE
`alosStack/ion_check`: specify font for while calling `montage`

### DIFF
--- a/contrib/stack/alosStack/ion_check.py
+++ b/contrib/stack/alosStack/ion_check.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
         runCmd('mv {} {}'.format(os.path.join(odir, 'out.ppm'), os.path.join(odir, 'out2.ppm')))
         runCmd('mdx {} -s {} -c8pha -cmap cmy -wrap 6.283185307179586 -addr -3.141592653589793{} -P -workdir {}'.format(diff, width, wbdArguments, odir))
         runCmd('mv {} {}'.format(os.path.join(odir, 'out.ppm'), os.path.join(odir, 'out3.ppm')))
-        runCmd("montage -pointsize {} -label 'original' {} -label 'ionosphere' {} -label 'corrected' {} -geometry +{} -compress LZW{} {}.tif".format(
+        runCmd("montage -font DejaVu-Sans -pointsize {} -label 'original' {} -label 'ionosphere' {} -label 'corrected' {} -geometry +{} -compress LZW{} {}.tif".format(
             int((ratio*width)/111*18+0.5),
             os.path.join(odir, 'out1.ppm'),
             os.path.join(odir, 'out2.ppm'),


### PR DESCRIPTION
The issue was opened by Dani-Lindsay, at first cmd_3.sh fails during `alosStack/ion_check.py` because  imagemagick was not installed. After installing imagemagick by `conda install -c conda-forge imagemagick`, I got another error message: 

convert-im6.q16: unable to read font `helvetica' @ error/annotate.c/RenderFreetype/1396.

The error message can be fixed by changing line 106 in ion_check.py from 
`runCmd("montage -pointsize {} -label 'original' {} -label 'ionosphere' {} -label 'corrected' {} -geometry +{} -compress LZW{} {}.tif".format( `
to 
`runCmd("montage -font DejaVu-Sans -pointsize {} -label 'original' {} -label 'ionosphere' {} -label 'corrected' {} -geometry +{} -compress LZW{} {}.tif".format(`