### PR TITLE
stripmapStack: fix reference date ignored in offset inversion

### DIFF
--- a/contrib/stack/stripmapStack/Stack.py
+++ b/contrib/stack/stripmapStack/Stack.py
@@ -474,19 +474,21 @@ class run(object):
             self.runf.write(self.text_cmd + 'stripmapWrapper.py -c '+ configName+'\n')
 
   
-    def invertMisregPoly(self):
+    def invertMisregPoly(self, stackReference):
 
         pairDirs = os.path.join(self.workDir, 'refineSecondaryTiming/pairs/')
         dateDirs = os.path.join(self.workDir, 'refineSecondaryTiming/dates/')
-        cmd = self.text_cmd + 'invertMisreg.py -i ' + pairDirs + ' -o ' + dateDirs
+        cmd = self.text_cmd + 'invertMisreg.py -i ' + pairDirs + ' -o ' + dateDirs + ' -r ' + stackReference
         self.runf.write(cmd + '\n')
 
 
-    def  invertDenseOffsets(self):
+    def  invertDenseOffsets(self, stackReference=None):
 
         pairDirs = os.path.join(self.workDir, self.dense_offsets_folder, 'pairs')
         dateDirs = os.path.join(self.workDir, self.dense_offsets_folder, 'dates')
         cmd = self.text_cmd + 'invertOffsets.py -i ' + pairDirs + ' -o ' + dateDirs
+        if stackReference is not None:
+            cmd += ' -r ' + stackReference
         self.runf.write(cmd + '\n')
 
     def rubbersheet(self, secondaryDates, config_prefix):

--- a/contrib/stack/stripmapStack/invertMisreg.py
+++ b/contrib/stack/stripmapStack/invertMisreg.py
@@ -24,6 +24,8 @@ def createParser():
             help='Directory with the overlap directories that has calculated misregistration for each pair')
     parser.add_argument('-o', '--output', type=str, dest='output', required=True,
             help='output directory to save misregistration for each date with respect to the stack Reference date')
+    parser.add_argument('-r', '--reference', type=str, dest='reference', default=None,
+            help='Reference date (YYYYMMDD format). If not provided, the first date in sorted dateList will be used.')
 #    parser.add_argument('-f', '--misregFileName', type=str, dest='misregFileName', default='misreg.txt',
 #            help='misreg file name that contains the calculated misregistration for a pair')
 
@@ -93,7 +95,7 @@ def getPolyInfo(filename):
   #return np.size(azCoefs), np.size(rgCoefs), np.shape(azCoefs), np.shape(rgCoefs)
 
 ######################################
-def design_matrix(pairDirs):
+def design_matrix(pairDirs, referenceDate=None):
   '''Make the design matrix for the inversion.  '''
   tbase,dateList,dateDict = date_list(pairDirs)
   numDates = len(dateDict)
@@ -125,12 +127,20 @@ def design_matrix(pairDirs):
     Laz[ni,:] = azOff[:]
     Lrg[ni,:] = rgOff[:]
 
-  A = A[:,1:]
-  B = B[:,:-1]
+  if referenceDate is None:
+    refIdx = 0
+  elif referenceDate not in dateList:
+    print('Warning: Reference date {} not found in dateList. Using first date as reference.'.format(referenceDate))
+    refIdx = 0
+  else:
+    refIdx = dateList.index(referenceDate)
+
+  A = np.delete(A, refIdx, axis=1)
+  B = np.delete(B, refIdx, axis=1)
   
  # ind=~np.isnan(Laz)
  # return A[ind[:,0],:],B[ind[:,0],:],Laz[ind,:], Lrg[ind]
-  return A, B, Laz, Lrg
+  return A, B, Laz, Lrg, refIdx
  
 ######################################
 def main(iargs=None):
@@ -143,7 +153,11 @@ def main(iargs=None):
 
   tbase, dateList, dateDict = date_list(pairDirs)
 
-  A, B, Laz, Lrg = design_matrix(pairDirs)
+  referenceDate = inps.reference
+  if referenceDate is None:
+    referenceDate = dateList[0]
+
+  A, B, Laz, Lrg, refIdx = design_matrix(pairDirs, referenceDate=referenceDate)
   A1 = np.linalg.pinv(A)
   A1 = np.array(A1,np.float32)
 
@@ -158,8 +172,10 @@ def main(iargs=None):
   RMSE_az = np.sqrt(np.sum(residual_az**2)/len(residual_az))
   RMSE_rg = np.sqrt(np.sum(residual_rg**2)/len(residual_rg))
 
-  Saz = np.vstack((np.zeros((1,Saz.shape[1]), dtype=np.float32), Saz))
-  Srg = np.vstack((np.zeros((1,Srg.shape[1]), dtype=np.float32), Srg))
+  zero_row_az = np.zeros((1, Saz.shape[1]), dtype=np.float32)
+  zero_row_rg = np.zeros((1, Srg.shape[1]), dtype=np.float32)
+  Saz = np.vstack([Saz[:refIdx], zero_row_az, Saz[refIdx:]])
+  Srg = np.vstack([Srg[:refIdx], zero_row_rg, Srg[refIdx:]])
 
   print('')
   print('Rank of design matrix: ' + str(np.linalg.matrix_rank(A)))

--- a/contrib/stack/stripmapStack/invertOffsets.py
+++ b/contrib/stack/stripmapStack/invertOffsets.py
@@ -29,6 +29,8 @@ def createParser():
             help='Directory with the pair directories that includes dense offsets for each pair')
     parser.add_argument('-o', '--output', type=str, dest='output', required=True,
             help='output directory to save dense-offsets for each date with respect to the stack Reference date')
+    parser.add_argument('-r', '--reference', type=str, dest='reference', default=None,
+            help='Reference date (YYYY-MM-DD HH:MM:SS format from h5 file, or YYYYMMDD format). If not provided, the first date in sorted dateList will be used.')
 
     return parser
 
@@ -104,7 +106,7 @@ def date_list(h5file):
 
 #####################################
 
-def design_matrix(h5File):
+def design_matrix(h5File, referenceDate=None):
   tbase,dateList,dateDict, references, secondarys = date_list(h5File)
   numDates = len(dateDict)
   numPairs = len(references)
@@ -118,17 +120,31 @@ def design_matrix(h5File):
      A[ni,ndxt2] = 1
      B[ni,ndxt1:ndxt2] = tbase[ndxt1+1:ndxt2+1]-tbase[ndxt1:ndxt2]
 
-  #print('A',A)
-  #print('%%%%%%%%%%%%%%% %%%%%')  
-  A = A[:,1:]
-  B = B[:,:-1]
+  if referenceDate is not None and referenceDate not in dateList:
+    referenceDate = datetime.datetime(
+        *time.strptime(referenceDate, "%Y%m%d")[0:5]
+    ).strftime("%Y-%m-%d %H:%M:%S")
 
-  return A, B  
+  if referenceDate is None:
+    refIdx = 0
+  elif referenceDate not in dateList:
+    print('Warning: Reference date {} not found in dateList. Using first date as reference.'.format(referenceDate))
+    refIdx = 0
+  else:
+    refIdx = dateList.index(referenceDate)
+
+  A = np.delete(A, refIdx, axis=1)
+  B = np.delete(B, refIdx, axis=1)
+
+  return A, B, refIdx  
 
 def invert_wlq(inps,h5File):
     tbase,dateList,dateDict, references, secondarys = date_list(h5File)
+    referenceDate = inps.reference
+    if referenceDate is None:
+      referenceDate = dateList[0]
     numPairs = len(references)
-    A,B = design_matrix(h5File)
+    A,B,refIdx = design_matrix(h5File, referenceDate=referenceDate)
    
     h5 = h5py.File(h5File,'r')
     data = h5['/platform-track/observations'].get('offset-azimuth')
@@ -168,9 +184,12 @@ def invert_wlq(inps,h5File):
         #Cm = np.vstack((np.zeros((1,ts.shape[1]), dtype=np.float32), ts))
 
            ts = ts.reshape([NumValidPixels,Npar]).T
-        #ts = np.vstack((np.zeros((1,ts.shape[1]), dtype=np.float32), ts))
-           ds[1:,j,ind] = ts
-           dsq[1:,j,ind] = Cm
+           zero_row = np.zeros((1, ts.shape[1]), dtype=np.float32)
+           ts = np.vstack([ts[:refIdx], zero_row, ts[refIdx:]])
+           ds[:,j,ind] = ts
+           Cm_zero = np.zeros((1, Cm.shape[1]), dtype=np.float32)
+           Cm = np.vstack([Cm[:refIdx], Cm_zero, Cm[refIdx:]])
+           dsq[:,j,ind] = Cm
 
     dateListE = [d.encode("ascii", "ignore") for d in dateList]
     dateListE = np.array(dateListE)
@@ -219,8 +238,11 @@ def invert_wlq(inps,h5File):
 def invert(inps,h5File):
 
     tbase,dateList,dateDict, references, secondarys = date_list(h5File)
+    referenceDate = inps.reference
+    if referenceDate is None:
+      referenceDate = dateList[0]
     numPairs = len(references)
-    A,B = design_matrix(h5File)
+    A,B,refIdx = design_matrix(h5File, referenceDate=referenceDate)
 
     h5 = h5py.File(h5File,'r')
     data = h5['/platform-track/observations'].get('offset-azimuth')    
@@ -245,7 +267,8 @@ def invert(inps,h5File):
         #dsr[:,i,:] =  L_residual
         dst[i,:] = np.absolute(np.sum(np.exp(1j*L_residual),0))/Nz
 
-        ts = np.vstack((np.zeros((1,ts.shape[1]), dtype=np.float32), ts))
+        zero_row = np.zeros((1, ts.shape[1]), dtype=np.float32)
+        ts = np.vstack([ts[:refIdx], zero_row, ts[refIdx:]])
         ds[:,i,:] = ts
 
     dateListE = [d.encode("ascii", "ignore") for d in dateList]

--- a/contrib/stack/stripmapStack/stackStripMap.py
+++ b/contrib/stack/stripmapStack/stackStripMap.py
@@ -182,7 +182,7 @@ def slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, pairs, 
     i+=1
     runObj = run()
     runObj.configure(inps, 'run_{:02d}_invertMisreg'.format(i))
-    runObj.invertMisregPoly()
+    runObj.invertMisregPoly(stackReferenceDate)
     runObj.finalize()
 
     i+=1
@@ -203,7 +203,7 @@ def slcStack(inps, acquisitionDates, stackReferenceDate, secondaryDates, pairs, 
         i+=1
         runObj = run()
         runObj.configure(inps, 'run_{:02d}_invertDenseOffsets'.format(i))
-        runObj.invertDenseOffsets()
+        runObj.invertDenseOffsets(stackReferenceDate)
         runObj.finalize()
 
         i+=1


### PR DESCRIPTION
## Summary

This PR fixes a bug in stripmap stack offset network inversion where the user-specified stack reference date (`stackStripMap -m`) was not used by `invertMisreg.py` or `invertOffsets.py`.

Changes:
- Pass the stack reference date from `stackStripMap.py` / `Stack.py` to both inversion scripts via a new `-r/--reference` argument
- Remove the reference-date column from the design matrix by index (`refIdx`) instead of always dropping the first sorted acquisition
- Insert zero-offset rows at the correct reference-date index in inversion outputs

## Problem

`stackStripMap.py` allows selecting an arbitrary stack reference date via `-m/--reference_date`, and downstream steps (e.g. `refineSecondaryTiming`, `resampleSlc`) already use that date.

However, before this fix, both `invertMisreg.py` and `invertOffsets.py` **always** removed the first sorted date from the design matrix:

```python
A = A[:, 1:]   # always drop column 0 (first sorted date)
```

and always prepended the zero-offset row at index 0:

```python
S = np.vstack((np.zeros(...), S))
```

This is only correct when the reference date happens to be the **first sorted acquisition**. If the user selects a different reference date, the inverted per-date offsets are expressed relative to the wrong frame, causing misregistration in fine coregistration (`resampleSlc` reads `refineSecondaryTiming/dates/<date>/misreg`).

## Fix

1. **`Stack.py` / `stackStripMap.py`**: pass `stackReferenceDate` to:
   - `invertMisreg.py ... -r <ref>`
   - `invertOffsets.py ... -r <ref>` (rubbersheet / dense-offset path)

2. **`invertMisreg.py` / `invertOffsets.py`**:
   - add `-r/--reference`
   - locate `refIdx` from the reference date in `dateList`
   - replace `A[:,1:]` with `np.delete(A, refIdx, axis=1)`
   - insert the zero row at `refIdx` in the solved time series

3. **`invertOffsets.py` only**: `dateList` from the internal HDF5 file uses `YYYY-MM-DD HH:MM:SS`, while the stack passes `YYYYMMDD`. A one-line format conversion is applied before matching `refIdx`, using the same `if / elif / else` structure as `invertMisreg.py`.

## Files changed

| File | Change |
|------|--------|
| `contrib/stack/stripmapStack/stackStripMap.py` | Pass `stackReferenceDate` to inversion steps |
| `contrib/stack/stripmapStack/Stack.py` | Append `-r` in generated run commands |
| `contrib/stack/stripmapStack/invertMisreg.py` | Honor `-r` in design matrix and output assembly |
| `contrib/stack/stripmapStack/invertOffsets.py` | Same fix for dense-offset inversion |

## Test

### Dataset and motivation

We tested this fix using the same ALOS-2 dataset over Kyushu, Japan described in:

> Z. Yunjun et al., "Range Geolocation Accuracy of C-/L-Band SAR and its Implications for Operational Stack Coregistration," *IEEE Transactions on Geoscience and Remote Sensing*, vol. 60, pp. 1–19, 2022, Art no. 5227219, doi: [10.1109/TGRS.2022.3168509](https://doi.org/10.1109/TGRS.2022.3168509).

As shown in Fig. 13 of that paper, the temporal variation of range misregistration in this stack is dominated by ionospheric effects, with large delays during 2015–2016 associated with strong solar activity [Fig. 13(a)].

<img width="1106" height="688" alt="Range misregistration time series from Yunjun et al. (2022) Fig. 13" src="https://github.com/user-attachments/assets/5c94506d-fab2-420e-8583-4b4e4dd1a879" />

We chose this dataset deliberately because the acquisitions span both **2015** and **2019**, i.e. epochs separated by large cumulative range offsets. This makes the test sensitive to reference-frame errors: if inversion assumes the wrong reference date, the misregistration time series is shifted to the wrong frame, and the resulting coregistration error is amplified rather than masked.

**Stack configuration:**
- Reference date (`-m`): `20190218`
- Secondary dates: `20150209`, `20150223`, `20150810`, `20150824`, `20190304`

```bash
stackStripMap.py -s slc/ -w . -d dem/elevation.dem -a 3 -r 3 -u snaphu -f 0.8 \
  -W ionosphere -z --nofocus -m 20190218
```

### Before fix

With `-m 20190218`, the stack still inverted offsets relative to the first sorted acquisition rather than the specified reference. Two symptoms were observed:

1. **Interferometric coherence**: interferograms tied to the user-selected reference date showed noticeably lower coherence than pairs with long temporal baselines, consistent with residual misregistration after fine coregistration.

<img width="676" height="806" alt="Coherence before fix (pair 1)" src="https://github.com/user-attachments/assets/b392373e-a37c-4efd-a7f4-fe7519dcdf79" />

<img width="676" height="806" alt="Coherence before fix (pair 2)" src="https://github.com/user-attachments/assets/fadfcdfb-864f-4367-8af7-66a5184ad399" />

2. **Dense-offset inversion**: the inverted dense-offset time series for the designated reference date under `dense_offsets/dates/` was **not** zero, as it should be when offsets are expressed relative to the stack reference.

<img width="676" height="816" alt="3192220205c858b5268626693b0b070c" src="https://github.com/user-attachments/assets/53c93259-60fe-4290-a8aa-b289e6d518f9" />


### After fix

Re-running the same stack with the patched code:

```bash
stackStripMap.py -s slc/ -w ./new -d dem/elevation.dem -a 3 -r 3 -u snaphu -f 0.8 \
  -W ionosphere -z --nofocus -m 20190218
```

Results:
- Interferogram coherence for pairs involving the chosen reference date improved and became more consistent with other pairs in the stack.
- The dense-offset solution for the reference date is now zero (within numerical precision), as expected.

<img width="676" height="806" alt="Coherence after fix (pair 1)" src="https://github.com/user-attachments/assets/3395c9b9-f38c-48aa-9c00-ffc14a71760f" />

<img width="676" height="806" alt="Coherence after fix (pair 2)" src="https://github.com/user-attachments/assets/ed217bb6-688c-4b86-be36-4be094a6933e" />

<img width="676" height="816" alt="Dense offsets after fix: reference date is zero" src="https://github.com/user-attachments/assets/bb8784c2-ac2a-45c1-b1cb-9571e164d61a" />

## Backward compatibility

- If `-r` is not provided, behavior is unchanged: the first sorted date is used as reference (same as before).
- When called from `stackStripMap.py`, `-r` is now always passed explicitly.