### PR TITLE
Changed mlab.griddata to scipy.interpolate.griddata 

### DIFF
--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -230,6 +230,7 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
     return k
 
 def rotate(k , theta):
+    from matplotlib import mlab
 
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))

--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -251,7 +251,7 @@ def rotate(k , theta):
         xR = AR[0,:].reshape(Sy,Sx)
         yR = AR[1,:].reshape(Sy,Sx)
 
-        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), interp='linear')
+        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), method='linear')
         #k = f(xR, yR)
         k = k.data
         k[np.isnan(k)] = 0.0

--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -231,7 +231,6 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
 
 def rotate(k , theta):
 
-
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))
 
@@ -244,7 +243,7 @@ def rotate(k , theta):
 
     A=np.vstack((x.flatten(), y.flatten()))
     if theta!=0:
-	from scipy.interpolate import griddata
+        from scipy.interpolate import griddata
         theta = theta*np.pi/180.
         R = np.array([[np.cos(theta), -1.0*np.sin(theta)],[np.sin(theta), np.cos(theta)]])
         AR = np.dot(R,A)

--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -230,7 +230,7 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
     return k
 
 def rotate(k , theta):
-    from matplotlib import mlab
+
 
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))
@@ -244,13 +244,14 @@ def rotate(k , theta):
 
     A=np.vstack((x.flatten(), y.flatten()))
     if theta!=0:
+	from scipy.interpolate import griddata
         theta = theta*np.pi/180.
         R = np.array([[np.cos(theta), -1.0*np.sin(theta)],[np.sin(theta), np.cos(theta)]])
         AR = np.dot(R,A)
         xR = AR[0,:].reshape(Sy,Sx)
         yR = AR[1,:].reshape(Sy,Sx)
 
-        k = mlab.griddata(x.flatten(),y.flatten(),k.flatten(),xR,yR, interp='linear')
+        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), interp='linear')
         #k = f(xR, yR)
         k = k.data
         k[np.isnan(k)] = 0.0

--- a/components/isceobj/StripmapProc/runDispersive.py
+++ b/components/isceobj/StripmapProc/runDispersive.py
@@ -253,7 +253,7 @@ def rotate(k , theta):
 
         k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), method='linear')
         #k = f(xR, yR)
-        k = k.data
+        #k = k.data
         k[np.isnan(k)] = 0.0
         a = 1./np.sum(k)
         k = a*k

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -335,6 +335,7 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
     return k
 
 def rotate(k , theta):
+    from matplotlib import mlab
 
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -335,7 +335,7 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
     return k
 
 def rotate(k , theta):
-    from matplotlib import mlab
+
 
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))
@@ -349,13 +349,14 @@ def rotate(k , theta):
 
     A=np.vstack((x.flatten(), y.flatten()))
     if theta!=0:
+        from scipy.interpolate import griddata
         theta = theta*np.pi/180.
         R = np.array([[np.cos(theta), -1.0*np.sin(theta)],[np.sin(theta), np.cos(theta)]])
         AR = np.dot(R,A)
         xR = AR[0,:].reshape(Sy,Sx)
         yR = AR[1,:].reshape(Sy,Sx)
 
-        k = mlab.griddata(x.flatten(),y.flatten(),k.flatten(),xR,yR, interp='linear')
+        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), interp='linear')
         #k = f(xR, yR)
         k = k.data
         k[np.isnan(k)] = 0.0

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -358,7 +358,7 @@ def rotate(k , theta):
 
         k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), method='linear')
         #k = f(xR, yR)
-        k = k.data
+        #k = k.data
         k[np.isnan(k)] = 0.0
         a = 1./np.sum(k)
         k = a*k

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -336,7 +336,6 @@ def Gaussian_kernel(Sx, Sy, sig_x,sig_y):
 
 def rotate(k , theta):
 
-
     Sy,Sx = np.shape(k)
     x,y = np.meshgrid(np.arange(Sx),np.arange(Sy))
 

--- a/contrib/stack/stripmapStack/estimateIono.py
+++ b/contrib/stack/stripmapStack/estimateIono.py
@@ -356,7 +356,7 @@ def rotate(k , theta):
         xR = AR[0,:].reshape(Sy,Sx)
         yR = AR[1,:].reshape(Sy,Sx)
 
-        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), interp='linear')
+        k = griddata((x.flatten(),y.flatten()),k.flatten(),(xR,yR), method='linear')
         #k = f(xR, yR)
         k = k.data
         k[np.isnan(k)] = 0.0


### PR DESCRIPTION
- Changed mlab.griddata to scipy.interpolate.griddata on  runDispersive.py and estimateIono.py since mlab.griddata was deprecated in matplotlib.