### PR TITLE
Two patches for scons to run properly

### DIFF
--- a/components/isceobj/Util/denseoffsets/src/denseoffsetsRead.F
+++ b/components/isceobj/Util/denseoffsets/src/denseoffsetsRead.F
@@ -39,7 +39,7 @@
                     integer*8 :: acc
                     integer :: irow,band,n,i
 
-                    call getLineBand(acc,carr,band,irow)
+                    call getLineBand_c(acc,carr,band,irow)
                 end subroutine readCpxAmp
 
                 subroutine readAmp(acc,arr,irow,band,n,carr)
@@ -49,7 +49,7 @@
                     integer :: irow,band,n
                     integer :: i
 
-                    call getLineBand(acc,arr,band,irow)
+                    call getLineBand_r4(acc,arr,band,irow)
                     do i=1,n
                         carr(i) = cmplx(arr(i), 0.0)
                     enddo

--- a/components/isceobj/Util/estimateoffsets/src/estimateoffsetsRead.F
+++ b/components/isceobj/Util/estimateoffsets/src/estimateoffsetsRead.F
@@ -39,7 +39,7 @@
                     integer*8 :: acc
                     integer :: irow,band,n,i
 
-                    call getLineBand(acc,carr,band,irow)
+                    call getLineBand_c(acc,carr,band,irow)
                     !call getLine(acc, carr, irow)
                     do i=1,n
                         arr(i) = cabs(carr(i))
@@ -52,7 +52,7 @@
                     integer*8 :: acc
                     integer :: irow,band,n
 
-                    call getLineBand(acc,arr,band,irow)
+                    call getLineBand_r4(acc,arr,band,irow)
                 end subroutine
 
         end module estimateoffsetsRead 

--- a/contrib/PyCuAmpcor/src/SConscript
+++ b/contrib/PyCuAmpcor/src/SConscript
@@ -17,18 +17,13 @@ listFiles = ['GDALImage.cpp', 'cuArrays.cpp', 'cuArraysCopy.cu',
              'cuAmpcorController.cpp', 'cuCorrFrequency.cu',
              'cuAmpcorChunk.cpp', 'cuEstimateStats.cu']
 
-lib = envPyCuAmpcor.SharedLibrary(target = 'PyCuAmpcor', source= listFiles, SHLIBPREFIX='')
-
 # add gdal include path
 gdal_cflags = subprocess.check_output('gdal-config --cflags', shell=True)[:-1].decode('utf-8')
 envPyCuAmpcor.Append(ENABLESHAREDNVCCFLAG = ' -DNDEBUG ' + gdal_cflags)
 
-envPyCuAmpcor.Install(build,lib)
-envPyCuAmpcor.Alias('install', build)
-
 def pybind11PseudoBuilder(env, src, bld, inst):
     listFiles = [ src ]
-    env.MergeFlags('-fopenmp -O3 -std=c++11 -fPIC -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -Wstrict-prototypes')
+    env.MergeFlags('-fopenmp -O3 -std=c++11 -fPIC -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall')
     libList = ['gdal']
     env.PrependUnique(LIBS=libList)
     env.Append(CPPDEFINES = 'GPU_ACC_ENABLED')


### PR DESCRIPTION
When using scons install method with python 13 and gcc/gfortan 13.3, I ran into two issues 
1) an error with getLineBand in denseoffsetsRead.F and estimateoffsetsRead.F.  The solution is to use the respective getLineBand method for real or complex data, as defined in  components/iscesys/ImageApi/DataAccessor/src/DataAccessorF.cpp. 
(these filed are not included in the CMake file, are they no longer in use?) 
2) warnings issued during PyCuAmpcor compilation, "Two environments with different actions...". Basically, all the functions are included in the pybind11 module and we don't need an additional lib (which causes the two different actions). 