### PR TITLE
Support Sentinel-1C

### DIFF
--- a/components/isceobj/Sensor/TOPS/Sentinel1.py
+++ b/components/isceobj/Sensor/TOPS/Sentinel1.py
@@ -603,6 +603,8 @@ class Sentinel1(Component):
                 burst.trackNumber = (orbitnumber-73)%175 + 1
             elif mission == 'S1B':
                 burst.trackNumber = (orbitnumber-27)%175 + 1
+            elif mission == 'S1C':
+                burst.trackNumber = (orbitnumber-172)%175 + 1
             else:
                 raise ValueError('Encountered unknown mission id {0}'.format(mission))
 


### PR DESCRIPTION
This PR adds the relative orbit calculation for Sentinel-1C so that `ValueError('Encountered unknown mission id S1C` is not thrown. 

Note that this is the same formula as used in [s1-reader](https://github.com/isce-framework/s1-reader/pull/144/files).

This PR should address issue #947.