### PR TITLE
unpackFrame_ROIPAC_raw.py fixes

### DIFF
--- a/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
+++ b/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
@@ -5,6 +5,8 @@ from isceobj.Sensor import createSensor
 import shelve
 import argparse
 import os
+from mroipac.dopiq.DopIQ import DopIQ
+import copy
 
 def cmdLineParse():
     '''

--- a/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
+++ b/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
@@ -19,17 +19,19 @@ def cmdLineParse():
     parser.add_argument('-o', '--output', dest='slcdir', type=str,
             required=True, help='Output data directory')
 
+    parser.add_argument('-d','--default', dest='defaultDoppler', type=str, action='store_true'
+            required=False, help='use DEFAULT to estimate doppler')
+
     return parser.parse_args()
 
 
-def unpack(rawname, hdrname, slcname):
+def unpack(rawname, hdrname, slcname, default):
     '''
     Unpack raw to binary file.
     '''
 
     if not os.path.isdir(slcname):
         os.mkdir(slcname)
-
     date = os.path.basename(slcname)
     obj = createSensor('ROI_PAC')
     obj.configure()
@@ -42,7 +44,26 @@ def unpack(rawname, hdrname, slcname):
     print(obj.output)
     obj.extractImage()
     obj.frame.getImage().renderHdr()
-    obj.extractDoppler()
+
+    if defaultDoppler == True:
+        obj.extractDoppler()
+    else:
+        dop = DopIQ()
+        dop.configure()
+
+        img = copy.deepcopy(obj.frame.getImage())
+        img.setAccessMode('READ')
+
+        dop.wireInputPort('frame', object=obj.frame)
+        dop.wireInputPort('instrument', object=obj.frame.instrument)
+        dop.wireInputPort('image', object=img)
+        dop.calculateDoppler()
+        dop.fitDoppler()
+        fit = dop.quadratic
+        coef = [fit['a'], fit['b'], fit['c']]
+
+        print(coef)
+        obj.frame._dopplerVsPixel = [x*obj.frame.PRF for x in coef]
 
     pickName = os.path.join(slcname, 'raw')
     with shelve.open(pickName) as db:
@@ -57,4 +78,4 @@ if __name__ == '__main__':
     if inps.slcdir.endswith('/'):
         inps.slcdir = inps.slcdir[:-1]
 
-    unpack(inps.rawfile, inps.hdrfile, inps.slcdir)
+    unpack(inps.rawfile, inps.hdrfile, inps.slcdir, inps.defaultDoppler)

--- a/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
+++ b/contrib/stack/stripmapStack/unpackFrame_ROIPAC_raw.py
@@ -4,11 +4,7 @@ import isce
 from isceobj.Sensor import createSensor
 import shelve
 import argparse
-import glob
-from isceobj.Util import Poly1D
-from isceobj.Planet.AstronomicalHandbook import Const
 import os
-import copy
 
 def cmdLineParse():
     '''


### PR DESCRIPTION
- Use default values instead of using DOPIQ when focusing images
- Use `os.path.abspath` for the image name so stackStripMap.py can read the path of the raw files when processing
- Change the file format to UNIX using `:set ff=unix`