### PR TITLE
update S1C orbit calculation for June 2026 orbital reconfiguration

### DIFF
--- a/components/isceobj/Sensor/TOPS/Sentinel1.py
+++ b/components/isceobj/Sensor/TOPS/Sentinel1.py
@@ -604,7 +604,10 @@ class Sentinel1(Component):
             elif mission == 'S1B':
                 burst.trackNumber = (orbitnumber-27)%175 + 1
             elif mission == 'S1C':
-                burst.trackNumber = (orbitnumber-172)%175 + 1
+                if orbitnumber <= 8018:
+                    burst.trackNumber = (orbitnumber-172)%175 + 1
+                else:
+                    burst.trackNumber = (orbitnumber-99)%175 + 1
             else:
                 raise ValueError('Encountered unknown mission id {0}'.format(mission))
 


### PR DESCRIPTION
Sentinel-1C is being maneuvered from Jun 8-24 2026, resulting in a new formula for computing track number from absolute orbit.

- https://dataspace.copernicus.eu/news/2026-5-28-sentinel-1-orbital-reconfiguration-dates

Per @jhkennedy , the new formula for S1C was presented at FRINGE 2026:

> Relative Orbit Number = mod (Absolute Orbit Number orbit - 172, 175) + 1 **until 2026-06-24**
> Relative Orbit Number = mod (Absolute Orbit Number orbit - 99, 175) + 1 **from 2026-06-24**

The last S1C SLC products acquired on Jun 8 prior to the start of the orbit reconfiguration have an absolute orbit of 8018.