### PR TITLE
Added "char" type in ALOS_fbd2fbsmodule.c and ALOS_fbs2fbdmodule.c

### DIFF
--- a/components/stdproc/alosreformat/ALOS_fbd2fbs/bindings/ALOS_fbd2fbsmodule.c
+++ b/components/stdproc/alosreformat/ALOS_fbd2fbs/bindings/ALOS_fbd2fbsmodule.c
@@ -34,7 +34,7 @@
 
 #include "ALOS_fbd2fbsmodule.h"
 
-const* __doc__ =  "Python extension for ALOS_fbd2fbs.c";
+const char* __doc__ =  "Python extension for ALOS_fbd2fbs.c";
 
 static struct PyModuleDef moduledef = {
     // header

--- a/components/stdproc/alosreformat/ALOS_fbs2fbd/bindings/ALOS_fbs2fbdmodule.c
+++ b/components/stdproc/alosreformat/ALOS_fbs2fbd/bindings/ALOS_fbs2fbdmodule.c
@@ -34,7 +34,7 @@
 
 #include "ALOS_fbs2fbdmodule.h"
 
-const* __doc__ =  "Python extension for ALOS_fbs2fbd.c";
+const char* __doc__ =  "Python extension for ALOS_fbs2fbd.c";
 
 static struct PyModuleDef moduledef = {
     // header

--- a/contrib/stack/alosStack/alosStack_tutorial.txt
+++ b/contrib/stack/alosStack/alosStack_tutorial.txt
@@ -1,6 +1,7 @@
 ######################################################################################
 # Tutorial for alosStack
 # Cunren Liang, October 2020
+# updated Eric Fielding, May 2023
 ######################################################################################
 
 This is the tutorial of alosStack processor.
@@ -11,10 +12,10 @@ This is the tutorial of alosStack processor.
 ###########################################
 
 Set environment variable 'ISCE_STACK'
-export ISCE_STACK=CODE_DIR/contrib/stack
+export ISCE_STACK=CODE_DIR/isce2/contrib/stack/
 
-where CODE_DIR is the directory of your isce code. Note that alosStack is not installed when you install
-the software, so CODE_DIR is your code directory rather than installation directory.
+where CODE_DIR is the directory of your isce code. The alosStack is not installed in your ISCE_HOME directory when you install
+the software, so CODE_DIR is your ISCE2 source code directory rather than installation directory.
 
 
 ###########################################


### PR DESCRIPTION
Recent C compilers gave an error because this pointer had no type set and tried to set it to "int". Adding the "char" fixes it.