### PR TITLE
`wbd`: add `-u/--url` option to allow for different urls

### DIFF
--- a/components/isceobj/Alos2Proc/runDownloadDem.py
+++ b/components/isceobj/Alos2Proc/runDownloadDem.py
@@ -166,7 +166,7 @@ def downloadDem(bbox, demType='version3', resolution=1, fillingValue=-32768, out
         print(k,'=',v)
 
 
-def download_wbd(s, n, w, e):
+def download_wbd(s, n, w, e, url=None):
     '''
     download water body
     water body. (0) --- land; (-1) --- water; (-2) --- no data.
@@ -192,6 +192,10 @@ def download_wbd(s, n, w, e):
     ############################################################
     sw = createManager('wbd')
     sw.configure()
+
+    # change the default url to the specified one.
+    if url and isinstance(url, str):
+        sw.url = url
 
     outputFile = sw.defaultName([latMin,latMax,lonMin,lonMax])
     if os.path.exists(outputFile) and os.path.exists(outputFile+'.xml'):


### PR DESCRIPTION
This PR adds the `wbd.py -u/--url` option to be able to change the water body tile files' url, similar to the `dem.py --url` option. The default behavior is kept the same, so no change is expected on the user side or in the previous usage. Detailed changes are as below:

+ `isceobj.Alos2Proc.runDownloadDem.download_wbd()`: add `url` optional argument to be able to change the default url for the water body tile files.

+ `applications.wbd.py`:
   - add `cmd_line_parse()` function to handle the command line inputs.
   - add `-u/--url` option to allow changing the url of water body tile files.
   - add example usage