### PR TITLE
fix some incorrect pointer types as required by newer gcc compilers

### DIFF
--- a/contrib/Snaphu/include/snaphu.h
+++ b/contrib/Snaphu/include/snaphu.h
@@ -141,11 +141,11 @@
 #define DEF_NLOOKSAZ         5
 #define DEF_NLOOKSOTHER      1
 #define DEF_NCORRLOOKS       23.8
-#define DEF_NCORRLOOKSRANGE  3  
+#define DEF_NCORRLOOKSRANGE  3
 #define DEF_NCORRLOOKSAZ     15
 #define DEF_NEARRANGE        831000.0
 #define DEF_DR               8.0
-#define DEF_DA               20.0 
+#define DEF_DA               20.0
 #define DEF_RANGERES         10.0
 #define DEF_AZRES            6.0
 #define DEF_LAMBDA           0.0565647
@@ -158,7 +158,7 @@
 #define DEF_DZRCRITFACTOR    2.0
 #define DEF_SHADOW           FALSE
 #define DEF_DZEIMIN          -4.0
-#define DEF_LAYWIDTH         16 
+#define DEF_LAYWIDTH         16
 #define DEF_LAYMINEI         1.25
 #define DEF_SLOPERATIOFACTOR 1.18
 #define DEF_SIGSQEI          100.0
@@ -180,8 +180,8 @@
 
 #define DEF_DZLAYPEAK        -2.0
 #define DEF_AZDZFACTOR       0.99
-#define DEF_DZEIFACTOR       4.0 
-#define DEF_DZEIWEIGHT       0.5 
+#define DEF_DZEIFACTOR       4.0
+#define DEF_DZEIWEIGHT       0.5
 #define DEF_DZLAYFACTOR      1.0
 #define DEF_LAYCONST         0.9
 #define DEF_LAYFALLOFFCONST  2.0
@@ -210,8 +210,8 @@
 #define DEF_INITDZR          2048.0
 #define DEF_INITDZSTEP       100.0
 #define DEF_MAXCOST          1000.0
-#define DEF_COSTSCALE        100.0 
-#define DEF_COSTSCALEAMBIGHT 80.0 
+#define DEF_COSTSCALE        100.0
+#define DEF_COSTSCALEAMBIGHT 80.0
 #define DEF_DNOMINCANGLE     0.01
 #define DEF_SRCROW           -1
 #define DEF_SRCCOL           -1
@@ -479,12 +479,12 @@ typedef struct paramST{
   signed char transmitmode; /* transmit mode (PINGPONG or SINGLEANTTRANSMIT) */
   double baseline;        /* baseline length (meters, always postive) */
   double baselineangle;   /* baseline angle above horizontal (rad) */
-  long nlooksrange;       /* number of looks in range for input data */ 
-  long nlooksaz;          /* number of looks in azimuth for input data */ 
-  long nlooksother;       /* number of nonspatial looks for input data */ 
+  long nlooksrange;       /* number of looks in range for input data */
+  long nlooksaz;          /* number of looks in azimuth for input data */
+  long nlooksother;       /* number of nonspatial looks for input data */
   double ncorrlooks;      /* number of independent looks in correlation est */
-  long ncorrlooksrange;   /* number of looks in range for correlation */ 
-  long ncorrlooksaz;      /* number of looks in azimuth for correlation */ 
+  long ncorrlooksrange;   /* number of looks in range for correlation */
+  long ncorrlooksaz;      /* number of looks in azimuth for correlation */
   double nearrange;       /* slant range to near part of swath (meters) */
   double dr;              /* range bin spacing (meters) */
   double da;              /* azimuth bin spacing (meters) */
@@ -585,7 +585,7 @@ typedef struct paramST{
   long conncompthresh;    /* cost threshold for connected component */
   long maxncomps;         /* max number of connected components */
 
-  
+
 }paramT;
 
 
@@ -650,186 +650,186 @@ typedef double totalcostT;            /* typedef long long totalcostT; */
 
 /* functions in snaphu.c */
 
-void Unwrap(infileT *infiles, outfileT *outfiles, paramT *params, 
+void Unwrap(infileT *infiles, outfileT *outfiles, paramT *params,
 	    long linelen, long nlines);
-void UnwrapTile(infileT *infiles, outfileT *outfiles, paramT *params, 
+void UnwrapTile(infileT *infiles, outfileT *outfiles, paramT *params,
 		tileparamT *tileparams, long nlines, long linelen);
 
 
 /* functions in snaphu_tile.c */
 
-void SetupTile(long nlines, long linelen, paramT *params, 
-	       tileparamT *tileparams, outfileT *outfiles, 
+void SetupTile(long nlines, long linelen, paramT *params,
+	       tileparamT *tileparams, outfileT *outfiles,
 	       outfileT *tileoutfiles, long tilerow, long tilecol);
-void GrowRegions(void **costs, short **flows, long nrow, long ncol, 
+void GrowRegions(void **costs, short **flows, long nrow, long ncol,
 		 incrcostT **incrcosts, outfileT *outfiles, paramT *params);
-void GrowConnCompsMask(void **costs, short **flows, long nrow, long ncol, 
-		       incrcostT **incrcosts, outfileT *outfiles, 
+void GrowConnCompsMask(void **costs, short **flows, long nrow, long ncol,
+		       incrcostT **incrcosts, outfileT *outfiles,
 		       paramT *params);
 long ThickenCosts(incrcostT **incrcosts, long nrow, long ncol);
-nodeT *RegionsNeighborNode(nodeT *node1, long *arcnumptr, nodeT **nodes, 
-			   long *arcrowptr, long *arccolptr, 
+nodeT *RegionsNeighborNode(nodeT *node1, long *arcnumptr, nodeT **nodes,
+			   long *arcrowptr, long *arccolptr,
 			   long nrow, long ncol);
 void ClearBuckets(bucketT *bkts);
-void MergeRegions(nodeT **nodes, nodeT *source, long *regionsizes, 
+void MergeRegions(nodeT **nodes, nodeT *source, long *regionsizes,
 		  long closestregion, long nrow, long ncol);
-void RenumberRegion(nodeT **nodes, nodeT *source, long newnum, 
+void RenumberRegion(nodeT **nodes, nodeT *source, long newnum,
 		    long nrow, long ncol);
-void AssembleTiles(outfileT *outfiles, paramT *params, 
+void AssembleTiles(outfileT *outfiles, paramT *params,
 		   long nlines, long linelen);
 void ReadNextRegion(long tilerow, long tilecol, long nlines, long linelen,
-		    outfileT *outfiles, paramT *params, 
+		    outfileT *outfiles, paramT *params,
 		    short ***nextregionsptr, float ***nextunwphaseptr,
-		    void ***nextcostsptr, 
+		    void ***nextcostsptr,
 		    long *nextnrowptr, long *nextncolptr);
-void SetTileReadParams(tileparamT *tileparams, long nexttilenlines, 
-		       long nexttilelinelen, long tilerow, long tilecol, 
+void SetTileReadParams(tileparamT *tileparams, long nexttilenlines,
+		       long nexttilelinelen, long tilerow, long tilecol,
 		       long nlines, long linelen, paramT *params);
-void ReadEdgesAboveAndBelow(long tilerow, long tilecol, long nlines, 
-			    long linelen, paramT *params, outfileT *outfiles, 
+void ReadEdgesAboveAndBelow(long tilerow, long tilecol, long nlines,
+			    long linelen, paramT *params, outfileT *outfiles,
 			    short *regionsabove, short *regionsbelow,
 			    float *unwphaseabove, float *unwphasebelow,
 			    void *costsabove, void *costsbelow);
-void TraceRegions(short **regions, short **nextregions, short **lastregions, 
-		  short *regionsabove, short *regionsbelow, float **unwphase, 
-		  float **nextunwphase, float **lastunwphase, 
-		  float *unwphaseabove, float *unwphasebelow, void **costs, 
-		  void **nextcosts, void **lastcosts, void *costsabove, 
+void TraceRegions(short **regions, short **nextregions, short **lastregions,
+		  short *regionsabove, short *regionsbelow, float **unwphase,
+		  float **nextunwphase, float **lastunwphase,
+		  float *unwphaseabove, float *unwphasebelow, void **costs,
+		  void **nextcosts, void **lastcosts, void *costsabove,
 		  void *costsbelow, long prevnrow, long prevncol, long tilerow,
 		  long tilecol, long nrow, long ncol, nodeT **scndrynodes,
-		  nodesuppT **nodesupp, scndryarcT **scndryarcs, 
-		  long ***scndrycosts, short *nscndrynodes, 
-		  short *nscndryarcs, long *totarclens, short **bulkoffsets, 
+		  nodesuppT **nodesupp, scndryarcT **scndryarcs,
+		  long ***scndrycosts, short *nscndrynodes,
+		  short *nscndryarcs, long *totarclens, short **bulkoffsets,
 		  paramT *params);
-long FindNumPathsOut(nodeT *from, paramT *params, long tilerow, long tilecol, 
-		     long nnrow, long nncol, short **regions, 
+long FindNumPathsOut(nodeT *from, paramT *params, long tilerow, long tilecol,
+		     long nnrow, long nncol, short **regions,
 		     short **nextregions, short **lastregions,
 		     short *regionsabove, short *regionsbelow, long prevncol);
-void RegionTraceCheckNeighbors(nodeT *from, nodeT **nextnodeptr, 
-			       nodeT **primarynodes, short **regions, 
-			       short **nextregions, short **lastregions, 
-			       short *regionsabove, short *regionsbelow,  
-			       long tilerow, long tilecol, long nnrow, 
-			       long nncol, nodeT **scndrynodes, 
-			       nodesuppT **nodesupp, scndryarcT **scndryarcs, 
-			       long *nnewnodesptr, long *nnewarcsptr, 
-			       long flowmax, long nrow, long ncol, 
-			       long prevnrow, long prevncol, paramT *params, 
-			       void **costs, void **rightedgecosts, 
-			       void **loweredgecosts, void **leftedgecosts, 
-			       void **upperedgecosts, short **flows, 
+void RegionTraceCheckNeighbors(nodeT *from, nodeT **nextnodeptr,
+			       nodeT **primarynodes, short **regions,
+			       short **nextregions, short **lastregions,
+			       short *regionsabove, short *regionsbelow,
+			       long tilerow, long tilecol, long nnrow,
+			       long nncol, nodeT **scndrynodes,
+			       nodesuppT **nodesupp, scndryarcT **scndryarcs,
+			       long *nnewnodesptr, long *nnewarcsptr,
+			       long flowmax, long nrow, long ncol,
+			       long prevnrow, long prevncol, paramT *params,
+			       void **costs, void **rightedgecosts,
+			       void **loweredgecosts, void **leftedgecosts,
+			       void **upperedgecosts, short **flows,
 			       short **rightedgeflows, short **loweredgeflows,
 			       short **leftedgeflows, short **upperedgeflows,
-			       long ***scndrycosts, 
-			       nodeT ***updatednontilenodesptr, 
-			       long *nupdatednontilenodesptr, 
+			       long ***scndrycosts,
+			       nodeT ***updatednontilenodesptr,
+			       long *nupdatednontilenodesptr,
 			       long *updatednontilenodesizeptr,
-			       short **inontilenodeoutarcptr, 
+			       short **inontilenodeoutarcptr,
 			       long *totarclenptr);
-void SetUpperEdge(long ncol, long tilerow, long tilecol, void **voidcosts, 
-		  void *voidcostsabove, float **unwphase, 
-		  float *unwphaseabove, void **voidupperedgecosts, 
+void SetUpperEdge(long ncol, long tilerow, long tilecol, void **voidcosts,
+		  void *voidcostsabove, float **unwphase,
+		  float *unwphaseabove, void **voidupperedgecosts,
 		  short **upperedgeflows, paramT *params, short **bulkoffsets);
-void SetLowerEdge(long nrow, long ncol, long tilerow, long tilecol, 
-		  void **voidcosts, void *voidcostsbelow, 
-		  float **unwphase, float *unwphasebelow, 
-		  void **voidloweredgecosts, short **loweredgeflows, 
+void SetLowerEdge(long nrow, long ncol, long tilerow, long tilecol,
+		  void **voidcosts, void *voidcostsbelow,
+		  float **unwphase, float *unwphasebelow,
+		  void **voidloweredgecosts, short **loweredgeflows,
 		  paramT *params, short **bulkoffsets);
-void SetLeftEdge(long nrow, long prevncol, long tilerow, long tilecol, 
-		 void **voidcosts, void **voidlastcosts, float **unwphase, 
-		 float **lastunwphase, void **voidleftedgecosts, 
+void SetLeftEdge(long nrow, long prevncol, long tilerow, long tilecol,
+		 void **voidcosts, void **voidlastcosts, float **unwphase,
+		 float **lastunwphase, void **voidleftedgecosts,
 		 short **leftedgeflows, paramT *params, short **bulkoffsets);
-void SetRightEdge(long nrow, long ncol, long tilerow, long tilecol, 
-		  void **voidcosts, void **voidnextcosts, 
-		  float **unwphase, float **nextunwphase, 
-		  void **voidrightedgecosts, short **rightedgeflows, 
+void SetRightEdge(long nrow, long ncol, long tilerow, long tilecol,
+		  void **voidcosts, void **voidnextcosts,
+		  float **unwphase, float **nextunwphase,
+		  void **voidrightedgecosts, short **rightedgeflows,
 		  paramT *params, short **bulkoffsets);
-void TraceSecondaryArc(nodeT *primaryhead, nodeT **scndrynodes, 
-		       nodesuppT **nodesupp, scndryarcT **scndryarcs, 
-		       long ***scndrycosts, long *nnewnodesptr, 
-		       long *nnewarcsptr, long tilerow, long tilecol, 
-		       long flowmax, long nrow, long ncol, 
-		       long prevnrow, long prevncol, paramT *params, 
-		       void **tilecosts, void **rightedgecosts, 
+void TraceSecondaryArc(nodeT *primaryhead, nodeT **scndrynodes,
+		       nodesuppT **nodesupp, scndryarcT **scndryarcs,
+		       long ***scndrycosts, long *nnewnodesptr,
+		       long *nnewarcsptr, long tilerow, long tilecol,
+		       long flowmax, long nrow, long ncol,
+		       long prevnrow, long prevncol, paramT *params,
+		       void **tilecosts, void **rightedgecosts,
 		       void **loweredgecosts, void **leftedgecosts,
-		       void **upperedgecosts, short **tileflows, 
-		       short **rightedgeflows, short **loweredgeflows, 
+		       void **upperedgecosts, short **tileflows,
+		       short **rightedgeflows, short **loweredgeflows,
 		       short **leftedgeflows, short **upperedgeflows,
-		       nodeT ***updatednontilenodesptr, 
-		       long *nupdatednontilenodesptr, 
+		       nodeT ***updatednontilenodesptr,
+		       long *nupdatednontilenodesptr,
 		       long *updatednontilenodesizeptr,
 		       short **inontilenodeoutarcptr, long *totarclenptr);
-nodeT *FindScndryNode(nodeT **scndrynodes, nodesuppT **nodesupp, 
+nodeT *FindScndryNode(nodeT **scndrynodes, nodesuppT **nodesupp,
 		      long tilenum, long primaryrow, long primarycol);
-void IntegrateSecondaryFlows(long linelen, long nlines, nodeT **scndrynodes, 
-			     nodesuppT **nodesupp, scndryarcT **scndryarcs, 
-			     short *nscndryarcs, short **scndryflows, 
-			     short **bulkoffsets, outfileT *outfiles, 
+void IntegrateSecondaryFlows(long linelen, long nlines, nodeT **scndrynodes,
+			     nodesuppT **nodesupp, scndryarcT **scndryarcs,
+			     short *nscndryarcs, short **scndryflows,
+			     short **bulkoffsets, outfileT *outfiles,
 			     paramT *params);
-void ParseSecondaryFlows(long tilenum, short *nscndryarcs, short **tileflows, 
-			 short **regions, short **scndryflows, 
-			 nodesuppT **nodesupp, scndryarcT **scndryarcs, 
+void ParseSecondaryFlows(long tilenum, short *nscndryarcs, short **tileflows,
+			 short **regions, short **scndryflows,
+			 nodesuppT **nodesupp, scndryarcT **scndryarcs,
 			 long nrow, long ncol, long ntilerow, long ntilecol,
 			 paramT *params);
 
 
 /* functions in snaphu_solver.c */
 
-long TreeSolve(nodeT **nodes, nodesuppT **nodesupp, nodeT *ground, 
-	       nodeT *source, candidateT **candidatelistptr, 
+long TreeSolve(nodeT **nodes, nodesuppT **nodesupp, nodeT *ground,
+	       nodeT *source, candidateT **candidatelistptr,
 	       candidateT **candidatebagptr, long *candidatelistsizeptr,
-	       long *candidatebagsizeptr, bucketT *bkts, short **flows, 
-	       void **costs, incrcostT **incrcosts, nodeT ***apexes, 
-	       signed char **iscandidate, long ngroundarcs, long nflow, 
-	       float **mag, float **wrappedphase, char *outfile, 
-	       long nnoderow, short *nnodesperrow, long narcrow, 
+	       long *candidatebagsizeptr, bucketT *bkts, short **flows,
+	       void **costs, incrcostT **incrcosts, nodeT ***apexes,
+	       signed char **iscandidate, long ngroundarcs, long nflow,
+	       float **mag, float **wrappedphase, char *outfile,
+	       long nnoderow, short *nnodesperrow, long narcrow,
 	       short *narcsperrow, long nrow, long ncol,
 	       outfileT *outfiles, paramT *params);
-void AddNewNode(nodeT *from, nodeT *to, long arcdir, bucketT *bkts, 
-		long nflow, incrcostT **incrcosts, long arcrow, long arccol, 
+void AddNewNode(nodeT *from, nodeT *to, long arcdir, bucketT *bkts,
+		long nflow, incrcostT **incrcosts, long arcrow, long arccol,
 		paramT *params);
-void CheckArcReducedCost(nodeT *from, nodeT *to, nodeT *apex, 
-			 long arcrow, long arccol, long arcdir, 
-			 long nflow, nodeT **nodes, nodeT *ground, 
-			 candidateT **candidatebagptr, 
-			 long *candidatebagnextptr, 
-			 long *candidatebagsizeptr, incrcostT **incrcosts, 
+void CheckArcReducedCost(nodeT *from, nodeT *to, nodeT *apex,
+			 long arcrow, long arccol, long arcdir,
+			 long nflow, nodeT **nodes, nodeT *ground,
+			 candidateT **candidatebagptr,
+			 long *candidatebagnextptr,
+			 long *candidatebagsizeptr, incrcostT **incrcosts,
 			 signed char **iscandidate, paramT *params);
-long InitTree(nodeT *source, nodeT **nodes, nodesuppT **nodesupp, 
-	      nodeT *ground, long ngroundarcs, bucketT *bkts, long nflow, 
-	      incrcostT **incrcosts, nodeT ***apexes, 
-	      signed char **iscandidate, long nnoderow, short *nnodesperrow, 
-	      long narcrow, short *narcsperrow, long nrow, long ncol, 
+long InitTree(nodeT *source, nodeT **nodes, nodesuppT **nodesupp,
+	      nodeT *ground, long ngroundarcs, bucketT *bkts, long nflow,
+	      incrcostT **incrcosts, nodeT ***apexes,
+	      signed char **iscandidate, long nnoderow, short *nnodesperrow,
+	      long narcrow, short *narcsperrow, long nrow, long ncol,
 	      paramT *params);
 nodeT *FindApex(nodeT *from, nodeT *to);
 int CandidateCompare(const void *c1, const void *c2);
 nodeT *NeighborNodeGrid(nodeT *node1, long arcnum, long *upperarcnumptr,
-			nodeT **nodes, nodeT *ground, long *arcrowptr, 
-			long *arccolptr, long *arcdirptr, long nrow, 
+			nodeT **nodes, nodeT *ground, long *arcrowptr,
+			long *arccolptr, long *arcdirptr, long nrow,
 			long ncol, nodesuppT **nodesupp);
 nodeT *NeighborNodeNonGrid(nodeT *node1, long arcnum, long *upperarcnumptr,
-			   nodeT **nodes, nodeT *ground, long *arcrowptr, 
-			   long *arccolptr, long *arcdirptr, long nrow, 
+			   nodeT **nodes, nodeT *ground, long *arcrowptr,
+			   long *arccolptr, long *arcdirptr, long nrow,
 			   long ncol, nodesuppT **nodesupp);
-void GetArcGrid(nodeT *from, nodeT *to, long *arcrow, long *arccol, 
+void GetArcGrid(nodeT *from, nodeT *to, long *arcrow, long *arccol,
 		long *arcdir, long nrow, long ncol, nodesuppT **nodesupp);
-void GetArcNonGrid(nodeT *from, nodeT *to, long *arcrow, long *arccol, 
+void GetArcNonGrid(nodeT *from, nodeT *to, long *arcrow, long *arccol,
 		   long *arcdir, long nrow, long ncol, nodesuppT **nodesupp);
-void NonDegenUpdateChildren(nodeT *startnode, nodeT *lastnode, 
-			    nodeT *nextonpath, long dgroup, 
+void NonDegenUpdateChildren(nodeT *startnode, nodeT *lastnode,
+			    nodeT *nextonpath, long dgroup,
 			    long ngroundarcs, long nflow, nodeT **nodes,
-			    nodesuppT **nodesupp, nodeT *ground, 
-			    nodeT ***apexes, incrcostT **incrcosts, 
+			    nodesuppT **nodesupp, nodeT *ground,
+			    nodeT ***apexes, incrcostT **incrcosts,
 			    long nrow, long ncol, paramT *params);
-void InitNetwork(short **flows, long *ngroundarcsptr, long *ncycleptr, 
-		 long *nflowdoneptr, long *mostflowptr, long *nflowptr, 
-		 long *candidatebagsizeptr, candidateT **candidatebagptr, 
-		 long *candidatelistsizeptr, candidateT **candidatelistptr, 
-		 signed char ***iscandidateptr, nodeT ****apexesptr, 
-		 bucketT **bktsptr, long *iincrcostfileptr, 
-		 incrcostT ***incrcostsptr, nodeT ***nodesptr, nodeT *ground, 
+void InitNetwork(short **flows, long *ngroundarcsptr, long *ncycleptr,
+		 long *nflowdoneptr, long *mostflowptr, long *nflowptr,
+		 long *candidatebagsizeptr, candidateT **candidatebagptr,
+		 long *candidatelistsizeptr, candidateT **candidatelistptr,
+		 signed char ***iscandidateptr, nodeT ****apexesptr,
+		 bucketT **bktsptr, long *iincrcostfileptr,
+		 incrcostT ***incrcostsptr, nodeT ***nodesptr, nodeT *ground,
 		 long *nnoderowptr, short **nnodesperrowptr, long *narcrowptr,
-		 short **narcsperrowptr, long nrow, long ncol, 
+		 short **narcsperrowptr, long nrow, long ncol,
 		 signed char *notfirstloopptr, totalcostT *totalcostptr,
 		 paramT *params);
 void InitNodeNums(long nrow, long ncol, nodeT **nodes, nodeT *ground);
@@ -840,104 +840,104 @@ void BucketRemove(nodeT *node, long ind, bucketT *bkts);
 nodeT *ClosestNode(bucketT *bkts);
 nodeT *ClosestNodeCircular(bucketT *bkts);
 nodeT *MinOutCostNode(bucketT *bkts);
-nodeT *SelectSource(nodeT **nodes, nodeT *ground, long nflow, 
-		    short **flows, long ngroundarcs, 
+nodeT *SelectSource(nodeT **nodes, nodeT *ground, long nflow,
+		    short **flows, long ngroundarcs,
 		    long nrow, long ncol, paramT *params);
-short GetCost(incrcostT **incrcosts, long arcrow, long arccol, 
+short GetCost(incrcostT **incrcosts, long arcrow, long arccol,
 	      long arcdir);
-long ReCalcCost(void **costs, incrcostT **incrcosts, long flow, 
-		long arcrow, long arccol, long nflow, long nrow, 
+long ReCalcCost(void **costs, incrcostT **incrcosts, long flow,
+		long arcrow, long arccol, long nflow, long nrow,
 		paramT *params);
 void SetupIncrFlowCosts(void **costs, incrcostT **incrcosts, short **flows,
-			long nflow, long nrow, long narcrow, 
+			long nflow, long nrow, long narcrow,
 			short *narcsperrow, paramT *params);
 totalcostT EvaluateTotalCost(void **costs, short **flows, long nrow, long ncol,
 			     short *narcsperrow,paramT *params);
-void MSTInitFlows(float **wrappedphase, short ***flowsptr, 
-		  short **mstcosts, long nrow, long ncol, 
+void MSTInitFlows(float **wrappedphase, short ***flowsptr,
+		  short **mstcosts, long nrow, long ncol,
 		  nodeT ***nodes, nodeT *ground, long maxflow);
-void SolveMST(nodeT **nodes, nodeT *source, nodeT *ground, 
-	      bucketT *bkts, short **mstcosts, signed char **residue, 
+void SolveMST(nodeT **nodes, nodeT *source, nodeT *ground,
+	      bucketT *bkts, short **mstcosts, signed char **residue,
 	      signed char **arcstatus, long nrow, long ncol);
 long DischargeTree(nodeT *source, short **mstcosts, short **flows,
-		   signed char **residue, signed char **arcstatus, 
+		   signed char **residue, signed char **arcstatus,
 		   nodeT **nodes, nodeT *ground, long nrow, long ncol);
-signed char ClipFlow(signed char **residue, short **flows, 
-		     short **mstcosts, long nrow, long ncol, 
+signed char ClipFlow(signed char **residue, short **flows,
+		     short **mstcosts, long nrow, long ncol,
 		     long maxflow);
-void MCFInitFlows(float **wrappedphase, short ***flowsptr, short **mstcosts, 
+void MCFInitFlows(float **wrappedphase, short ***flowsptr, short **mstcosts,
 		  long nrow, long ncol, long cs2scalefactor);
 
 
 /* functions in snaphu_cost.c */
 
-void BuildCostArrays(void ***costsptr, short ***mstcostsptr, 
-		     float **mag, float **wrappedphase, 
-		     float **unwrappedest, long linelen, long nlines, 
-		     long nrow, long ncol, paramT *params, 
-		     tileparamT *tileparams, infileT *infiles, 
+void BuildCostArrays(void ***costsptr, short ***mstcostsptr,
+		     float **mag, float **wrappedphase,
+		     float **unwrappedest, long linelen, long nlines,
+		     long nrow, long ncol, paramT *params,
+		     tileparamT *tileparams, infileT *infiles,
 		     outfileT *outfiles);
-void **BuildStatCostsTopo(float **wrappedphase, float **mag, 
-			  float **unwrappedest, float **pwr, 
+void **BuildStatCostsTopo(float **wrappedphase, float **mag,
+			  float **unwrappedest, float **pwr,
 			  float **corr, short **rowweight, short **colweight,
-			  long nrow, long ncol, tileparamT *tileparams, 
+			  long nrow, long ncol, tileparamT *tileparams,
 			  outfileT *outfiles, paramT *params);
-void **BuildStatCostsDefo(float **wrappedphase, float **mag, 
-			  float **unwrappedest, float **corr, 
+void **BuildStatCostsDefo(float **wrappedphase, float **mag,
+			  float **unwrappedest, float **corr,
 			  short **rowweight, short **colweight,
-			  long nrow, long ncol, tileparamT *tileparams, 
+			  long nrow, long ncol, tileparamT *tileparams,
 			  outfileT *outfiles, paramT *params);
-void **BuildStatCostsSmooth(float **wrappedphase, float **mag, 
-			    float **unwrappedest, float **corr, 
+void **BuildStatCostsSmooth(float **wrappedphase, float **mag,
+			    float **unwrappedest, float **corr,
 			    short **rowweight, short **colweight,
-			    long nrow, long ncol, tileparamT *tileparams, 
+			    long nrow, long ncol, tileparamT *tileparams,
 			    outfileT *outfiles, paramT *params);
-void GetIntensityAndCorrelation(float **mag, float **wrappedphase, 
-				float ***pwrptr, float ***corrptr, 
+void GetIntensityAndCorrelation(float **mag, float **wrappedphase,
+				float ***pwrptr, float ***corrptr,
 				infileT *infiles, long linelen, long nlines,
-				long nrow, long ncol, outfileT *outfiles, 
+				long nrow, long ncol, outfileT *outfiles,
 				paramT *params, tileparamT *tileparams);
-void RemoveMean(float **ei, long nrow, long ncol, 
+void RemoveMean(float **ei, long nrow, long ncol,
                 long krowei, long kcolei);
-float *BuildDZRCritLookupTable(double *nominc0ptr, double *dnomincptr, 
+float *BuildDZRCritLookupTable(double *nominc0ptr, double *dnomincptr,
 			       long *tablesizeptr, tileparamT *tileparams,
 			       paramT *params);
-double SolveDZRCrit(double sinnomincangle, double cosnomincangle, 
+double SolveDZRCrit(double sinnomincangle, double cosnomincangle,
 		    paramT *params, double threshold);
-void SolveEIModelParams(double *slope1ptr, double *slope2ptr, 
-			double *const1ptr, double *const2ptr, 
-			double dzrcrit, double dzr0, double sinnomincangle, 
+void SolveEIModelParams(double *slope1ptr, double *slope2ptr,
+			double *const1ptr, double *const2ptr,
+			double dzrcrit, double dzr0, double sinnomincangle,
 			double cosnomincangle, paramT *params);
 double EIofDZR(double dzr, double sinnomincangle, double cosnomincangle,
 	       paramT *params);
-float **BuildDZRhoMaxLookupTable(double nominc0, double dnominc, 
-				 long nominctablesize, double rhomin, 
+float **BuildDZRhoMaxLookupTable(double nominc0, double dnominc,
+				 long nominctablesize, double rhomin,
 				 double drho, long nrho, paramT *params);
-double CalcDZRhoMax(double rho, double nominc, paramT *params, 
+double CalcDZRhoMax(double rho, double nominc, paramT *params,
 		    double threshold);
-void CalcCostTopo(void **costs, long flow, long arcrow, long arccol, 
-		  long nflow, long nrow, paramT *params, 
+void CalcCostTopo(void **costs, long flow, long arcrow, long arccol,
+		  long nflow, long nrow, paramT *params,
 		  long *poscostptr, long *negcostptr);
-void CalcCostDefo(void **costs, long flow, long arcrow, long arccol, 
-		  long nflow, long nrow, paramT *params, 
+void CalcCostDefo(void **costs, long flow, long arcrow, long arccol,
+		  long nflow, long nrow, paramT *params,
 		  long *poscostptr, long *negcostptr);
-void CalcCostSmooth(void **costs, long flow, long arcrow, long arccol, 
-		    long nflow, long nrow, paramT *params, 
+void CalcCostSmooth(void **costs, long flow, long arcrow, long arccol,
+		    long nflow, long nrow, paramT *params,
 		    long *poscostptr, long *negcostptr);
-void CalcCostL0(void **costs, long flow, long arcrow, long arccol, 
-		long nflow, long nrow, paramT *params, 
+void CalcCostL0(void **costs, long flow, long arcrow, long arccol,
+		long nflow, long nrow, paramT *params,
 		long *poscostptr, long *negcostptr);
-void CalcCostL1(void **costs, long flow, long arcrow, long arccol, 
-		long nflow, long nrow, paramT *params, 
+void CalcCostL1(void **costs, long flow, long arcrow, long arccol,
+		long nflow, long nrow, paramT *params,
 		long *poscostptr, long *negcostptr);
-void CalcCostL2(void **costs, long flow, long arcrow, long arccol, 
-		long nflow, long nrow, paramT *params, 
+void CalcCostL2(void **costs, long flow, long arcrow, long arccol,
+		long nflow, long nrow, paramT *params,
 		long *poscostptr, long *negcostptr);
-void CalcCostLP(void **costs, long flow, long arcrow, long arccol, 
-		long nflow, long nrow, paramT *params, 
+void CalcCostLP(void **costs, long flow, long arcrow, long arccol,
+		long nflow, long nrow, paramT *params,
 		long *poscostptr, long *negcostptr);
-void CalcCostNonGrid(void **costs, long flow, long arcrow, long arccol, 
-		     long nflow, long nrow, paramT *params, 
+void CalcCostNonGrid(void **costs, long flow, long arcrow, long arccol,
+		     long nflow, long nrow, paramT *params,
 		     long *poscostptr, long *negcostptr);
 long EvalCostTopo(void **costs, short **flows, long arcrow, long arccol,
 		  long nrow, paramT *params);
@@ -953,7 +953,7 @@ long EvalCostL2(void **costs, short **flows, long arcrow, long arccol,
 		long nrow, paramT *params);
 long EvalCostLP(void **costs, short **flows, long arcrow, long arccol,
 		long nrow, paramT *params);
-long EvalCostNonGrid(void **costs, short **flows, long arcrow, long arccol, 
+long EvalCostNonGrid(void **costs, short **flows, long arcrow, long arccol,
 		     long nrow, paramT *params);
 void CalcInitMaxFlow(paramT *params, void **costs, long nrow, long ncol);
 
@@ -970,12 +970,12 @@ void CalcWrappedRangeDiffs(float **dpsi, float **avgdpsi, float **wrappedphase,
 			   long nrow, long ncol);
 void CalcWrappedAzDiffs(float **dpsi, float **avgdpsi, float **wrappedphase,
 			long kperpdpsi, long kpardpsi, long nrow, long ncol);
-void CycleResidue(float **phase, signed char **residue, 
+void CycleResidue(float **phase, signed char **residue,
 		  int nrow, int ncol);
 void CalcFlow(float **phase, short ***flowsptr, long nrow, long ncol);
 void IntegratePhase(float **psi, float **phi, short **flows,
 		    long nrow, long ncol);
-float **ExtractFlow(float **unwrappedphase, short ***flowsptr, 
+float **ExtractFlow(float **unwrappedphase, short ***flowsptr,
 		    long nrow, long ncol);
 void FlipPhaseArraySign(float **arr, paramT *params, long nrow, long ncol);
 void FlipFlowArraySign(short **arr, paramT *params, long nrow, long ncol);
@@ -988,18 +988,18 @@ void *ReAlloc(void *ptr, size_t size);
 void Free2DArray(void **array, unsigned int nrow);
 void Set2DShortArray(short **arr, long nrow, long ncol, long value);
 signed char ValidDataArray(float **arr, long nrow, long ncol);
-signed char IsFinite(double d);
+int IsFinite(double d);
 long LRound(double a);
 long Short2DRowColAbsMax(short **arr, long nrow, long ncol);
 float LinInterp1D(float *arr, double index, long nelem);
-float LinInterp2D(float **arr, double rowind, double colind , 
+float LinInterp2D(float **arr, double rowind, double colind ,
                   long nrow, long ncol);
 void Despeckle(float **mag, float ***ei, long nrow, long ncol);
 float **MirrorPad(float **array1, long nrow, long ncol, long krow, long kcol);
-void BoxCarAvg(float **avgarr, float **padarr, long nrow, long ncol, 
+void BoxCarAvg(float **avgarr, float **padarr, long nrow, long ncol,
 	       long krow, long kcol);
 char *StrNCopy(char *dest, const char *src, size_t n);
-void FlattenWrappedPhase(float **wrappedphase, float **unwrappedest, 
+void FlattenWrappedPhase(float **wrappedphase, float **unwrappedest,
 			 long nrow, long ncol);
 void Add2DFloatArrays(float **arr1, float **arr2, long nrow, long ncol);
 int StringToDouble(char *str, double *d);
@@ -1017,62 +1017,62 @@ int LongCompare(const void *c1, const void *c2);
 void SetDefaults(infileT *infiles, outfileT *outfiles, paramT *params);
 void ProcessArgs(int argc, char *argv[], infileT *infiles, outfileT *outfiles,
 		 long *ncolptr, paramT *params);
-void CheckParams(infileT *infiles, outfileT *outfiles, 
+void CheckParams(infileT *infiles, outfileT *outfiles,
 		 long linelen, long nlines, paramT *params);
 void ReadConfigFile(char *conffile, infileT *infiles, outfileT *outfiles,
 		    long *ncolptr, paramT *params);
-void WriteConfigLogFile(int argc, char *argv[], infileT *infiles, 
+void WriteConfigLogFile(int argc, char *argv[], infileT *infiles,
 			outfileT *outfiles, long linelen, paramT *params);
 void LogStringParam(FILE *fp, char *key, char *value);
 void LogBoolParam(FILE *fp, char *key, signed char boolvalue);
 void LogFileFormat(FILE *fp, char *key, signed char fileformat);
 long GetNLines(infileT *infiles, long linelen);
-void WriteOutputFile(float **mag, float **unwrappedphase, char *outfile, 
+void WriteOutputFile(float **mag, float **unwrappedphase, char *outfile,
 		     outfileT *outfiles, long nrow, long ncol);
 FILE *OpenOutputFile(char *outfile, char *realoutfile);
-void WriteAltLineFile(float **mag, float **phase, char *outfile, 
+void WriteAltLineFile(float **mag, float **phase, char *outfile,
 		      long nrow, long ncol);
-void WriteAltSampFile(float **arr1, float **arr2, char *outfile, 
+void WriteAltSampFile(float **arr1, float **arr2, char *outfile,
 		      long nrow, long ncol);
-void Write2DArray(void **array, char *filename, long nrow, long ncol, 
+void Write2DArray(void **array, char *filename, long nrow, long ncol,
 		  size_t size);
-void Write2DRowColArray(void **array, char *filename, long nrow, 
+void Write2DRowColArray(void **array, char *filename, long nrow,
 			long ncol, size_t size);
 void ReadInputFile(infileT *infiles, float ***magptr, float ***wrappedphaseptr,
-		   short ***flowsptr, long linelen, long nlines, 
+		   short ***flowsptr, long linelen, long nlines,
 		   paramT *params, tileparamT *tileparams);
-void ReadMagnitude(float **mag, infileT *infiles, long linelen, long nlines, 
+void ReadMagnitude(float **mag, infileT *infiles, long linelen, long nlines,
 		   tileparamT *tileparams);
-void ReadUnwrappedEstimateFile(float ***unwrappedestptr, infileT *infiles, 
-			       long linelen, long nlines, 
+void ReadUnwrappedEstimateFile(float ***unwrappedestptr, infileT *infiles,
+			       long linelen, long nlines,
 			       paramT *params, tileparamT *tileparams);
-void ReadWeightsFile(short ***weightsptr,char *weightfile, 
+void ReadWeightsFile(short ***weightsptr,char *weightfile,
 		     long linelen, long nlines, tileparamT *tileparams);
-void ReadIntensity(float ***pwrptr, float ***pwr1ptr, float ***pwr2ptr, 
-		   infileT *infiles, long linelen, long nlines, 
+void ReadIntensity(float ***pwrptr, float ***pwr1ptr, float ***pwr2ptr,
+		   infileT *infiles, long linelen, long nlines,
 		   paramT *params, tileparamT *tileparams);
 void ReadCorrelation(float ***corrptr, infileT *infiles,
 		     long linelen, long nlines, tileparamT *tileparams);
-void ReadAltLineFile(float ***mag, float ***phase, char *alfile, 
+void ReadAltLineFile(float ***mag, float ***phase, char *alfile,
 		     long linelen, long nlines, tileparamT *tileparams);
-void ReadAltLineFilePhase(float ***phase, char *alfile, 
+void ReadAltLineFilePhase(float ***phase, char *alfile,
 			  long linelen, long nlines, tileparamT *tileparams);
-void ReadComplexFile(float ***mag, float ***phase, char *rifile, 
+void ReadComplexFile(float ***mag, float ***phase, char *rifile,
 		     long linelen, long nlines, tileparamT *tileparams);
-void Read2DArray(void ***arr, char *infile, long linelen, long nlines, 
+void Read2DArray(void ***arr, char *infile, long linelen, long nlines,
 		 tileparamT *tileparams, size_t elptrsize, size_t elsize);
 void ReadAltSampFile(float ***arr1, float ***arr2, char *infile,
 		     long linelen, long nlines, tileparamT *tileparams);
-void Read2DRowColFile(void ***arr, char *filename, long linelen, long nlines, 
+void Read2DRowColFile(void ***arr, char *filename, long linelen, long nlines,
 		      tileparamT *tileparams, size_t size);
-void Read2DRowColFileRows(void ***arr, char *filename, long linelen, 
+void Read2DRowColFileRows(void ***arr, char *filename, long linelen,
 			  long nlines, tileparamT *tileparams, size_t size);
 void SetDumpAll(outfileT *outfiles, paramT *params);
 void SetStreamPointers(void);
 void SetVerboseOut(paramT *params);
 void ChildResetStreamPointers(pid_t pid, long tilerow, long tilecol,
 			      paramT *params);
-void DumpIncrCostFiles(incrcostT **incrcosts, long iincrcostfile, 
+void DumpIncrCostFiles(incrcostT **incrcosts, long iincrcostfile,
 		       long nflow, long nrow, long ncol);
 void MakeTileDir(paramT *params, outfileT *outfiles);
 void ParseFilename(char *filename, char *path, char *basename);
@@ -1080,7 +1080,7 @@ void ParseFilename(char *filename, char *path, char *basename);
 
 /* functions in snaphu_cs2.c  */
 
-void SolveCS2(signed char **residue, short **mstcosts, long nrow, long ncol, 
+void SolveCS2(signed char **residue, short **mstcosts, long nrow, long ncol,
 	      long cs2scalefactor, short ***flowsptr);
 
 

--- a/contrib/Snaphu/src/snaphu_io.c
+++ b/contrib/Snaphu/src/snaphu_io.c
@@ -24,6 +24,7 @@
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <time.h>
 
 #include "snaphu.h"
 

--- a/contrib/Snaphu/src/snaphu_util.c
+++ b/contrib/Snaphu/src/snaphu_util.c
@@ -23,6 +23,7 @@
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <time.h>
 
 #include "snaphu.h"
 

--- a/contrib/Snaphu/src/snaphu_util.c
+++ b/contrib/Snaphu/src/snaphu_util.c
@@ -29,7 +29,7 @@
 
 /* function: IsTrue()
  * ------------------
- * Returns TRUE if the string input is any of TRUE, True, true, 1, 
+ * Returns TRUE if the string input is any of TRUE, True, true, 1,
  * y, Y, yes, YES
  */
 int IsTrue(char *str){
@@ -46,7 +46,7 @@ int IsTrue(char *str){
 
 /* function: IsFalse()
  * ------------------
- * Returns FALSE if the string input is any of FALSE, False, false, 
+ * Returns FALSE if the string input is any of FALSE, False, false,
  * 0, n, N, no, NO
  */
 int IsFalse(char *str){
@@ -82,10 +82,10 @@ signed char SetBooleanSignedChar(signed char *boolptr, char *str){
 /* function: ModDiff()
  * -------------------
  * Computes floating point difference between two numbers.
- * f1 and f2 should be between [0,2pi).  The result is the 
+ * f1 and f2 should be between [0,2pi).  The result is the
  * modulo difference between (-pi,pi].  Assumes that
- * PI and TWOPI have been defined.  
- */  
+ * PI and TWOPI have been defined.
+ */
 double ModDiff(double f1, double f2){
 
   double f3;
@@ -184,13 +184,13 @@ void CalcWrappedAzDiffs(float **dpsi, float **avgdpsi, float **wrappedphase,
 
 /* function: CycleResidue()
  * ------------------------
- * Computes the cycle array of a phase 2D phase array. Input arrays 
- * should be type float ** and signed char ** with memory pre-allocated.  
- * Numbers of rows and columns in phase array should be passed.  
+ * Computes the cycle array of a phase 2D phase array. Input arrays
+ * should be type float ** and signed char ** with memory pre-allocated.
+ * Numbers of rows and columns in phase array should be passed.
  * Residue array will then have size nrow-1 x ncol-1.  Residues will
  * always be -1, 0, or 1 if wrapped phase is passed in.
  */
-void CycleResidue(float **phase, signed char **residue, 
+void CycleResidue(float **phase, signed char **residue,
 		  int nrow, int ncol){
 
   int row, col;
@@ -227,7 +227,7 @@ void CycleResidue(float **phase, signed char **residue,
 
 /* function: CalcFlow()
  * --------------------
- * Calculates flow based on unwrapped phase data in a 2D array.  
+ * Calculates flow based on unwrapped phase data in a 2D array.
  * Allocates memory for row and column flow arrays.
  */
 void CalcFlow(float **phase, short ***flowsptr, long nrow, long ncol){
@@ -247,7 +247,7 @@ void CalcFlow(float **phase, short ***flowsptr, long nrow, long ncol){
 					 /TWOPI);
     }
   }
-  
+
   /* get col flows (horizontal phase differences) */
   for(row=0;row<nrow;row++){
     for(col=0;col<ncol-1;col++){
@@ -264,7 +264,7 @@ void CalcFlow(float **phase, short ***flowsptr, long nrow, long ncol){
  * This function takes row and column flow information and integrates
  * wrapped phase to create an unwrapped phase field.  The unwrapped
  * phase field will be the same size as the wrapped field.  The array
- * rowflow should have size N-1xM and colflow size NxM-1 where the 
+ * rowflow should have size N-1xM and colflow size NxM-1 where the
  * phase fields are NxM.  Output is saved to a file.
  */
 void IntegratePhase(float **psi, float **phi, short **flows,
@@ -274,7 +274,7 @@ void IntegratePhase(float **psi, float **phi, short **flows,
   short **rowflow, **colflow;
   rowflow=flows;
   colflow=&(flows[nrow-1]);
- 
+
   /* set first element as seed */
   phi[0][0]=psi[0][0];
 
@@ -298,16 +298,16 @@ void IntegratePhase(float **psi, float **phi, short **flows,
 /* function: ExtractFlow()
  * -----------------------
  * Given an unwrapped phase array, parse the data and find the flows.
- * Assumes only integer numbers of cycles have been added to get the 
- * unwrapped phase from the wrapped pase.  Gets memory and writes 
+ * Assumes only integer numbers of cycles have been added to get the
+ * unwrapped phase from the wrapped pase.  Gets memory and writes
  * wrapped phase to passed pointer.  Assumes flows fit into short ints.
  */
-float **ExtractFlow(float **unwrappedphase, short ***flowsptr, 
-		    long nrow, long ncol){    
+float **ExtractFlow(float **unwrappedphase, short ***flowsptr,
+		    long nrow, long ncol){
 
   long row, col;
   float **wrappedphase;
-  
+
   /* get memory for wrapped phase array */
   wrappedphase=(float **)Get2DMem(nrow,ncol,sizeof(float *),sizeof(float));
 
@@ -377,7 +377,7 @@ void FlipFlowArraySign(short **arr, paramT *params, long nrow, long ncol){
  * --------------------
  * Allocates memory for 2D array.
  * Dynamically allocates memory and returns pointer of
- * type void ** for an array of size nrow x ncol.  
+ * type void ** for an array of size nrow x ncol.
  * First index is row number: array[row][col]
  * size is size of array element, psize is size of pointer
  * to array element (eg sizeof(float *)).
@@ -388,7 +388,7 @@ void **Get2DMem(int nrow, int ncol, int psize, size_t size){
   void **array;
 
   if((array=malloc(nrow*psize))==NULL){
-    fprintf(sp0,"Out of memory\n"); 
+    fprintf(sp0,"Out of memory\n");
     exit(ABNORMAL_EXIT);
   }
   for(row=0; row<nrow; row++){
@@ -413,7 +413,7 @@ void **Get2DRowColMem(long nrow, long ncol, int psize, size_t size){
   void **array;
 
   if((array=malloc((2*nrow-1)*psize))==NULL){
-    fprintf(sp0,"Out of memory\n"); 
+    fprintf(sp0,"Out of memory\n");
     exit(ABNORMAL_EXIT);
   }
   for(row=0; row<nrow-1; row++){
@@ -444,7 +444,7 @@ void **Get2DRowColZeroMem(long nrow, long ncol, int psize, size_t size){
   void **array;
 
   if((array=malloc((2*nrow-1)*psize))==NULL){
-    fprintf(sp0,"Out of memory\n"); 
+    fprintf(sp0,"Out of memory\n");
     exit(ABNORMAL_EXIT);
   }
   for(row=0; row<nrow-1; row++){
@@ -484,9 +484,9 @@ void *MAlloc(size_t size){
  * Has same functionality as calloc(), but exits if out of memory.
  */
 void *CAlloc(size_t nitems, size_t size){
-  
+
   void *ptr;
-  
+
   if((ptr=calloc(nitems,size))==NULL){
     fprintf(sp0,"Out of memory\n");
     exit(ABNORMAL_EXIT);
@@ -500,9 +500,9 @@ void *CAlloc(size_t nitems, size_t size){
  * Has same functionality as realloc(), but exits if out of memory.
  */
 void *ReAlloc(void *ptr, size_t size){
-  
+
   void *ptr2;
-  
+
   if((ptr2=realloc(ptr,size))==NULL){
     fprintf(sp0,"Out of memory\n");
     exit(ABNORMAL_EXIT);
@@ -568,14 +568,14 @@ signed char ValidDataArray(float **arr, long nrow, long ncol){
 
 /* function: IsFinite()
  * --------------------
- * This function takes a double and returns a nonzero value if 
+ * This function takes a double and returns a nonzero value if
  * the arguemnt is finite (not NaN and not infinite), and zero otherwise.
  * Different implementations are given here since not all machines have
  * these functions available.
  */
-signed char IsFinite(double d){
+int IsFinite(double d){
 
-  return(finite(d));
+  return(isfinite(d));
   /* return(isfinite(d)); */
   /* return(!(isnan(d) || isinf(d))); */
   /* return(TRUE) */
@@ -584,7 +584,7 @@ signed char IsFinite(double d){
 
 /* function: LRound()
  * ------------------
- * Rounds a floating point number to the nearest integer.  
+ * Rounds a floating point number to the nearest integer.
  * The function takes a float and returns a long.
  */
 long LRound(double a){
@@ -595,8 +595,8 @@ long LRound(double a){
 
 /* function: Short2DRowColAbsMax()
  * -------------------------------
- * Returns the maximum of the absolute values of element in a 
- * two-dimensional short array.  The number of rows and columns 
+ * Returns the maximum of the absolute values of element in a
+ * two-dimensional short array.  The number of rows and columns
  * should be passed in.
  */
 long Short2DRowColAbsMax(short **arr, long nrow, long ncol){
@@ -649,7 +649,7 @@ float LinInterp1D(float *arr, double index, long nelem){
  * Given a 2-D array of floats, interpolates at the specified noninteger
  * indices.  Returns first or last array values if index is out of bounds.
  */
-float LinInterp2D(float **arr, double rowind, double colind , 
+float LinInterp2D(float **arr, double rowind, double colind ,
                   long nrow, long ncol){
 
   long rowintpart;
@@ -670,7 +670,7 @@ float LinInterp2D(float **arr, double rowind, double colind ,
 
 /* function: Despeckle()
  * ---------------------
- * Filters magnitude/power data with adaptive geometric filter to get rid of 
+ * Filters magnitude/power data with adaptive geometric filter to get rid of
  * speckle.  Allocates 2D memory for ei.  Does not square before averaging.
  */
 void Despeckle(float **mag, float ***ei, long nrow, long ncol){
@@ -701,7 +701,7 @@ void Despeckle(float **mag, float ***ei, long nrow, long ncol){
     Irow=row+ARMLEN;
     for(col=0;col<ncol;col++){
       Icol=col+ARMLEN;
-      
+
       /* filter only if input is nonzero so we preserve mask info in input */
       if(intensity[Irow][Icol]==0){
 
@@ -741,7 +741,7 @@ void Despeckle(float **mag, float ***ei, long nrow, long ncol){
 	    wfull+=intensity[Irow+i][Icol-j];
 	    wfull+=intensity[Irow-i][Icol-j];
 	  }
-	} 
+	}
 	ratiomax=1;
 	for(k=1;k<=NARMS;k+=2){
 	  wstick=w[0]+w[k]+w[k+1];
@@ -755,7 +755,7 @@ void Despeckle(float **mag, float ***ei, long nrow, long ncol){
 	}
       }
     }
-  }   
+  }
 
   /* free memory */
   Free2DArray((void **)intensity,nrow+2*ARMLEN);
@@ -778,7 +778,7 @@ float **MirrorPad(float **array1, long nrow, long ncol, long krow, long kcol){
   /* get memory */
   array2=(float **)Get2DMem(nrow+2*krow,ncol+2*kcol,
 			    sizeof(float *),sizeof(float));
-  
+
   /* center array1 in new array */
   for(row=0;row<nrow;row++){
     for(col=0;col<ncol;col++){
@@ -819,7 +819,7 @@ float **MirrorPad(float **array1, long nrow, long ncol, long krow, long kcol){
         =array2[nrow+krow-2-row][col];
     }
   }
-  
+
   /* return a pointer to the padded array */
   return(array2);
 
@@ -828,12 +828,12 @@ float **MirrorPad(float **array1, long nrow, long ncol, long krow, long kcol){
 
 /* function: BoxCarAvg()
  * ---------------------
- * Takes in 2-D array, convolves with boxcar filter of size specified.  
+ * Takes in 2-D array, convolves with boxcar filter of size specified.
  * Uses a recursion technique (but the function does not actually call
- * itself recursively) to compute the result, so there may be roundoff 
+ * itself recursively) to compute the result, so there may be roundoff
  * errors.
  */
-void BoxCarAvg(float **avgarr, float **padarr, long nrow, long ncol, 
+void BoxCarAvg(float **avgarr, float **padarr, long nrow, long ncol,
 	       long krow, long kcol){
 
   long i, row, col, n;
@@ -873,11 +873,11 @@ void BoxCarAvg(float **avgarr, float **padarr, long nrow, long ncol,
 
 /* function: StrNCopy()
  * --------------------
- * Just like strncpy(), but terminates string by putting a null 
+ * Just like strncpy(), but terminates string by putting a null
  * character at the end (may overwrite last character).
  */
 char *StrNCopy(char *dest, const char *src, size_t n){
- 
+
   char *s;
 
   s=strncpy(dest,src,n-1);
@@ -892,9 +892,9 @@ char *StrNCopy(char *dest, const char *src, size_t n){
  * the unwrapped data elementwise from the wrapped data and stores
  * the result, rewrapped to [0,2pi), in the wrapped array.
  */
-void FlattenWrappedPhase(float **wrappedphase, float **unwrappedest, 
+void FlattenWrappedPhase(float **wrappedphase, float **unwrappedest,
 			 long nrow, long ncol){
- 
+
   long row, col;
 
   /* loop to subtract, rewrap, store in wrapped array. */
@@ -917,7 +917,7 @@ void FlattenWrappedPhase(float **wrappedphase, float **unwrappedest,
 void Add2DFloatArrays(float **arr1, float **arr2, long nrow, long ncol){
 
   long row, col;
- 
+
   /* loop over all rows and columns, add and store result in first array */
   for(row=0;row<nrow;row++){
     for(col=0;col<ncol;col++){
@@ -938,7 +938,7 @@ int StringToDouble(char *str, double *d){
 
   double tempdouble;
   char *endp;
-  
+
   endp=str;
   tempdouble=strtod(str,&endp);
   if(strlen(endp) || tempdouble>=HUGE_VAL || tempdouble<=-HUGE_VAL){
@@ -952,15 +952,15 @@ int StringToDouble(char *str, double *d){
 
 /* function: StringToLong()
  * ------------------------
- * Uses strtol to convert a string to a base-10 long, but also does error 
- * checking.  If any part of the string is not converted, the function does 
+ * Uses strtol to convert a string to a base-10 long, but also does error
+ * checking.  If any part of the string is not converted, the function does
  * not make the assignment and returns TRUE.  Otherwise, returns FALSE.
  */
 int StringToLong(char *str, long *l){
 
   long templong;
   char *endp;
-  
+
   endp=str;
   templong=strtol(str,&endp,10);
   if(strlen(endp) || templong==LONG_MAX || templong==LONG_MIN){
@@ -974,7 +974,7 @@ int StringToLong(char *str, long *l){
 
 /* function: CatchSignals()
  * ------------------------
- * Traps common signals that by default cause the program to abort.  
+ * Traps common signals that by default cause the program to abort.
  * Sets (pointer to function) Handler as the signal handler for all.
  * Note that SIGKILL usually cannot be caught.  No return value.
  */
@@ -997,10 +997,10 @@ void CatchSignals(void (*SigHandler)(int)){
 /* function: SetDump()
  * -------------------
  * Set the global variable dumpresults_global to TRUE if SIGINT or SIGHUP
- * signals recieved.  Also sets requestedstop_global if SIGINT signal 
- * received.  This function should only be called via signal() when 
+ * signals recieved.  Also sets requestedstop_global if SIGINT signal
+ * received.  This function should only be called via signal() when
  * a signal is caught.
- */ 
+ */
 void SetDump(int signum){
 
   if(signum==SIGINT){
@@ -1052,7 +1052,7 @@ void KillChildrenExit(int signum){
  * Signal hanlder that prints message about the signal received, then exits.
  */
 void SignalExit(int signum){
-  
+
   signal(SIGTERM,SIG_IGN);
   fprintf(sp0,"Exiting with status %d on signal %d\n",ABNORMAL_EXIT,signum);
   fflush(NULL);
@@ -1067,7 +1067,7 @@ void SignalExit(int signum){
  * DisplayElapsedTime().
  */
 void StartTimers(time_t *tstart, double *cputimestart){
-  
+
   struct rusage usagebuf;
 
   *tstart=time(NULL);
@@ -1092,8 +1092,8 @@ void StartTimers(time_t *tstart, double *cputimestart){
  * Displays the elapsed wall clock and CPU times for the process and its
  * children.  Times should be initialized at the start of the program with
  * StartTimers().  The code is written to show the total processor time
- * for the parent process and all of its children, but whether or not 
- * this is actually done depends on the implementation of the system time 
+ * for the parent process and all of its children, but whether or not
+ * this is actually done depends on the implementation of the system time
  * functions.
  */
 void DisplayElapsedTime(time_t tstart, double cputimestart){

--- a/contrib/alos2filter/src/psfilt1.c
+++ b/contrib/alos2filter/src/psfilt1.c
@@ -24,7 +24,7 @@
 #define REL_EOF   2	/* fseek relative to end of file */
 
 #define SQR(a)    ( (a)*(a) )
-#define PI	3.14159265359 
+#define PI	3.14159265359
 #define TWO_PI  6.28318530718
 #define SQRT2   1.41421356237 	/* square root of 2 */
 #define RTD	57.2957795131	/* radians to degrees */
@@ -36,12 +36,12 @@
 
 typedef struct{float re,im;} fcomplex;
 
-void fourn(float *, unsigned int *, int ndim, int isign); 
+void fourn(float *, unsigned int *, int ndim, int isign);
 void psd_wgt(fcomplex **cmp, fcomplex **seg_fft, double, int, int, int);
 
 void start_timing();					/* timing routines */
 void stop_timing();
-	
+
 unsigned int nfft[3];
 int xmin=0;						/* window column minima */
 int ymin=0;						/* window row minima */
@@ -50,7 +50,7 @@ int ymax, xmax;          /* interferogram width, window maxima */
 fcomplex **cmatrix(int nrl, int nrh, int ncl, int nch);
 void free_cmatrix(fcomplex **m, int nrl, int nrh, int ncl, int nch);
 void nrerror(char error_text[]);
-signed char IsFinite(double d);
+int IsFinite(double d);
 
 int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw, int step)
 {
@@ -62,7 +62,7 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    float *data;				/* pointer to floats for FFT, union with seg_fft */
    //double alpha;			/* exponent used to to determine spectal weighting function */
    double rw,azw;			/* range and azimuth weights used in window function */
- 
+
    int nlines=0;			/* number of lines in the file */
    int offs;				/* width and height of file segment*/
    //int fftw;       /* fft window size*/
@@ -70,10 +70,10 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    int xw,yh;				/* width, height of processed region */
    int i,j,i1,j1;			/* loop counters */
    int ndim;				/* number of dimensions of FFT */
-   int isign;				/* direction of FFT */     
+   int isign;				/* direction of FFT */
    int nlc;				/* number of guides, number of low correlation pixels */
    int lc;				/* line counter */
-    
+
    FILE *int_file, *sm_file;
 
    double psd,psd_sc;  /* power spectrum, scale factor */
@@ -88,41 +88,41 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    float sf0; // an extra factor to scale the data
    sf0  = 1.0;
 
-   
+
    fprintf(stderr,"*** Weighted power spectrum interferogram filter v1.0 clw 19-Feb-97 ***\n");
     if(0){
      //fprintf(stderr,"\nUsage: %s <interferogram> <smoothed interferogram> <width> [alpha] [fftw] [step] [xmin] [xmax] [ymin] [ymax]\n\n",argv[0]) ;
-    
+
      fprintf(stderr,"input parameters: \n");
      fprintf(stderr,"  interferogram      complex interferogram image filename\n");
      fprintf(stderr,"  smoothed interf.   smoothed interferogram filename\n");
      fprintf(stderr,"  width              number of samples/row\n");
-     fprintf(stderr,"  alpha              spectrum amplitude scale factor (default=.5)\n");  
+     fprintf(stderr,"  alpha              spectrum amplitude scale factor (default=.5)\n");
      fprintf(stderr,"  fftw               fft window size in both range and azimuth directions \n");
      fprintf(stderr,"  step               moving step size in both range and azimuth directions (default = fftw/2)\n");
-     fprintf(stderr,"  xmin               offset to starting range pixel (default = 0)\n");    
-     fprintf(stderr,"  xmax               offset last range pixel (default = width-1)\n");    
-     fprintf(stderr,"  ymin               offset to starting azimuth row (default = 0)\n");    
-     fprintf(stderr,"  ymax               offset to last azimuth row (default = nlines-1)\n\n");    
+     fprintf(stderr,"  xmin               offset to starting range pixel (default = 0)\n");
+     fprintf(stderr,"  xmax               offset last range pixel (default = width-1)\n");
+     fprintf(stderr,"  ymin               offset to starting azimuth row (default = 0)\n");
+     fprintf(stderr,"  ymax               offset to last azimuth row (default = nlines-1)\n\n");
      exit(-1);
    }
 
    start_timing();
-   int_file = fopen(inputfile,"rb"); 
+   int_file = fopen(inputfile,"rb");
    if (int_file == NULL){fprintf(stderr,"cannot open interferogram file: %s\n",inputfile); exit(-1);}
 
-   sm_file = fopen(outputfile,"wb"); 
+   sm_file = fopen(outputfile,"wb");
    if (sm_file == NULL){fprintf(stderr,"cannot create smoothed interferogram file: %s\n",outputfile); exit(-1);}
 
-   //sscanf(argv[3],"%d",&width);  
-   xmax = width-1;	 
- 
+   //sscanf(argv[3],"%d",&width);
+   xmax = width-1;
+
    fseeko(int_file, 0L, REL_EOF);		/* determine # lines in the file */
    nlines=(int)(ftello(int_file)/(width*2*sizeof(float)));
-   fprintf(stderr,"#lines in the interferogram file: %d\n",nlines); 
+   fprintf(stderr,"#lines in the interferogram file: %d\n",nlines);
    rewind(int_file);
 
-   
+
    //alpha = ALPHA;
    //if(argc >= 4)sscanf(argv[4],"%lf",&alpha);
    fprintf(stdout,"spectrum weighting exponent: %8.4f\n",alpha);
@@ -139,26 +139,26 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
      fprintf(stdout,"WARNING: wrong step size: %5d, using %5d instead\n",step, fftw/2);
      step = fftw/2;
    }
-   fprintf(stdout,"range and azimuth step size (pixels): %5d\n",step); 
-   
+   fprintf(stdout,"range and azimuth step size (pixels): %5d\n",step);
+
    ymax=nlines-1;				/* default value of ymax */
    //if(argc > 7)sscanf(argv[7],"%d",&xmin);	/* window to process */
    //if(argc > 8)sscanf(argv[8],"%d",&xmax);
    //if(argc > 9)sscanf(argv[9],"%d",&ymin);
    //if(argc > 10)sscanf(argv[10],"%d",&ymax);
- 
+
    if (ymax > nlines-1){
-     ymax = nlines-1; 
-    fprintf(stderr,"WARNING: insufficient #lines in the file for given input range: ymax: %d\n",ymax);     
+     ymax = nlines-1;
+    fprintf(stderr,"WARNING: insufficient #lines in the file for given input range: ymax: %d\n",ymax);
    }
 
    if (xmax > width-1) xmax=width-1;	/* check to see if xmax within bounds */
    xw=xmax-xmin+1;			/* width of array */
-   yh=ymax-ymin+1;			/* height of array */ 
+   yh=ymax-ymin+1;			/* height of array */
    offs=ymin;				/* first line of file to start reading/writing */
    fprintf(stdout,"array width, height, offset: %5d %5d %5d\n",xw,yh,offs);
- 
-   cmp = cmatrix(0, fftw-1, -fftw,width+fftw);			/* add space around the arrays */ 
+
+   cmp = cmatrix(0, fftw-1, -fftw,width+fftw);			/* add space around the arrays */
    sm = cmatrix(0,fftw-1,-fftw,width+fftw);
 
    tmp = (fcomplex **)malloc(sizeof(fcomplex *)*step);
@@ -186,28 +186,28 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    for(i=0; i < fftw; i++){				/* initialize circular data buffers */
      for(j= -fftw; j < width+fftw; j++){
        cmp[i][j].re = 0.0; cmp[i][j].im = 0.0;
-       sm[i][j].re = 0.0; sm[i][j].im = 0.0;   
+       sm[i][j].re = 0.0; sm[i][j].im = 0.0;
      }
    }
- 
+
    for (i=0; i < fftw; i++){
      for (j=0; j < fftw; j++){
-       azw = 1.0 - fabs(2.0*(double)(i-fftw/2)/(fftw+1));  
-       rw  = 1.0 - fabs(2.0*(double)(j-fftw/2)/(fftw+1));  
+       azw = 1.0 - fabs(2.0*(double)(i-fftw/2)/(fftw+1));
+       rw  = 1.0 - fabs(2.0*(double)(j-fftw/2)/(fftw+1));
        wf[i][j]=azw*rw/(double)(fftw*fftw);
 #ifdef DEBUG
        fprintf(stderr,"i,j,wf: %5d %5d %12.4e\n",i,j,wf[i][j]);
 #endif
      }
    }
- 
+
    nfft[1] = fftw;
    nfft[2] = nfft[1];
    nfft[0] = 0;
    ndim = 2;
    isign = 1;				/* initialize FFT parameter values, inverse FFT */
 
-   
+
    fseek(int_file, offs*width*sizeof(fcomplex), REL_BEGIN); 	/* seek offset to start line of interferogram */
    for (i=0; i < fftw - step; i++){
     fread((char *)cmp[i], sizeof(fcomplex), width, int_file);
@@ -218,8 +218,8 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    }
    lc=0;
 
-   p_forward  = fftwf_plan_dft_2d(fftw, fftw, (fftw_complex *)seg_fft[0], (fftw_complex *)seg_fft[0], FFTW_FORWARD, FFTW_MEASURE);
-   p_backward = fftwf_plan_dft_2d(fftw, fftw, (fftw_complex *)seg_fft[0], (fftw_complex *)seg_fft[0], FFTW_BACKWARD, FFTW_MEASURE);
+   p_forward  = fftwf_plan_dft_2d(fftw, fftw, (fftwf_complex *)seg_fft[0], (fftwf_complex *)seg_fft[0], FFTW_FORWARD, FFTW_MEASURE);
+   p_backward = fftwf_plan_dft_2d(fftw, fftw, (fftwf_complex *)seg_fft[0], (fftwf_complex *)seg_fft[0], FFTW_BACKWARD, FFTW_MEASURE);
 
    for (i=0; i < yh; i += step){
      for(i1=fftw - step; i1 < fftw; i1++){
@@ -233,12 +233,12 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
        }
        for(j1= -fftw; j1 < width+fftw; j1++){
          sm[i1][j1].re=0.0; sm[i1][j1].im=0.0; 			/* clear out area for new sum */
-       }     
+       }
      }
      if(i%(2*step) == 0)fprintf(stderr,"\rprogress: %3d%%", (int)(i*100/yh + 0.5));
-  
+
      for (j=0; j < width; j += step){
-       //psd_wgt(cmp, seg_fft, alpha, j, i, fftw);	
+       //psd_wgt(cmp, seg_fft, alpha, j, i, fftw);
        ////////////////////////////////////////////////////////////////////////////////////////
        //replace function psd_wgt with the following to call FFTW, crl, 23-APR-2020
        for (ii=0; ii < fftw; ii++){            /* load up data array */
@@ -256,7 +256,7 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
            psd = seg_fft[ii][jj].re * seg_fft[ii][jj].re + seg_fft[ii][jj].im * seg_fft[ii][jj].im;
            psd_sc = pow(psd,alpha/2.);
            seg_fft[ii][jj].re *= psd_sc;
-           seg_fft[ii][jj].im *= psd_sc;    
+           seg_fft[ii][jj].im *= psd_sc;
          }
        }
        /////////////////////////////////////////////////////////////////////////////////////////
@@ -266,17 +266,17 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
        for (i1=0; i1 < fftw; i1++){			/* save filtered output values */
          for (j1=0; j1 < fftw; j1++){
            if(cmp[i1][j+j1].re !=0.0){
-             sm[i1][j+j1].re += wf[i1][j1]*seg_fft[i1][j1].re; 
+             sm[i1][j+j1].re += wf[i1][j1]*seg_fft[i1][j1].re;
              sm[i1][j+j1].im += wf[i1][j1]*seg_fft[i1][j1].im;
            }
            else{
-             sm[i1][j+j1].re=0.0; 
+             sm[i1][j+j1].re=0.0;
              sm[i1][j+j1].im=0.0;
            }
          }
        }
-     }         
-     for (i1=0; i1 < step; i1++){	
+     }
+     for (i1=0; i1 < step; i1++){
        if (lc < yh){
         for(k = 0; k < width; k++){
           if(!IsFinite(sm[i1][k].re))
@@ -288,7 +288,7 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
             sm[i1][k].im = 0.0;
           }
         }
-        fwrite((char *)sm[i1], sizeof(fcomplex), width, sm_file); 
+        fwrite((char *)sm[i1], sizeof(fcomplex), width, sm_file);
        }
        lc++;
      }
@@ -297,13 +297,13 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
      for (i1=0; i1 < step; i1++){cmp[fftw - step+i1] = tmp[i1]; sm[fftw - step+i1]=tmp1[i1];} /* copy pointers back */
    }
    fprintf(stderr,"\rprogress: %3d%%", 100);
-   
-   for(i=lc; i < yh; i++){				/* write null lines of filtered complex data */	
+
+   for(i=lc; i < yh; i++){				/* write null lines of filtered complex data */
      for(k = 0; k < width; k++){
       if(!IsFinite(bufcz[k].re))
         bufcz[k].re = 0.0;
       if(!IsFinite(bufcz[k].im))
-        bufcz[k].im = 0.0;  
+        bufcz[k].im = 0.0;
       if(!IsFinite(sqrt(bufcz[k].re*bufcz[k].re + bufcz[k].im*bufcz[k].im))){
         bufcz[k].re = 0.0;
         bufcz[k].im = 0.0;
@@ -311,7 +311,7 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
      }
      fwrite((char *)bufcz, sizeof(fcomplex), width, sm_file);
      lc++;
-   } 
+   }
 
    fprintf(stdout,"\nnumber of lines written to file: %d\n",lc);
    stop_timing();
@@ -328,14 +328,14 @@ int psfilt1(char *inputfile, char *outputfile, int width, double alpha, int fftw
    free(tmp1);
    free(wf);
    free(wfb);
-   fclose(int_file); 
+   fclose(int_file);
    fclose(sm_file);
 
-   return(0);  
-} 
- 
+   return(0);
+}
+
 void psd_wgt(fcomplex **cmp, fcomplex **seg_fft, double alpha, int ix, int iy, int fftw)
-/* 
+/*
   subroutine to perform non-linear spectral filtering  17-Feb-97 clw
 */
 
@@ -343,14 +343,14 @@ void psd_wgt(fcomplex **cmp, fcomplex **seg_fft, double alpha, int ix, int iy, i
   double psd,psd_sc;	/* power spectrum, scale factor */
   int i,j;		/* loop counters */
   int ndim,isign;	/* number of dimensions in fft */
-  
+
   int ic;
- 
+
   unsigned int nfft[3];
   ic = 0;
-   
+
   ndim=2, isign = -1, nfft[1]=fftw, nfft[2]=fftw, nfft[0]=0; /* fft initialization */
-  
+
   for (i=0; i < fftw; i++){  					/* load up data array */
     for (j=ix; j < ix+fftw; j++){
       seg_fft[i][j-ix].re = cmp[i][j].re;
@@ -365,7 +365,7 @@ void psd_wgt(fcomplex **cmp, fcomplex **seg_fft, double alpha, int ix, int iy, i
       psd = seg_fft[i][j].re * seg_fft[i][j].re + seg_fft[i][j].im * seg_fft[i][j].im;
       psd_sc = pow(psd,alpha/2.);
       seg_fft[i][j].re *= psd_sc;
-      seg_fft[i][j].im *= psd_sc;    
+      seg_fft[i][j].im *= psd_sc;
     }
   }
 }
@@ -509,20 +509,20 @@ void stop_timing()
   elapsed_time = (end_time - start_time);
 
   fprintf(stdout,"\n\nuser time    (s):  %10.3f\n", (double)user_time/clk_tck);
-  fprintf(stdout,"system time  (s):  %10.3f\n", (double)system_time/clk_tck); 
+  fprintf(stdout,"system time  (s):  %10.3f\n", (double)system_time/clk_tck);
   fprintf(stdout,"elapsed time (s):  %10.3f\n\n", (double) elapsed_time/clk_tck);
 }
 
 /* function: IsFinite()
  * --------------------
- * This function takes a double and returns a nonzero value if 
+ * This function takes a double and returns a nonzero value if
  * the arguemnt is finite (not NaN and not infinite), and zero otherwise.
  * Different implementations are given here since not all machines have
  * these functions available.
  */
-signed char IsFinite(double d){
+int IsFinite(double d){
 
-  return(finite(d));
+  return(isfinite(d));
   /* return(isfinite(d)); */
   /* return(!(isnan(d) || isinf(d))); */
   /* return(TRUE) */

--- a/contrib/mdx/src/graphx_mdx.c
+++ b/contrib/mdx/src/graphx_mdx.c
@@ -677,7 +677,7 @@ char a_data[3360];
            if (i_db > 8-1) printf("a_lll = %d %s %d %d %d\n",a_lll,a_lll,*(a_lll+0),*(a_lll+1),*(a_lll+2));
 
            XtAddCallback(textwin, XmNactivateCallback,
-              XmProcessTraversal, (XtPointer)XmTRAVERSE_NEXT_TAB_GROUP);
+              (XtCallbackProc)XmProcessTraversal, (XtPointer)XmTRAVERSE_NEXT_TAB_GROUP);
 
            }
 


### PR DESCRIPTION
I fixed some code which are reported as "incorrect pointer/type" error by newer versions of gcc. The updated code can be compiled by Apple Clang as well. 

@CunrenLiang, please make sure the changes don't break the code.  