### PR TITLE
Image: resolve basename-only paths relative to XML

### DIFF
--- a/components/isceobj/Image/Image.py
+++ b/components/isceobj/Image/Image.py
@@ -371,7 +371,6 @@ class Image(DataAccessor, Configurable):
         self.init(prop,fac,misc)
     '''
     def load(self, filename, parser='xml'):
-        import os
         super(Image, self).load(filename, parser=parser)
         base_dir = os.path.dirname(os.path.abspath(filename))
 

--- a/components/isceobj/Image/Image.py
+++ b/components/isceobj/Image/Image.py
@@ -370,6 +370,19 @@ class Image(DataAccessor, Configurable):
         prop, fac, misc = parser.parse(filename)
         self.init(prop,fac,misc)
     '''
+    def load(self, filename, parser='xml'):
+        import os
+        super(Image, self).load(filename, parser=parser)
+        base_dir = os.path.dirname(os.path.abspath(filename))
+
+        # Resolve basename-only image paths relative to the XML file.
+        # Relative paths that already include a directory are kept unchanged.
+        if self.filename and not os.path.isabs(self.filename) and not os.path.dirname(self.filename):
+            self.filename = os.path.join(base_dir, self.filename)
+
+        if self._extraFilename and not os.path.isabs(self._extraFilename) and not os.path.dirname(self._extraFilename):
+            self._extraFilename = os.path.join(base_dir, self._extraFilename)
+
     @use_api
     def renderHdr(self, outfile=None):
         from datetime import datetime


### PR DESCRIPTION
# Resolve basename-only image paths relative to XML metadata

## Problem

ISCE image metadata XML can contain basename-only raster paths:

```xml
<property name="file_name">
  <value>example.dem.wgs84</value>
</property>
<property name="extra_file_name">
  <value>example.dem.wgs84.vrt</value>
</property>
```

When loading such XML by path, `Image.load()` currently keeps `self.filename` and `self._extraFilename` as those basename values. Downstream processing can then look for the raster and VRT in the current working directory instead of the directory containing the XML metadata.

This makes it harder to reuse one shared DEM across multiple processing work directories, because each work directory may otherwise need its own local copy or hardlink of the DEM files.

## Proposed change

Add an `Image.load()` wrapper that delegates to `Configurable.load()` and then resolves basename-only image paths relative to the XML file location:

```python
def load(self, filename, parser='xml'):
    super(Image, self).load(filename, parser=parser)
    base_dir = os.path.dirname(os.path.abspath(filename))

    # Resolve basename-only image paths relative to the XML file.
    # Relative paths that already include a directory are kept unchanged.
    if self.filename and not os.path.isabs(self.filename) and not os.path.dirname(self.filename):
        self.filename = os.path.join(base_dir, self.filename)

    if self._extraFilename and not os.path.isabs(self._extraFilename) and not os.path.dirname(self._extraFilename):
        self._extraFilename = os.path.join(base_dir, self._extraFilename)
```

The basename-only guard is important. Relative paths that already include directories should remain unchanged, because some internal products intentionally rely on those paths as written.

## Validation

The change was validated in three ways:

1. Loading DEM XML with basename-only `file_name` and `extra_file_name` values now resolves both paths relative to the XML location.
2. Relative paths that already include directories are left unchanged, avoiding duplicated path prefixes.
3. End-to-end processing works with a shared DEM referenced from outside the pair work directory, without requiring local DEM copies or hardlinks inside each work directory.

## Motivation

This makes XML-relative image metadata behave in the way users generally expect: basename values inside an image metadata XML file refer to files located next to that XML file. It also reduces friction when reusing large shared rasters across many processing directories.
