### PR TITLE
bugfix in `cuDenseOffsets.py --full/out-geom` for `topsApp` product

### DIFF
--- a/contrib/PyCuAmpcor/examples/cuDenseOffsets.py
+++ b/contrib/PyCuAmpcor/examples/cuDenseOffsets.py
@@ -394,7 +394,7 @@ def estimateOffsetField(reference, secondary, inps=None):
 
 
 def prepareGeometry(full_dir, out_dir, x_start, y_start, x_step, y_step, x_win_num, y_win_num,
-                    fbases=['hgt','lat','lon','los','shadowMask','waterMask']):
+                    fbases=['lat','lon','los','hgt','z','shadowMask','waterMask']):
     """Generate multilooked geometry datasets in the same grid as the estimated offset field
     from the full resolution geometry datasets.
     Parameters: full_dir    - str, path of input  geometry directory in full resolution


### PR DESCRIPTION
This PR fixes a bug while running `cuDenseOffsets.py --full/out-geom` on `topsApp.py` products by:
+ setting `lat` as the first geometry dataset, instead of `hgt`, because the former is shared between topsApp and topsStack products
+ add `z` from topsApp, in addition to `hgt` from topsStack, as the input geometry dataset