### PR TITLE
fix for gpu geo2rdr and topo out of memory issue

### DIFF
--- a/components/zerodop/GPUgeo2rdr/cuda/GPUgeo.cu
+++ b/components/zerodop/GPUgeo2rdr/cuda/GPUgeo.cu
@@ -304,7 +304,7 @@ int nLinesPossible(int length, int width) {
     // printf("GPU Memory to be used %ld\n", freeByte);
     // printf("Device has roughly %.4f GB of memory, ", double(totalByte)/1.e9);
     // determine the allowed max lines per run, 556 is per pixel memory usage (estimated)
-    linesPerRun = freeByte / (7*sizeof(double) * width);
+    linesPerRun = freeByte / (8*sizeof(double) * width);
     assert(linesPerRun>0);
     printf("and can process roughly %d lines (each with %d pixels) per run.\n", linesPerRun, width);
     return linesPerRun;

--- a/components/zerodop/GPUtopozero/src/Topo.cpp
+++ b/components/zerodop/GPUtopozero/src/Topo.cpp
@@ -462,7 +462,7 @@ void Topo::topo() {
         // use 100Mb as a rounding unit , may be adjusted
         size_t memoryRoundingUnit = 1024ULL * 1024ULL * 100;
         // memory to be used for each pixel in bytes, with 9 double elements per pixel
-        size_t pixelBytes = sizeof(double) * 9;
+        size_t pixelBytes = sizeof(double) * 10;
         // memory overhead for other shared parameters, in terms of memoryRoundUnit, or 200M
         size_t memoryOverhead = 2;
 


### PR DESCRIPTION
This PR is to fix the out of memory issue for GPU modules geo2rdr and topo for some cases with large dem files. It is due to the underestimate of the overhead memory usage in processing each  line. The fix was confirmed to be working by users.

More details, please see pr #440, and issue #731.   