### PR TITLE
Bugfix plot ion topsStack

### DIFF
--- a/contrib/stack/topsStack/plotIonDates.py
+++ b/contrib/stack/topsStack/plotIonDates.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     for ipair in pairs:
         ion = os.path.join(idir, ipair + '.ion')
         runCmd('mdx {} -s {} -cmap cmy -wrap 6.283185307179586 -addr -3.141592653589793 -P -workdir {}'.format(ion, width, odir))
-        runCmd("montage -pointsize {} -label '{}' {} -geometry +{} -compress LZW{} {}.tif".format(
+        runCmd("montage -font DejaVu-Sans -pointsize {} -label '{}' {} -geometry +{} -compress LZW{} {}.tif".format(
             int((ratio*width)/111*9+0.5),
             ipair,
             os.path.join(odir, 'out.ppm'),

--- a/contrib/stack/topsStack/plotIonPairs.py
+++ b/contrib/stack/topsStack/plotIonPairs.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     for ipair in pairs:
         ion = os.path.join(idir, ipair, 'ion_cal', 'filt.ion')
         runCmd('mdx {} -s {} -rhdr {} -cmap cmy -wrap 6.283185307179586 -addr -3.141592653589793 -P -workdir {}'.format(ion, width, width*4, odir))
-        runCmd("montage -pointsize {} -label '{}' {} -geometry +{} -compress LZW{} {}.tif".format(
+        runCmd("montage -font DejaVu-Sans -pointsize {} -label '{}' {} -geometry +{} -compress LZW{} {}.tif".format(
             int((ratio*width)/111*9+0.5),
             ipair,
             os.path.join(odir, 'out.ppm'),


### PR DESCRIPTION
- Added `-font DejaVu-Sans` in line 89 on [plotIonPairs.py](https://github.com/isce-framework/isce2/blob/main/contrib/stack/topsStack/plotIonPairs.py) and [plotIonDates.py](https://github.com/isce-framework/isce2/blob/main/contrib/stack/topsStack/plotIonDates.py) due to an error similar with https://github.com/isce-framework/isce2/pull/687