### PR TITLE
add symlink in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,3 +64,5 @@ RUN set -ex \
 COPY --from=builder /tmp/isce*.deb /tmp/isce2.deb
 
 RUN dpkg -i /tmp/isce2.deb
+
+RUN ln -s /usr/lib/python3.8/dist-packages/isce2 /usr/lib/python3.8/dist-packages/isce


### PR DESCRIPTION
I was trying to run rtcApp.py in the docker image, however it failed with `ModuleNotFoundError: No module named 'isce'`. This issue was acknowledged here already some time ago: https://github.com/isce-framework/isce2/issues/642, where the solution of a symlink was proposed. However, the issue was closed without actually implementing the solution.

This MR adds the symlink to the docker image, which fixes the ModuleNotFoundError.