### PR TITLE
Fix type casting in chi squared print statement

### DIFF
--- a/components/isceobj/Util/Library/python/Poly2D.py
+++ b/components/isceobj/Util/Library/python/Poly2D.py
@@ -377,7 +377,7 @@ print(xx[23], yy[23], z[23], gg(yy[23], xx[23]))
 
         val, res, rank, eigs = np.linalg.lstsq(A,z, rcond=cond)
         if len(res)> 0:
-            print('Chi squared: %f'%(np.sqrt(res/(1.0*len(z)))))
+            print('Chi squared: %f'%(float(np.sqrt(res/(1.0*len(z))))))
         else:
             print('No chi squared value....')
             print('Try reducing rank of polynomial.')


### PR DESCRIPTION
For use with numpy>=1.25. Newer versions of numpy break with old code. 

run_06 breaks if numpy is upgraded to newer/modern versions