### PR TITLE
docs: always use 4-digit frame number for alos2

### DIFF
--- a/components/isceobj/Alos2Proc/runFrameOffset.py
+++ b/components/isceobj/Alos2Proc/runFrameOffset.py
@@ -76,7 +76,8 @@ def frameOffset(track, image, outputfile, crossCorrelation=True, matchingMode=0)
     azimuthOffsetMatching = []
 
     for j in range(len(track.frames)):
-        frameNumber = track.frames[j].frameNumber
+        # use int type for frameNumber to get rid of padding 0s
+        frameNumber = int(track.frames[j].frameNumber)
         swathNumber = track.frames[j].swaths[0].swathNumber
         swathDir = 'f{}_{}/s{}'.format(j+1, frameNumber, swathNumber)
 

--- a/components/isceobj/Alos2Proc/runFrameOffset.py
+++ b/components/isceobj/Alos2Proc/runFrameOffset.py
@@ -76,8 +76,7 @@ def frameOffset(track, image, outputfile, crossCorrelation=True, matchingMode=0)
     azimuthOffsetMatching = []
 
     for j in range(len(track.frames)):
-        # use int type for frameNumber to get rid of padding 0s
-        frameNumber = int(track.frames[j].frameNumber)
+        frameNumber = track.frames[j].frameNumber
         swathNumber = track.frames[j].swaths[0].swathNumber
         swathDir = 'f{}_{}/s{}'.format(j+1, frameNumber, swathNumber)
 

--- a/examples/input_files/alos2/alos2App.xml
+++ b/examples/input_files/alos2/alos2App.xml
@@ -10,7 +10,7 @@
     <property name="secondary directory">../../../z_common_data/insarzd_test_dataset/gorkha/d048/150503</property>
     <!--Normally no need to set frame numbers, but if reference and secondary frames do not meet the following
     one-to-one correspondence, you need to set frame numbers here. See instructions below on how to find
-    and set frame numbers.
+    and set frame numbers. Always use 4-digit to set the frame number, e.g. 2980, 0750, etc.
 
     Reference Data Folder               Secondary Data Folder
        Frame ****     .............     Frame ****


### PR DESCRIPTION
While processing multiple frames of ALOS2 ScanSAR data using `alos2App.py`, an error occurs as below if the frame number has 3-digit, e.g. 750. This PR fixes this error by converting the `frameNumber` from `str` to `int` type, to remove the padding 0 for frames in 3-digit, consistent with the factual folder name and other parts of the workflow.

```bash
The remaining steps are (in order):  ['frame_offset', 'frame_mosaic', 'rdr2geo', 'geo2rdr', 'rdrdem_offset', 'rect_rgoffset', 'diff_int', 'look', 'coherence'
Running step frame_offset
estimate offset frame 0700
estimate offset frame 0750
Traceback (most recent call last):
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/applications/alos2App.py", line 1173, in <module>
    insar.run()
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/iscesys/Component/Application.py", line 142, in run
    exitStatus = self._processSteps()
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/iscesys/Component/Application.py", line 405, in _processSt
    result = func(*pargs, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/isceobj/Alos2Proc/Factories.py", line 40, in __call__
    return self.method(self.other, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/isceobj/Alos2Proc/runFrameOffset.py", line 40, in runFrame
    offsetReference = frameOffset(referenceTrack, self._insar.referenceSlc, self._insar.referenceFrameOffset,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/isceobj/Alos2Proc/runFrameOffset.py", line 108, in frameOf
    offsetMatching = estimateFrameOffset(swath1, swath2, image1, image2, matchingMode=matchingMode)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/isceobj/Alos2Proc/runFrameOffset.py", line 172, in estimat
    mSLC.load(image1+'.xml')
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/iscesys/Component/Configurable.py", line 1407, in load
    tmpProp, tmpFact, tmpMisc = FP.parse(filename)
                                ^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/site-packages/isce/components/iscesys/Parsers/XmlParser.py", line 41, in parse
    root = ET.parse(filename)
           ^^^^^^^^^^^^^^^^^^
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/xml/etree/ElementTree.py", line 1218, in parse
    tree.parse(source, parser)
  File "/home/zhangyunjun/tools/mambaforge/envs/insar/lib/python3.11/xml/etree/ElementTree.py", line 569, in parse
    source = open(source, "rb")
             ^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '../f1_0700/s1/220905.slc.xml'
```